### PR TITLE
fix: handle DVMP memory path in MemoryManager::get_pointer()

### DIFF
--- a/core/store/model/memory_manager.cc
+++ b/core/store/model/memory_manager.cc
@@ -416,15 +416,9 @@ std::vector<void*> MemoryManager::get_pointer(ModelLocation location) const {
       // Return pointer to first chunk if loaded, otherwise null.
       // Documentation should clarify this behaviour.
       if (pageable_cpu_state_ == MemoryState::LOADED || pageable_cpu_state_ == MemoryState::ALLOCATED) {
-        // Check for buffered loading path (pinned memory)
-        if (pinned_mem_ != nullptr && !pinned_mem_->get().empty()) {
-          const auto vec = pinned_mem_->get(); // Pointer to first chunk data
-          return std::vector<void*>(vec.begin(), vec.end());
-        }
-        // Check for mmap/zero-copy path (DVMP memory)
-        if (dvmp_cpu_base_ != nullptr) {
-          return std::vector<void*>({dvmp_cpu_base_});
-        }
+        // For mmap/zero-copy path (DVMP memory)
+        assert(dvmp_cpu_base_ != nullptr);
+        return std::vector<void*>({dvmp_cpu_base_});
       }
       VLOG(2) << "MemoryManager(" << model_identifier_
               << "): get_pointer(PAGEABLE_CPU) returning null. State: " << state_to_string(pageable_cpu_state_)

--- a/core/store/model/memory_manager.cc
+++ b/core/store/model/memory_manager.cc
@@ -415,14 +415,21 @@ std::vector<void*> MemoryManager::get_pointer(ModelLocation location) const {
     case ModelLocation::PAGEABLE_CPU:
       // Return pointer to first chunk if loaded, otherwise null.
       // Documentation should clarify this behaviour.
-      if ((pageable_cpu_state_ == MemoryState::LOADED || pageable_cpu_state_ == MemoryState::ALLOCATED) &&
-          pinned_mem_ != nullptr && !pinned_mem_->get().empty()) {
-        const auto vec = pinned_mem_->get(); // Pointer to first chunk data
-        return std::vector<void*>(vec.begin(), vec.end());
+      if (pageable_cpu_state_ == MemoryState::LOADED || pageable_cpu_state_ == MemoryState::ALLOCATED) {
+        // Check for buffered loading path (pinned memory)
+        if (pinned_mem_ != nullptr && !pinned_mem_->get().empty()) {
+          const auto vec = pinned_mem_->get(); // Pointer to first chunk data
+          return std::vector<void*>(vec.begin(), vec.end());
+        }
+        // Check for mmap/zero-copy path (DVMP memory)
+        if (dvmp_cpu_base_ != nullptr) {
+          return std::vector<void*>({dvmp_cpu_base_});
+        }
       }
       VLOG(2) << "MemoryManager(" << model_identifier_
               << "): get_pointer(PAGEABLE_CPU) returning null. State: " << state_to_string(pageable_cpu_state_)
-              << ", PinnedMem valid: " << (pinned_mem_ != nullptr);
+              << ", PinnedMem valid: " << (pinned_mem_ != nullptr)
+              << ", DVMP base: " << dvmp_cpu_base_;
       return {};
     case ModelLocation::GPU:
       // Return pointer if memory is allocated, loading, or loaded (pointer valid during streaming and copy)


### PR DESCRIPTION
When using the mmap (zero-copy) path for page-aligned partitions, the
MemoryManager needs to check for DVMP memory when pinned_mem_ is null.
This fixes the aligned_cpu_test failure where get_pointer() was returning
an empty vector instead of the DVMP base address.

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>