### PR TITLE
chore(async): enhance AsyncCopyManager with callback handling and debug options

### DIFF
--- a/core/checkpoint/streaming_tensor_writer.cc
+++ b/core/checkpoint/streaming_tensor_writer.cc
@@ -123,7 +123,16 @@ absl::StatusOr<uint64_t> StreamingTensorWriter::write_tensor(
       common::HostRegion dst{.base = buffer_ptr, .length = chunk_size, .pinned = true};
 
       // Use a callback that marks the chunk ready with the same global id.
-      auto on_done = [spb = streaming_buffer_.get(), slot_id, global_chunk_id, chunk_size]() {
+      auto on_done = [spb = streaming_buffer_.get(), slot_id, global_chunk_id, chunk_size](absl::Status st) {
+        if (!st.ok()) {
+          LOG(ERROR) << "AsyncCopyManager::submit_d2h failed for chunk_id=" << global_chunk_id << ": " << st;
+          absl::Status rc = spb->return_chunk(slot_id);
+          if (!rc.ok()) {
+            LOG(WARNING) << "StreamingPinnedBuffer::return_chunk failed after async error slot=" << slot_id << ": "
+                         << rc;
+          }
+          return;
+        }
         absl::Status rc = spb->mark_chunk_ready(slot_id, global_chunk_id, chunk_size);
         if (!rc.ok()) {
           LOG(WARNING) << "StreamingPinnedBuffer::mark_chunk_ready failed slot=" << slot_id << ": " << rc;

--- a/core/common/BUILD
+++ b/core/common/BUILD
@@ -212,6 +212,16 @@ sc_cc_library(
     ],
 )
 
+sc_cc_library(
+    name = "streaming_chunk_guard_lib",
+    srcs = ["memory/streaming_chunk_guard.cc"],
+    hdrs = ["memory/streaming_chunk_guard.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":streaming_pinned_buffer_lib",
+    ],
+)
+
 # Canonical granularity constants (artifact chunk, tx slice, hash leaf)
 sc_header_only_library(
     name = "const_granularity_lib",
@@ -378,6 +388,31 @@ cc_test(
         ":virtual_address_space_lib",
         "//core/testing:catch_main",
         "//core/testing:common",
+        "@catch2//:catch2_main",
+    ],
+)
+
+cc_test(
+    name = "streaming_pinned_buffer_test",
+    srcs = ["memory/streaming_pinned_buffer_test.cc"],
+    tags = ["requires_cuda"],
+    deps = [
+        ":pinned_buffer_pool_lib",
+        ":streaming_pinned_buffer_lib",
+        "//core/testing:catch_main",
+        "@catch2//:catch2_main",
+    ],
+)
+
+cc_test(
+    name = "streaming_chunk_guard_test",
+    srcs = ["memory/streaming_chunk_guard_test.cc"],
+    tags = ["requires_cuda"],
+    deps = [
+        ":pinned_buffer_pool_lib",
+        ":streaming_chunk_guard_lib",
+        ":streaming_pinned_buffer_lib",
+        "//core/testing:catch_main",
         "@catch2//:catch2_main",
     ],
 )

--- a/core/common/artifact_verification.cc
+++ b/core/common/artifact_verification.cc
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <numeric>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 #include "absl/log/log.h"
@@ -27,6 +28,18 @@ static constexpr uint64_t kPrimE642 = 14029467366897019727ULL;
 static constexpr uint64_t kPrimE643 = 1609587929392839161ULL;
 static constexpr uint64_t kPrimE644 = 9650029242287828579ULL;
 static constexpr uint64_t kPrimE645 = 2870177450012600261ULL;
+
+std::string bytes_to_hex(absl::Span<const uint8_t> bytes) {
+  std::string out;
+  out.reserve(bytes.size() * 3);
+  for (size_t i = 0; i < bytes.size(); ++i) {
+    if (i != 0) {
+      out.push_back(' ');
+    }
+    absl::StrAppendFormat(&out, "%02x", bytes[i]);
+  }
+  return out;
+}
 
 // JSON serialization using nlohmann/json
 std::string ArtifactVerificationInfo::to_json() const {
@@ -547,6 +560,38 @@ absl::Status ArtifactVerifier::verify_artifact_data(
       }
 
       if (seg_hash != expected_info.segment_hashes.at(seg)) {
+        const size_t segment_len = seg_end - seg_start;
+        const size_t sample_len = std::min<size_t>(64, segment_len);
+        std::vector<uint8_t> head_sample(sample_len);
+        absl::Status head_status =
+            read_data_chunk(head_sample.data(), data_ptrs, data_sizes, seg_start, sample_len, device_id);
+        std::vector<uint8_t> tail_sample;
+        absl::Status tail_status = absl::OkStatus();
+        if (segment_len > sample_len) {
+          const size_t tail_len = std::min<size_t>(64, segment_len);
+          tail_sample.resize(tail_len);
+          tail_status =
+              read_data_chunk(tail_sample.data(), data_ptrs, data_sizes, seg_end - tail_len, tail_len, device_id);
+        }
+        LOG(ERROR) << "ArtifactVerifier: Segment hash mismatch (segment=" << seg << ", device=" << device_id
+                   << ", offset=" << seg_start << ", length=" << segment_len << ")"
+                   << " actual_hash=" << seg_hash << " expected_hash=" << expected_info.segment_hashes.at(seg);
+        if (head_status.ok()) {
+          LOG(ERROR) << "ArtifactVerifier: segment head bytes [" << bytes_to_hex(absl::MakeConstSpan(head_sample))
+                     << "]";
+        } else {
+          LOG(ERROR) << "ArtifactVerifier: failed to sample segment head (segment=" << seg
+                     << ") status=" << head_status;
+        }
+        if (!tail_sample.empty()) {
+          if (tail_status.ok()) {
+            LOG(ERROR) << "ArtifactVerifier: segment tail bytes [" << bytes_to_hex(absl::MakeConstSpan(tail_sample))
+                       << "]";
+          } else {
+            LOG(ERROR) << "ArtifactVerifier: failed to sample segment tail (segment=" << seg
+                       << ") status=" << tail_status;
+          }
+        }
         return absl::DataLossError(absl::StrCat("Segment ", seg, " hash mismatch"));
       }
     }

--- a/core/common/async_copy_manager.cc
+++ b/core/common/async_copy_manager.cc
@@ -383,17 +383,24 @@ absl::StatusOr<CopyHandle> AsyncCopyManager::submit_h2h(
 
   CopyHandle handle;
   auto p = handle.p_;
-  // Synchronous memcpy followed by immediate callback and handle completion.
-  std::memcpy(const_cast<void*>(dst.base), src.base, src.length);
-  {
-    absl::MutexLock lock(&p->mu);
-    p->status = absl::OkStatus();
-    p->done = true;
-    p->cv.SignalAll();
-  }
-  if (opts.callbacks.on_copy_done) {
-    enqueue_callback_([cb = opts.callbacks.on_copy_done]() { cb(absl::OkStatus()); });
-  }
+  const void* src_ptr = src.base;
+  void* dst_ptr = const_cast<void*>(dst.base);
+  const size_t bytes = src.length;
+  auto on_done = opts.callbacks.on_copy_done;
+  enqueue_callback_([p, dst_ptr, src_ptr, bytes, on_done = std::move(on_done)]() mutable {
+    std::memcpy(dst_ptr, src_ptr, bytes);
+    {
+      absl::MutexLock lock(&p->mu);
+      p->status = absl::OkStatus();
+      p->device_id = -1;
+      p->needs_device_check = false;
+      p->done = true;
+      p->cv.SignalAll();
+    }
+    if (on_done) {
+      on_done(absl::OkStatus());
+    }
+  });
   return handle;
 }
 

--- a/core/common/async_copy_manager.cc
+++ b/core/common/async_copy_manager.cc
@@ -1,11 +1,16 @@
 // Copyright (c) 2025, TensorCast Team.
 
 #include "core/common/async_copy_manager.h"
+#include <utility>
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/absl_check.h"
 #include "core/common/trace/trace_cuda_async_fn.h"
 
 namespace tensorcast::common {
+
+AsyncCopyManager::AsyncCopyManager() {
+  callback_thread_ = std::thread([this]() { callback_loop_(); });
+}
 
 AsyncCopyManager& AsyncCopyManager::instance() {
   static AsyncCopyManager inst;
@@ -89,6 +94,17 @@ AsyncCopyManager::~AsyncCopyManager() {
 }
 
 void AsyncCopyManager::shutdown() {
+  {
+    absl::MutexLock lock(&callback_mu_);
+    if (!callback_shutdown_) {
+      callback_shutdown_ = true;
+      callback_cv_.SignalAll();
+    }
+  }
+  if (callback_thread_.joinable()) {
+    callback_thread_.join();
+  }
+
   absl::MutexLock lock(&mu_);
   auto destroy_map = [](absl::flat_hash_map<int, cudaStream_t>& m) {
     for (auto& kv : m) {
@@ -195,16 +211,19 @@ absl::StatusOr<CopyHandle> AsyncCopyManager::submit_h2d(
       stage_or(opts, "H2D/Copy"),
       stream_to_use,
       [&]() { return cuda::memcpy_async(dst_ptr, src_ptr, bytes, cudaMemcpyHostToDevice, stream_to_use); },
-      [p, cb = opts.callbacks.on_copy_done, device_id = dst.device_id](absl::Status completion_status) {
-        if (cb) {
-          cb();
+      // CUDA host callbacks must avoid CUDA APIs; defer user callback onto CPU worker.
+      [this, p, cb = opts.callbacks.on_copy_done, device_id = dst.device_id](absl::Status completion_status) {
+        {
+          absl::MutexLock lock(&p->mu);
+          p->status = completion_status;
+          p->device_id = device_id;
+          p->needs_device_check = completion_status.ok() && device_id >= 0;
+          p->done = true;
+          p->cv.SignalAll();
         }
-        absl::MutexLock lock(&p->mu);
-        p->status = completion_status;
-        p->device_id = device_id;
-        p->needs_device_check = completion_status.ok() && device_id >= 0;
-        p->done = true;
-        p->cv.SignalAll();
+        if (cb) {
+          enqueue_callback_([cb, completion_status]() { cb(completion_status); });
+        }
       });
 
   if (!status.ok()) {
@@ -261,16 +280,18 @@ absl::StatusOr<CopyHandle> AsyncCopyManager::submit_d2d(
       stage_or(opts, "D2D/Copy"),
       stream_to_use,
       [&]() { return cuda::memcpy_async(dst_ptr, src_ptr, bytes, cudaMemcpyDeviceToDevice, stream_to_use); },
-      [p, cb = opts.callbacks.on_copy_done, device_id = dst.device_id](absl::Status completion_status) {
-        if (cb) {
-          cb();
+      [this, p, cb = opts.callbacks.on_copy_done, device_id = dst.device_id](absl::Status completion_status) {
+        {
+          absl::MutexLock lock(&p->mu);
+          p->status = completion_status;
+          p->device_id = device_id;
+          p->needs_device_check = completion_status.ok() && device_id >= 0;
+          p->done = true;
+          p->cv.SignalAll();
         }
-        absl::MutexLock lock(&p->mu);
-        p->status = completion_status;
-        p->device_id = device_id;
-        p->needs_device_check = completion_status.ok() && device_id >= 0;
-        p->done = true;
-        p->cv.SignalAll();
+        if (cb) {
+          enqueue_callback_([cb, completion_status]() { cb(completion_status); });
+        }
       });
 
   if (!status.ok()) {
@@ -322,16 +343,18 @@ absl::StatusOr<CopyHandle> AsyncCopyManager::submit_d2h(
       stage_or(opts, "D2H/Copy"),
       stream_to_use,
       [&]() { return cuda::memcpy_async(dst_ptr, src_ptr, bytes, cudaMemcpyDeviceToHost, stream_to_use); },
-      [p, cb = opts.callbacks.on_copy_done, device_id = src.device_id](absl::Status completion_status) {
-        if (cb) {
-          cb();
+      [this, p, cb = opts.callbacks.on_copy_done, device_id = src.device_id](absl::Status completion_status) {
+        {
+          absl::MutexLock lock(&p->mu);
+          p->status = completion_status;
+          p->device_id = device_id;
+          p->needs_device_check = completion_status.ok() && device_id >= 0;
+          p->done = true;
+          p->cv.SignalAll();
         }
-        absl::MutexLock lock(&p->mu);
-        p->status = completion_status;
-        p->device_id = device_id;
-        p->needs_device_check = completion_status.ok() && device_id >= 0;
-        p->done = true;
-        p->cv.SignalAll();
+        if (cb) {
+          enqueue_callback_([cb, completion_status]() { cb(completion_status); });
+        }
       });
 
   if (!status.ok()) {
@@ -362,16 +385,47 @@ absl::StatusOr<CopyHandle> AsyncCopyManager::submit_h2h(
   auto p = handle.p_;
   // Synchronous memcpy followed by immediate callback and handle completion.
   std::memcpy(const_cast<void*>(dst.base), src.base, src.length);
-  if (opts.callbacks.on_copy_done) {
-    opts.callbacks.on_copy_done();
-  }
   {
     absl::MutexLock lock(&p->mu);
     p->status = absl::OkStatus();
     p->done = true;
     p->cv.SignalAll();
   }
+  if (opts.callbacks.on_copy_done) {
+    enqueue_callback_([cb = opts.callbacks.on_copy_done]() { cb(absl::OkStatus()); });
+  }
   return handle;
+}
+
+void AsyncCopyManager::enqueue_callback_(std::function<void()> cb) {
+  if (!cb) {
+    return;
+  }
+  {
+    absl::MutexLock lock(&callback_mu_);
+    callback_queue_.push(std::move(cb));
+  }
+  callback_cv_.Signal();
+}
+
+void AsyncCopyManager::callback_loop_() {
+  while (true) {
+    std::function<void()> task;
+    {
+      absl::MutexLock lock(&callback_mu_);
+      while (!callback_shutdown_ && callback_queue_.empty()) {
+        callback_cv_.Wait(&callback_mu_);
+      }
+      if (callback_shutdown_ && callback_queue_.empty()) {
+        break;
+      }
+      task = std::move(callback_queue_.front());
+      callback_queue_.pop();
+    }
+    if (task) {
+      task();
+    }
+  }
 }
 
 } // namespace tensorcast::common

--- a/core/common/async_copy_manager.h
+++ b/core/common/async_copy_manager.h
@@ -88,6 +88,8 @@ class AsyncCopyManager {
   // Minimal D2D support: same-device only for this phase.
   absl::StatusOr<CopyHandle> submit_d2d(const DeviceRegion& src, const DeviceRegion& dst, const CopyOptions& opts = {});
 
+  // Dispatches the memcpy on the callback worker so completion behaves like
+  // other async submissions, enabling CPU-only tests to exercise pump logic.
   absl::StatusOr<CopyHandle> submit_h2h(const HostRegion& src, const HostRegion& dst, const CopyOptions& opts = {});
 
   // Destroy all lazily-created per-device streams. Safe to call multiple times.

--- a/core/common/async_copy_manager.h
+++ b/core/common/async_copy_manager.h
@@ -5,6 +5,8 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <queue>
+#include <thread>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -31,7 +33,12 @@ struct DeviceRegion {
 };
 
 struct CopyCallbacks {
-  std::function<void()> on_copy_done; // Fired on host callback when copy completes
+  // Fired asynchronously on a CPU worker thread after the CUDA work for this
+  // handle has completed. The callback runs outside of cudaLaunchHostFunc so it
+  // must still avoid invoking CUDA APIs directly; use AsyncCopyManager helpers
+  // (e.g., submit another copy) instead of calling CUDA Runtime/Driver calls.
+  // Status conveys the completion state reported by CUDA.
+  std::function<void(absl::Status)> on_copy_done;
 };
 
 struct CopyOptions {
@@ -87,18 +94,26 @@ class AsyncCopyManager {
   void shutdown();
 
  private:
-  AsyncCopyManager() = default;
+  AsyncCopyManager();
   ~AsyncCopyManager();
 
   // Internal helpers to lazily create and cache per-device non-blocking streams
   absl::StatusOr<cudaStream_t> get_h2d_stream_(int device_id);
   absl::StatusOr<cudaStream_t> get_d2h_stream_(int device_id);
   absl::StatusOr<cudaStream_t> get_d2d_stream_(int device_id);
+  void enqueue_callback_(std::function<void()> cb);
+  void callback_loop_();
 
   absl::Mutex mu_;
   absl::flat_hash_map<int, cudaStream_t> h2d_streams_ ABSL_GUARDED_BY(mu_);
   absl::flat_hash_map<int, cudaStream_t> d2h_streams_ ABSL_GUARDED_BY(mu_);
   absl::flat_hash_map<int, cudaStream_t> d2d_streams_ ABSL_GUARDED_BY(mu_);
+
+  absl::Mutex callback_mu_;
+  absl::CondVar callback_cv_;
+  std::queue<std::function<void()>> callback_queue_ ABSL_GUARDED_BY(callback_mu_);
+  bool callback_shutdown_ ABSL_GUARDED_BY(callback_mu_) = false;
+  std::thread callback_thread_;
 };
 
 } // namespace tensorcast::common

--- a/core/common/cuda_api.h
+++ b/core/common/cuda_api.h
@@ -150,6 +150,10 @@ absl::Status stream_add_callback(
     void (*callback)(cudaStream_t, cudaError_t, void*),
     void* user_data,
     unsigned int flags);
+// Enqueue a host callback on a CUDA stream. The callback must never invoke CUDA
+// Runtime/Driver APIs or block on stream work; callers should bounce any
+// follow-up CUDA interactions onto a different worker thread to comply with
+// cudaLaunchHostFunc requirements.
 absl::Status launch_host_func(cudaStream_t stream, void (*func)(void*), void* user_data);
 
 // Event management

--- a/core/common/memory/streaming_chunk_guard.cc
+++ b/core/common/memory/streaming_chunk_guard.cc
@@ -1,0 +1,123 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/common/memory/streaming_chunk_guard.h"
+
+#include "absl/log/log.h"
+
+namespace tensorcast::common::memory {
+
+StreamingChunkGuard::StreamingChunkGuard(std::shared_ptr<StreamingPinnedBuffer> buffer)
+    : buffer_shared_(std::move(buffer)), buffer_raw_(buffer_shared_.get()) {}
+
+StreamingChunkGuard::StreamingChunkGuard(gsl::not_null<StreamingPinnedBuffer*> buffer) : buffer_raw_(buffer.get()) {}
+
+StreamingChunkGuard::StreamingChunkGuard(StreamingPinnedBuffer* buffer) : buffer_raw_(buffer) {}
+
+StreamingChunkGuard::StreamingChunkGuard(StreamingChunkGuard&& other) noexcept {
+  *this = std::move(other);
+}
+
+StreamingChunkGuard& StreamingChunkGuard::operator=(StreamingChunkGuard&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  reset();
+  buffer_shared_ = std::move(other.buffer_shared_);
+  buffer_raw_ = buffer_shared_ ? buffer_shared_.get() : other.buffer_raw_;
+  host_ptr_ = other.host_ptr_;
+  slot_id_ = other.slot_id_;
+  promoted_ = other.promoted_;
+
+  other.host_ptr_ = nullptr;
+  other.slot_id_ = -1;
+  other.promoted_ = false;
+  other.buffer_raw_ = nullptr;
+  return *this;
+}
+
+StreamingChunkGuard::~StreamingChunkGuard() {
+  reset();
+}
+
+void StreamingChunkGuard::reset() {
+  if (!buffer_raw_ || slot_id_ < 0) {
+    return;
+  }
+
+  absl::Status status;
+  if (promoted_) {
+    status = buffer_raw_->return_chunk(slot_id_);
+  } else {
+    status = buffer_raw_->abort_producer_slot(slot_id_);
+  }
+  if (!status.ok()) {
+    LOG(WARNING) << "StreamingChunkGuard cleanup failed slot=" << slot_id_ << ": " << status;
+  }
+
+  slot_id_ = -1;
+  host_ptr_ = nullptr;
+  promoted_ = false;
+}
+
+absl::StatusOr<char*> StreamingChunkGuard::acquire() {
+  return acquire_internal(/*blocking=*/true);
+}
+
+absl::StatusOr<char*> StreamingChunkGuard::try_acquire() {
+  return acquire_internal(/*blocking=*/false);
+}
+
+absl::StatusOr<char*> StreamingChunkGuard::acquire_internal(bool blocking) {
+  if (!buffer_raw_) {
+    return absl::FailedPreconditionError("StreamingChunkGuard buffer is null");
+  }
+  if (slot_id_ >= 0) {
+    return absl::FailedPreconditionError("StreamingChunkGuard already acquired");
+  }
+
+  absl::StatusOr<int> slot_or = blocking ? buffer_raw_->get_free_chunk() : buffer_raw_->try_get_free_chunk();
+  if (!slot_or.ok()) {
+    return slot_or.status();
+  }
+
+  slot_id_ = *slot_or;
+  host_ptr_ = buffer_raw_->get_chunk_ptr(slot_id_);
+  if (host_ptr_ == nullptr) {
+    absl::Status rc = buffer_raw_->abort_producer_slot(slot_id_);
+    if (!rc.ok()) {
+      LOG(WARNING) << "StreamingChunkGuard abort_producer_slot failed slot=" << slot_id_ << ": " << rc;
+    }
+    slot_id_ = -1;
+    return absl::InternalError("StreamingChunkGuard failed to map chunk pointer");
+  }
+  return host_ptr_;
+}
+
+absl::Status StreamingChunkGuard::promote_to_consumer(size_t global_chunk_id, size_t bytes_in_chunk) {
+  if (slot_id_ < 0) {
+    return absl::FailedPreconditionError("StreamingChunkGuard has no active slot");
+  }
+  if (promoted_) {
+    return absl::FailedPreconditionError("StreamingChunkGuard already promoted");
+  }
+  auto status = buffer_raw_->promote_producer_slot_to_consumer(slot_id_, global_chunk_id, bytes_in_chunk);
+  if (status.ok()) {
+    promoted_ = true;
+  }
+  return status;
+}
+
+int StreamingChunkGuard::release_for_async() {
+  if (slot_id_ < 0) {
+    return -1;
+  }
+  if (!promoted_) {
+    LOG(FATAL) << "StreamingChunkGuard::release_for_async requires promoted slot";
+  }
+  int slot = slot_id_;
+  slot_id_ = -1;
+  host_ptr_ = nullptr;
+  return slot;
+}
+
+} // namespace tensorcast::common::memory

--- a/core/common/memory/streaming_chunk_guard.h
+++ b/core/common/memory/streaming_chunk_guard.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#pragma once
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gsl/pointers"
+
+#include "core/common/memory/streaming_pinned_buffer.h"
+
+namespace tensorcast::common::memory {
+
+// StreamingChunkGuard wraps the lifecycle of a StreamingPinnedBuffer slot.
+// Typical usage:
+//   StreamingChunkGuard guard(buffer);
+//   TCC_ASSIGN_OR_RETURN(auto host_ptr, guard.acquire());
+//   ... populate host_ptr ...
+//   TCC_RETURN_IF_ERROR(guard.promote_to_consumer(global_chunk_id, bytes));
+//   const int slot = guard.release_for_async();  // transfers ownership to async path
+//   // async callback must call StreamingPinnedBuffer::return_chunk(slot).
+//
+// If promote_to_consumer fails or the guard goes out of scope before release_for_async
+// is called, the guard automatically aborts or returns the slot, preventing leaks.
+class StreamingChunkGuard {
+ public:
+  explicit StreamingChunkGuard(std::shared_ptr<StreamingPinnedBuffer> buffer);
+  explicit StreamingChunkGuard(gsl::not_null<StreamingPinnedBuffer*> buffer);
+  explicit StreamingChunkGuard(StreamingPinnedBuffer* buffer);
+  StreamingChunkGuard(StreamingChunkGuard&& other) noexcept;
+  StreamingChunkGuard& operator=(StreamingChunkGuard&& other) noexcept;
+
+  StreamingChunkGuard(const StreamingChunkGuard&) = delete;
+  StreamingChunkGuard& operator=(const StreamingChunkGuard&) = delete;
+
+  ~StreamingChunkGuard();
+
+  // Acquire a producer-owned slot (blocking) and expose its host pointer.
+  absl::StatusOr<char*> acquire();
+
+  // Try to acquire a producer slot without blocking; returns Unavailable on contention.
+  absl::StatusOr<char*> try_acquire();
+
+  // Promote the currently-held slot into consumer ownership so async consumers
+  // (e.g. AsyncCopyManager callbacks) can safely recycle it via return_chunk().
+  absl::Status promote_to_consumer(size_t global_chunk_id, size_t bytes_in_chunk);
+
+  // Transfer responsibility for the slot to an async consumer. After this call,
+  // the guard will no longer clean up the slot in its destructor.
+  // Requires promote_to_consumer() to have succeeded.
+  int release_for_async();
+
+  bool has_slot() const {
+    return slot_id_ >= 0;
+  }
+
+  int slot_id() const {
+    return slot_id_;
+  }
+
+ private:
+  absl::StatusOr<char*> acquire_internal(bool blocking);
+  void reset();
+
+  std::shared_ptr<StreamingPinnedBuffer> buffer_shared_;
+  StreamingPinnedBuffer* buffer_raw_ = nullptr;
+  char* host_ptr_ = nullptr;
+  int slot_id_ = -1;
+  bool promoted_ = false;
+};
+
+} // namespace tensorcast::common::memory

--- a/core/common/memory/streaming_chunk_guard_test.cc
+++ b/core/common/memory/streaming_chunk_guard_test.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include <chrono>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "absl/status/status.h"
+
+#include "core/common/memory/pinned_buffer_pool.h"
+#include "core/common/memory/streaming_chunk_guard.h"
+#include "core/common/memory/streaming_pinned_buffer.h"
+
+namespace tensorcast::common::memory {
+namespace {
+
+constexpr size_t kChunkSize = 512;
+constexpr size_t kNumChunks = 8;
+
+std::shared_ptr<StreamingPinnedBuffer> MakeBuffer(std::shared_ptr<PinnedBufferPool> pool) {
+  auto buffer = std::make_shared<StreamingPinnedBuffer>(kNumChunks, kChunkSize, std::move(pool));
+  REQUIRE(buffer->initialize(std::chrono::milliseconds::zero()).ok());
+  return buffer;
+}
+
+TEST_CASE("StreamingChunkGuard returns producer slot on scope exit", "[streaming_chunk_guard]") {
+  auto pool = std::make_shared<PinnedBufferPool>(kChunkSize * kNumChunks, kChunkSize);
+  auto streaming = MakeBuffer(pool);
+
+  {
+    StreamingChunkGuard guard(streaming);
+    auto host_ptr_or = guard.acquire();
+    REQUIRE(host_ptr_or.ok());
+    REQUIRE(*host_ptr_or != nullptr);
+    // No promotion or release; guard destructor should abort and recycle.
+  }
+
+  StreamingChunkGuard guard(streaming);
+  auto host_ptr_or = guard.acquire();
+  REQUIRE(host_ptr_or.ok());
+  REQUIRE(*host_ptr_or != nullptr);
+  REQUIRE(guard.promote_to_consumer(/*global_chunk_id=*/0, /*bytes_in_chunk=*/kChunkSize).ok());
+  const int slot_id = guard.release_for_async();
+  REQUIRE(slot_id >= 0);
+  REQUIRE(streaming->return_chunk(slot_id).ok());
+
+  REQUIRE(streaming->release().ok());
+}
+
+TEST_CASE("StreamingChunkGuard TryAcquire reports availability", "[streaming_chunk_guard]") {
+  auto pool = std::make_shared<PinnedBufferPool>(kChunkSize, kChunkSize);
+  auto streaming = std::make_shared<StreamingPinnedBuffer>(/*num_chunks=*/1, kChunkSize, pool);
+  REQUIRE(streaming->initialize(std::chrono::milliseconds::zero()).ok());
+
+  {
+    StreamingChunkGuard guard(streaming);
+    REQUIRE(guard.acquire().ok());
+
+    StreamingChunkGuard contender(streaming);
+    auto try_result = contender.try_acquire();
+    REQUIRE_FALSE(try_result.ok());
+    REQUIRE(try_result.status().code() == absl::StatusCode::kUnavailable);
+  }
+
+  {
+    StreamingChunkGuard guard(streaming);
+    auto ptr_or = guard.try_acquire();
+    REQUIRE(ptr_or.ok());
+    REQUIRE(*ptr_or != nullptr);
+  }
+
+  REQUIRE(streaming->release().ok());
+}
+
+} // namespace
+} // namespace tensorcast::common::memory

--- a/core/common/memory/streaming_pinned_buffer.cc
+++ b/core/common/memory/streaming_pinned_buffer.cc
@@ -16,6 +16,9 @@ StreamingPinnedBuffer::StreamingPinnedBuffer(
     std::shared_ptr<PinnedBufferPool> pool)
     : num_chunks_(num_chunks), chunk_size_(chunk_size), pool_(std::move(pool)) {
   chunk_buffers_.reserve(num_chunks_);
+  slot_states_.assign(num_chunks_, SlotState::kFree);
+  slot_chunk_ids_.assign(num_chunks_, 0);
+  slot_epochs_.assign(num_chunks_, 0);
 
   // Verify that chunk_size from pool is aligned for DIRECT_IO
   if (pool_ && pool_->slice_bytes() % PinnedBufferPool::kDirectIOAlignment != 0) {
@@ -62,7 +65,11 @@ absl::Status StreamingPinnedBuffer::initialize(const std::chrono::milliseconds& 
   // Initialize all chunks as free
   for (size_t i = 0; i < num_chunks_; ++i) {
     free_queue_.push(static_cast<int>(i));
+    slot_states_[i] = SlotState::kFree;
+    slot_chunk_ids_[i] = 0;
+    slot_epochs_[i] = 0;
   }
+  next_epoch_ = 0;
 
   initialized_ = true;
   VLOG(1) << "Initialized streaming buffer with " << num_chunks_ << " chunks of " << chunk_size_ << " bytes each"
@@ -105,6 +112,12 @@ absl::Status StreamingPinnedBuffer::release() {
   while (!free_queue_.empty()) {
     free_queue_.pop();
   }
+  for (size_t i = 0; i < slot_states_.size(); ++i) {
+    slot_states_[i] = SlotState::kFree;
+    slot_chunk_ids_[i] = 0;
+    slot_epochs_[i] = 0;
+  }
+  next_epoch_ = 0;
   while (!ready_queue_.empty()) {
     ready_queue_.pop();
   }
@@ -140,6 +153,8 @@ absl::Status StreamingPinnedBuffer::reset_for_new_production() {
     auto rc = ready_queue_.front();
     ready_queue_.pop();
     free_queue_.push(rc.slot_id);
+    slot_states_[rc.slot_id] = SlotState::kFree;
+    slot_chunk_ids_[rc.slot_id] = 0;
   }
 
   // Ensure all slots are present in free_queue_. If some were lost due to
@@ -149,8 +164,12 @@ absl::Status StreamingPinnedBuffer::reset_for_new_production() {
     std::swap(free_queue_, empty);
     for (size_t i = 0; i < num_chunks_; ++i) {
       free_queue_.push(static_cast<int>(i));
+      slot_states_[i] = SlotState::kFree;
+      slot_chunk_ids_[i] = 0;
+      slot_epochs_[i] = 0;
     }
   }
+  next_epoch_ = 0;
 
   // Wake up any potential waiters
   ready_cv_.SignalAll();
@@ -196,6 +215,9 @@ absl::StatusOr<int> StreamingPinnedBuffer::get_free_chunk() {
 
   int slot_id = free_queue_.front();
   free_queue_.pop();
+  slot_chunk_ids_[slot_id] = 0;
+  slot_epochs_[slot_id] = ++next_epoch_;
+  set_slot_state_unsafe(slot_id, SlotState::kProducerOwned);
 
   if (waiting_logged) {
     LOG(INFO) << "StreamingPinnedBuffer wait resolved after " << absl::FormatDuration(absl::Now() - wait_start)
@@ -205,6 +227,68 @@ absl::StatusOr<int> StreamingPinnedBuffer::get_free_chunk() {
   return slot_id;
 }
 
+absl::Status StreamingPinnedBuffer::promote_producer_slot_to_consumer(
+    int slot_id,
+    size_t global_chunk_id,
+    size_t bytes_in_chunk) {
+  absl::MutexLock lock(&mutex_);
+
+  if (!initialized_) {
+    return absl::FailedPreconditionError("StreamingPinnedBuffer not initialized");
+  }
+
+  if (const auto status = validate_slot_id(slot_id); !status.ok()) {
+    return status;
+  }
+
+  if (bytes_in_chunk == 0 || bytes_in_chunk > chunk_size_) {
+    return absl::InvalidArgumentError("bytes_in_chunk must be within (0, chunk_size]");
+  }
+
+  if (get_slot_state_unsafe(slot_id) != SlotState::kProducerOwned) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(
+            "promote_producer_slot_to_consumer requires producer-owned slot; slot=",
+            slot_id,
+            " state=",
+            static_cast<int>(get_slot_state_unsafe(slot_id))));
+  }
+
+  slot_chunk_ids_[slot_id] = global_chunk_id;
+  slot_epochs_[slot_id] = ++next_epoch_;
+  set_slot_state_unsafe(slot_id, SlotState::kConsumerOwned);
+  chunks_produced_++;
+
+  return absl::OkStatus();
+}
+
+absl::Status StreamingPinnedBuffer::abort_producer_slot(int slot_id) {
+  absl::MutexLock lock(&mutex_);
+
+  if (!initialized_) {
+    return absl::FailedPreconditionError("StreamingPinnedBuffer not initialized");
+  }
+
+  if (const auto status = validate_slot_id(slot_id); !status.ok()) {
+    return status;
+  }
+
+  if (get_slot_state_unsafe(slot_id) != SlotState::kProducerOwned) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(
+            "abort_producer_slot expects producer-owned slot; slot=",
+            slot_id,
+            " state=",
+            static_cast<int>(get_slot_state_unsafe(slot_id))));
+  }
+
+  set_slot_state_unsafe(slot_id, SlotState::kFree);
+  slot_chunk_ids_[slot_id] = 0;
+  free_queue_.push(slot_id);
+  free_cv_.Signal();
+  return absl::OkStatus();
+}
+
 absl::Status StreamingPinnedBuffer::mark_chunk_ready(int slot_id, size_t global_chunk_id, size_t bytes_in_chunk) {
   absl::MutexLock lock(&mutex_);
 
@@ -212,8 +296,17 @@ absl::Status StreamingPinnedBuffer::mark_chunk_ready(int slot_id, size_t global_
     return absl::FailedPreconditionError("StreamingPinnedBuffer not initialized");
   }
 
-  if (slot_id < 0 || slot_id >= static_cast<int>(num_chunks_)) {
-    return absl::InvalidArgumentError("Invalid slot_id");
+  if (const auto status = validate_slot_id(slot_id); !status.ok()) {
+    return status;
+  }
+
+  if (get_slot_state_unsafe(slot_id) != SlotState::kProducerOwned) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(
+            "mark_chunk_ready expects producer-owned slot; slot=",
+            slot_id,
+            " state=",
+            static_cast<int>(get_slot_state_unsafe(slot_id))));
   }
 
   ReadyChunk chunk{
@@ -223,6 +316,8 @@ absl::Status StreamingPinnedBuffer::mark_chunk_ready(int slot_id, size_t global_
       .data_ptr = chunk_buffers_[slot_id]};
 
   ready_queue_.push(chunk);
+  slot_chunk_ids_[slot_id] = global_chunk_id;
+  set_slot_state_unsafe(slot_id, SlotState::kReady);
   chunks_produced_++;
   ready_cv_.Signal();
 
@@ -247,6 +342,19 @@ absl::StatusOr<StreamingPinnedBuffer::ReadyChunk> StreamingPinnedBuffer::get_rea
 
   ReadyChunk chunk = ready_queue_.front();
   ready_queue_.pop();
+  if (const auto status = validate_slot_id(chunk.slot_id); !status.ok()) {
+    return status;
+  }
+  if (get_slot_state_unsafe(chunk.slot_id) != SlotState::kReady) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(
+            "get_ready_chunk found slot in unexpected state=",
+            static_cast<int>(get_slot_state_unsafe(chunk.slot_id)),
+            " slot=",
+            chunk.slot_id));
+  }
+  set_slot_state_unsafe(chunk.slot_id, SlotState::kConsumerOwned);
+  slot_chunk_ids_[chunk.slot_id] = chunk.global_chunk_id;
 
   return chunk;
 }
@@ -258,10 +366,21 @@ absl::Status StreamingPinnedBuffer::return_chunk(int slot_id) {
     return absl::FailedPreconditionError("StreamingPinnedBuffer not initialized");
   }
 
-  if (slot_id < 0 || slot_id >= static_cast<int>(num_chunks_)) {
-    return absl::InvalidArgumentError("Invalid slot_id");
+  if (const auto status = validate_slot_id(slot_id); !status.ok()) {
+    return status;
   }
 
+  if (get_slot_state_unsafe(slot_id) != SlotState::kConsumerOwned) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(
+            "return_chunk expects consumer-owned slot; slot=",
+            slot_id,
+            " state=",
+            static_cast<int>(get_slot_state_unsafe(slot_id))));
+  }
+
+  set_slot_state_unsafe(slot_id, SlotState::kFree);
+  slot_chunk_ids_[slot_id] = 0;
   free_queue_.push(slot_id);
   chunks_consumed_++;
   free_cv_.Signal();
@@ -303,6 +422,9 @@ absl::StatusOr<int> StreamingPinnedBuffer::try_get_free_chunk() {
 
   int slot_id = free_queue_.front();
   free_queue_.pop();
+  set_slot_state_unsafe(slot_id, SlotState::kProducerOwned);
+  slot_chunk_ids_[slot_id] = 0;
+  slot_epochs_[slot_id] = ++next_epoch_;
 
   return slot_id;
 }
@@ -318,6 +440,21 @@ size_t StreamingPinnedBuffer::inflight() const {
 bool StreamingPinnedBuffer::production_done() const {
   absl::MutexLock lock(&mutex_);
   return production_complete_;
+}
+
+void StreamingPinnedBuffer::set_slot_state_unsafe(int slot_id, SlotState state) {
+  slot_states_[slot_id] = state;
+}
+
+StreamingPinnedBuffer::SlotState StreamingPinnedBuffer::get_slot_state_unsafe(int slot_id) const {
+  return slot_states_[slot_id];
+}
+
+absl::Status StreamingPinnedBuffer::validate_slot_id(int slot_id) const {
+  if (slot_id < 0 || slot_id >= static_cast<int>(num_chunks_)) {
+    return absl::InvalidArgumentError("Invalid slot_id");
+  }
+  return absl::OkStatus();
 }
 
 } // namespace tensorcast::common::memory

--- a/core/common/memory/streaming_pinned_buffer.h
+++ b/core/common/memory/streaming_pinned_buffer.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <queue>
 #include <vector>
@@ -22,6 +23,10 @@ namespace tensorcast::common::memory {
  * This class provides a producer-consumer pattern where:
  * - Producers can get free chunks, fill them with data, and mark them as ready
  * - Consumers can get ready chunks, use them, and return them to the free pool
+ *
+ * For single-threaded staging flows that immediately hand chunks to async
+ * callbacks (without enqueueing into the ready queue), prefer using
+ * `StreamingChunkGuard` to wrap slot acquisition, promotion, and cleanup.
  */
 class StreamingPinnedBuffer {
  public:
@@ -79,6 +84,22 @@ class StreamingPinnedBuffer {
    * @return Status indicating success or failure
    */
   absl::Status mark_chunk_ready(int slot_id, size_t global_chunk_id, size_t bytes_in_chunk) ABSL_LOCKS_EXCLUDED(mutex_);
+
+  /**
+   * @brief Promote a producer-owned chunk directly to consumer ownership without
+   *        enqueueing in the ready queue. Intended for synchronous staging flows.
+   * @param slot_id Slot previously acquired via get_free_chunk/try_get_free_chunk
+   * @param global_chunk_id Logical chunk identifier for diagnostics
+   * @param bytes_in_chunk Number of valid bytes produced in the chunk
+   */
+  absl::Status promote_producer_slot_to_consumer(int slot_id, size_t global_chunk_id, size_t bytes_in_chunk)
+      ABSL_LOCKS_EXCLUDED(mutex_);
+
+  /**
+   * @brief Abort production on a producer-owned chunk and return it to the free queue.
+   * @param slot_id Slot previously acquired via get_free_chunk/try_get_free_chunk
+   */
+  absl::Status abort_producer_slot(int slot_id) ABSL_LOCKS_EXCLUDED(mutex_);
 
   /**
    * @brief Structure representing a ready chunk for consumption.
@@ -158,12 +179,22 @@ class StreamingPinnedBuffer {
   bool production_done() const ABSL_LOCKS_EXCLUDED(mutex_);
 
  private:
+  enum class SlotState : uint8_t { kFree = 0, kProducerOwned, kReady, kConsumerOwned };
+
+  void set_slot_state_unsafe(int slot_id, SlotState state) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  SlotState get_slot_state_unsafe(int slot_id) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  absl::Status validate_slot_id(int slot_id) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
   const size_t num_chunks_;
   const size_t chunk_size_;
   std::shared_ptr<PinnedBufferPool> pool_;
 
   // Chunk buffers allocated from the pool
   std::vector<char*> chunk_buffers_;
+  std::vector<SlotState> slot_states_ ABSL_GUARDED_BY(mutex_);
+  std::vector<uint64_t> slot_chunk_ids_ ABSL_GUARDED_BY(mutex_);
+  std::vector<uint64_t> slot_epochs_ ABSL_GUARDED_BY(mutex_);
+  uint64_t next_epoch_ ABSL_GUARDED_BY(mutex_) = 0;
 
   // Free chunks available for producers
   std::queue<int> free_queue_ ABSL_GUARDED_BY(mutex_);

--- a/core/common/memory/streaming_pinned_buffer_test.cc
+++ b/core/common/memory/streaming_pinned_buffer_test.cc
@@ -1,0 +1,97 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include <chrono>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "core/common/memory/pinned_buffer_pool.h"
+#include "core/common/memory/streaming_pinned_buffer.h"
+
+namespace tensorcast::common::memory {
+
+TEST_CASE("StreamingPinnedBuffer detects invalid slot reuse", "[streaming_pinned_buffer]") {
+  constexpr size_t kChunkBytes = 4096;
+  constexpr size_t kNumChunks = 4;
+  auto pool = std::make_shared<PinnedBufferPool>(kChunkBytes * kNumChunks, kChunkBytes);
+  StreamingPinnedBuffer buffer(kNumChunks, kChunkBytes, pool);
+  REQUIRE(buffer.initialize(std::chrono::milliseconds(10)).ok());
+
+  auto slot_or = buffer.get_free_chunk();
+  REQUIRE(slot_or.ok());
+  const int slot_id = *slot_or;
+  REQUIRE(buffer.mark_chunk_ready(slot_id, /*global_chunk_id=*/1, kChunkBytes).ok());
+
+  auto ready_or = buffer.get_ready_chunk();
+  REQUIRE(ready_or.ok());
+  REQUIRE(ready_or->slot_id == slot_id);
+
+  // Attempting to mark the chunk ready again before returning must fail.
+  auto invalid_ready = buffer.mark_chunk_ready(slot_id, /*global_chunk_id=*/2, kChunkBytes);
+  REQUIRE_FALSE(invalid_ready.ok());
+
+  // Returning the chunk transitions it back to free.
+  REQUIRE(buffer.return_chunk(slot_id).ok());
+
+  // Reacquire and reuse succeeds (slot ordering is implementation-defined).
+  auto slot_two = buffer.get_free_chunk();
+  REQUIRE(slot_two.ok());
+  REQUIRE(buffer.mark_chunk_ready(*slot_two, /*global_chunk_id=*/3, kChunkBytes).ok());
+  auto ready_two = buffer.get_ready_chunk();
+  REQUIRE(ready_two.ok());
+  REQUIRE(buffer.return_chunk(ready_two->slot_id).ok());
+
+  REQUIRE(buffer.release().ok());
+}
+
+TEST_CASE("StreamingPinnedBuffer return_chunk enforces consumer ownership", "[streaming_pinned_buffer]") {
+  constexpr size_t kChunkBytes = 2048;
+  constexpr size_t kNumChunks = 2;
+  auto pool = std::make_shared<PinnedBufferPool>(kChunkBytes * kNumChunks, kChunkBytes);
+  StreamingPinnedBuffer buffer(kNumChunks, kChunkBytes, pool);
+  REQUIRE(buffer.initialize(std::chrono::milliseconds(0)).ok());
+
+  auto slot_or = buffer.get_free_chunk();
+  REQUIRE(slot_or.ok());
+  const int slot = *slot_or;
+
+  // Returning without flowing through mark/get should fail.
+  auto premature_return = buffer.return_chunk(slot);
+  REQUIRE_FALSE(premature_return.ok());
+
+  REQUIRE(buffer.mark_chunk_ready(slot, /*global_chunk_id=*/5, kChunkBytes).ok());
+  auto ready_or = buffer.get_ready_chunk();
+  REQUIRE(ready_or.ok());
+  REQUIRE(buffer.return_chunk(ready_or->slot_id).ok());
+
+  REQUIRE(buffer.release().ok());
+}
+
+TEST_CASE("StreamingPinnedBuffer promote and abort helpers work", "[streaming_pinned_buffer]") {
+  constexpr size_t kChunkBytes = 1024;
+  constexpr size_t kNumChunks = 2;
+  auto pool = std::make_shared<PinnedBufferPool>(kChunkBytes * kNumChunks, kChunkBytes);
+  StreamingPinnedBuffer buffer(kNumChunks, kChunkBytes, pool);
+  REQUIRE(buffer.initialize(std::chrono::milliseconds(0)).ok());
+
+  auto slot_or = buffer.get_free_chunk();
+  REQUIRE(slot_or.ok());
+  const int slot_id = *slot_or;
+  REQUIRE(
+      buffer.promote_producer_slot_to_consumer(slot_id, /*global_chunk_id=*/0, /*bytes_in_chunk=*/kChunkBytes).ok());
+  REQUIRE(buffer.return_chunk(slot_id).ok());
+
+  auto second_slot = buffer.get_free_chunk();
+  REQUIRE(second_slot.ok());
+  REQUIRE(buffer.abort_producer_slot(*second_slot).ok());
+
+  auto final_slot = buffer.get_free_chunk();
+  REQUIRE(final_slot.ok());
+  REQUIRE(buffer.mark_chunk_ready(*final_slot, /*global_chunk_id=*/1, /*bytes_in_chunk=*/kChunkBytes / 2).ok());
+  auto ready_chunk = buffer.get_ready_chunk();
+  REQUIRE(ready_chunk.ok());
+  REQUIRE(buffer.return_chunk(ready_chunk->slot_id).ok());
+
+  REQUIRE(buffer.release().ok());
+}
+
+} // namespace tensorcast::common::memory

--- a/core/common/trace/trace_cuda_async_fn.h
+++ b/core/common/trace/trace_cuda_async_fn.h
@@ -69,9 +69,14 @@ inline void sc_schedule_trace_host_cb(cudaStream_t stream, CudaTracePayload* pay
 // ---------------------------------------------------------------------------
 // Helper that executes a CUDA asynchronous operation (op) on the given stream,
 // starts a Trace span (stage) when called, and automatically ends the span once
-// the operation and all prior work in the stream completes.  An optional
-// on_complete callback is run inside the same host callback right after the
-// span ends, typically for resource cleanup.
+// the operation and all prior work in the stream completes.  The on_complete
+// callback ultimately runs as part of a cudaLaunchHostFunc callback before
+// being forwarded (if needed) to higher-level CPU workers. Per CUDA contract
+// the host callback must **never** invoke CUDA Runtime/Driver APIs or perform
+// stream synchronization that could wait on unfinished GPU work; violating
+// this can surface cudaErrorNotPermitted. Clients that need follow-up CUDA
+// work should enqueue that work onto their own worker thread or stream instead
+// of calling CUDA from on_complete.
 //
 // Usage:
 //   SC_RETURN_IF_ERROR(trace_cuda_async("h2d_copy", stream,

--- a/core/communicator/BUILD
+++ b/core/communicator/BUILD
@@ -278,6 +278,7 @@ sc_cc_library(
         "//core/common:device_guard_lib",
         "//core/common:error_handling_lib",
         "//core/common:pinned_buffer_pool_lib",
+        "//core/common:streaming_chunk_guard_lib",
         "//core/common:streaming_pinned_buffer_lib",
         "@opentelemetry-cpp//api:api",
     ],
@@ -318,6 +319,7 @@ sc_header_only_library(
         ":memory_stager_lib",
         "//core/common:cuda_api_lib",
         "//core/common:pinned_buffer_pool_lib",
+        "//core/common:streaming_chunk_guard_lib",
         "//core/common:streaming_pinned_buffer_lib",
     ],
 )

--- a/core/communicator/README.md
+++ b/core/communicator/README.md
@@ -288,6 +288,7 @@ Key characteristics:
 - Chunk sizing: `stage_chunk_mb_gpu` and `stage_chunk_mb_cpu` define per-stager slice sizes; GPU defaults to 16 MiB, CPU to 4 MiB.
 - Pool reuse: a single `PinnedBufferPool` services both staging paths (NUMA-specific pools are created when `simple_numa` is enabled).
 - Explicit release: MTCP senders free staged buffers once their socket writes complete, while RDMA paths rely on `RDMA_READ_DONE_EX` to release the corresponding `StageLease` entries in the registry.
+- GPU staging slots now use `StreamingChunkGuard` to acquire, promote, and hand buffers to async consumers, ensuring `StreamingPinnedBuffer` state transitions stay consistent while still aborting to the free queue if staging or copy submission fails.
 - Unified flow control: `FlowCreditLedger` grants staging credit per channel, `StagingWindow` slices responses into credit-bounded windows, and `stager.max_window_segments` (0 → auto) optionally caps the number of segments emitted per window.
 - Lane alignment on send/receive: MTCP now derives the active lane budget from the tensor’s total bytes and staging chunk size before assigning sockets on either side. Both sender and receiver use the same `offset + sub_offset_in_chunk` formula so GPU reads that span multiple sockets enqueue work to identical lane ordering, avoiding deadlocks when staging windows interleave connections.
 - Receive buffer lifecycle: MTCP channels now track in-flight read requests and, once the last staging window completes, release the per-transport `StreamingPinnedBuffer` slices back to the shared `PinnedBufferPool`. Subsequent reads re-initialize buffers on demand, so short-lived transports no longer monopolize pinned memory until the GC sweeps the channel.
@@ -530,6 +531,7 @@ Communicator is configured via `CommunicatorConfig` (C++ type, mirrored in Pytho
 
 - `enable_rdma`: enables RDMA transports and MR caching.
 - `transport.tcp_conn_count` / `transport.tcp_tos` / `transport.connect_timeout_sec`: MTCP fan-out, socket TOS, and control connect timeouts. The engine now honors the configured TCP fan-out during both the server listener setup and client dial; values ≤1 are automatically raised to the default multi-socket budget so staging credit math stays consistent.
+- `transport.so_reuseport`: enables multi-listener `SO_REUSEPORT`. Leave enabled in production multi-tenant deployments; tests disable it to force deterministic single-owner control sockets when running communicator suites in parallel.
 - `stager.stage_chunk_mb_{gpu,cpu}` & `stager.buffers_per_flow`: staging chunk size and pipeline depth.
 - `pool.pool_size_bytes` / `pool.preregister_mr`: pinned pool sizing and prereregistration policy.
 - `rdma.ack_ttl_ms`, `rdma.traffic_class`, `rdma.qp_timeout`, `rdma.qp_retry`: staged-buffer GC window and QP tuning knobs.

--- a/core/communicator/config_io.cc
+++ b/core/communicator/config_io.cc
@@ -120,6 +120,8 @@ void normalize_defaults(tc::CommunicatorConfig* cfg) {
     tr->set_tcp_tos(0);
   if (tr->connect_timeout_sec() <= 0)
     tr->set_connect_timeout_sec(10);
+  if (!tr->has_so_reuseport())
+    tr->set_so_reuseport(true);
 
   // Affinity defaults
   cfg->mutable_affinity();

--- a/core/communicator/config_io_test.cc
+++ b/core/communicator/config_io_test.cc
@@ -46,6 +46,7 @@ transport:
   REQUIRE(cfg.pool().pool_size_bytes() == 8ULL * 1024 * 1024 * 1024);
   REQUIRE(cfg.transport().tcp_conn_count() == 4);
   REQUIRE(cfg.transport().connect_timeout_sec() == 10);
+  REQUIRE(cfg.transport().so_reuseport() == true);
 }
 
 TEST_CASE("config_io JSON parse + defaults", "[communicator][config]") {
@@ -64,4 +65,5 @@ TEST_CASE("config_io JSON parse + defaults", "[communicator][config]") {
   // Defaults
   REQUIRE(cfg.pool().pool_size_bytes() == 8ULL * 1024 * 1024 * 1024);
   REQUIRE(cfg.transport().tcp_tos() == 0);
+  REQUIRE(cfg.transport().so_reuseport() == true);
 }

--- a/core/communicator/engine/engine.cc
+++ b/core/communicator/engine/engine.cc
@@ -239,6 +239,12 @@ Communicator::Communicator(const v1::CommunicatorConfig& config, uint32_t channe
   // Apply typed config to TCP contexts
   server_context_->set_connect_timeout(config_.transport().connect_timeout_sec());
   client_context_->set_connect_timeout(config_.transport().connect_timeout_sec());
+  bool so_reuseport_enabled = true;
+  if (config_.transport().has_so_reuseport()) {
+    so_reuseport_enabled = config_.transport().so_reuseport();
+  }
+  server_context_->set_so_reuseport(so_reuseport_enabled);
+  client_context_->set_so_reuseport(so_reuseport_enabled);
 
   // No default residency provider required; staging policy no longer consults UMA bridges.
 

--- a/core/communicator/engine/gpu_net_stager.h
+++ b/core/communicator/engine/gpu_net_stager.h
@@ -4,7 +4,10 @@
 
 #include <algorithm>
 #include <memory>
+#include <unordered_map>
+#include <utility>
 
+#include "absl/base/thread_annotations.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -12,6 +15,7 @@
 
 #include "core/common/cuda_api.h"
 #include "core/common/memory/pinned_buffer_pool.h"
+#include "core/common/memory/streaming_chunk_guard.h"
 #include "core/common/memory/streaming_pinned_buffer.h"
 #include "core/communicator/engine/memory_stager.h"
 #include "core/communicator/transport/partition_tensor.h"
@@ -39,8 +43,9 @@ class GpuNetStager : public MemoryStager {
       uint64_t offset,
       uint64_t bytes,
       StageMode mode) override {
-    if (bytes == 0)
-      return absl::InvalidArgumentError("GpuNetStager: zero bytes");
+    if (bytes == 0 || bytes > chunk_size_) {
+      return absl::InvalidArgumentError("GpuNetStager: bytes must be within (0, chunk_size]");
+    }
     if (offset + bytes > tensor->get_bytes()) {
       return absl::InvalidArgumentError("GpuNetStager: staging beyond tensor bounds");
     }
@@ -52,57 +57,59 @@ class GpuNetStager : public MemoryStager {
       if (!st.ok())
         return st;
     }
-    absl::StatusOr<int> slot_or =
-        mode == StageMode::kBlocking ? streaming_->get_free_chunk() : streaming_->try_get_free_chunk();
-    if (!slot_or.ok())
-      return slot_or.status();
-    int slot = *slot_or;
-    char* dst = streaming_->get_chunk_ptr(slot);
-    if (!dst)
-      return absl::InternalError("GpuNetStager: invalid slot pointer");
+    common::memory::StreamingChunkGuard slot_guard(streaming_.get());
+    absl::StatusOr<char*> dst_or = mode == StageMode::kBlocking ? slot_guard.acquire() : slot_guard.try_acquire();
+    if (!dst_or.ok()) {
+      return dst_or.status();
+    }
+    char* dst = *dst_or;
 
     // Perform synchronous D2H copy into pinned buffer
     int device_id = tensor->get_device_id();
     device_id = std::max(device_id, 0);
     auto guard = cuda::set_device(device_id);
     if (!guard.ok()) {
-      // Return the slot on failure
-      absl::Status _ret = streaming_->return_chunk(slot);
-      if (!_ret.ok()) {
-        LOG(WARNING) << "GpuNetStager: return_chunk failed after set_device error: " << _ret;
-      }
       return guard;
     }
     void* src = reinterpret_cast<void*>(tensor->get_uint64_addr() + offset);
     auto copy_st = cuda::memcpy(dst, src, bytes, cudaMemcpyDeviceToHost);
     if (!copy_st.ok()) {
-      absl::Status _ret = streaming_->return_chunk(slot);
-      if (!_ret.ok()) {
-        LOG(WARNING) << "GpuNetStager: return_chunk failed after memcpy error: " << _ret;
-      }
       return copy_st;
     }
+
+    // Derive a stable chunk index for diagnostics and slot tracking.
+    const size_t chunk_index = chunk_size_ > 0 ? static_cast<size_t>(offset / chunk_size_) : 0;
+    auto promote_status = slot_guard.promote_to_consumer(chunk_index, bytes);
+    if (!promote_status.ok()) {
+      return promote_status;
+    }
+    const int promoted_slot = slot_guard.release_for_async();
 
     void* host_ptr = static_cast<void*>(dst);
     {
       absl::MutexLock lk(&mu_);
-      ptr_to_slot_[host_ptr] = slot;
+      staged_slots_[host_ptr] = SlotMetadata{
+          .slot_id = promoted_slot,
+          .bytes_in_chunk = static_cast<size_t>(bytes),
+          .tensor_offset = offset,
+          .chunk_index = chunk_index,
+      };
     }
     return host_ptr;
   }
 
   absl::Status release_staged_buffer(gsl::not_null<void*> host_ptr) override {
-    int slot = -1;
+    SlotMetadata metadata;
     {
       absl::MutexLock lk(&mu_);
-      auto it = ptr_to_slot_.find(host_ptr.get());
-      if (it == ptr_to_slot_.end()) {
+      auto it = staged_slots_.find(host_ptr.get());
+      if (it == staged_slots_.end()) {
         return absl::NotFoundError("GpuNetStager: host ptr not found");
       }
-      slot = it->second;
-      ptr_to_slot_.erase(it);
+      metadata = it->second;
+      staged_slots_.erase(it);
     }
-    return streaming_->return_chunk(slot);
+    return streaming_->return_chunk(metadata.slot_id);
   }
 
   size_t get_chunk_size() const override {
@@ -119,7 +126,15 @@ class GpuNetStager : public MemoryStager {
   std::shared_ptr<common::memory::PinnedBufferPool> pool_;
   std::unique_ptr<common::memory::StreamingPinnedBuffer> streaming_;
   mutable absl::Mutex mu_;
-  std::unordered_map<void*, int> ptr_to_slot_ ABSL_GUARDED_BY(mu_);
+
+  struct SlotMetadata {
+    int slot_id;
+    size_t bytes_in_chunk;
+    uint64_t tensor_offset;
+    size_t chunk_index;
+  };
+
+  std::unordered_map<void*, SlotMetadata> staged_slots_ ABSL_GUARDED_BY(mu_);
 };
 
 } // namespace tensorcast::communicator::engine

--- a/core/communicator/transport/mtcp_transport.cc
+++ b/core/communicator/transport/mtcp_transport.cc
@@ -25,6 +25,7 @@
 
 #include "core/common/async_copy_manager.h"
 #include "core/common/device_guard.h"
+#include "core/common/memory/streaming_chunk_guard.h"
 #include "core/communicator/base/constants.h"
 #include "core/communicator/misc/utils.h"
 #include "core/communicator/transport/mtcp_transport.h"
@@ -1156,16 +1157,16 @@ void MTcpTransport::recv_loop() {
             lane %= lanes_to_use;
           }
 
-          // Acquire a free staging buffer
-          auto slot_result = gpu_recv_buffer_->get_free_chunk();
-          if (!slot_result.ok()) {
-            LOG(ERROR) << "Failed to get free chunk from GPU receive buffer: " << slot_result.status();
+          auto slot_guard = std::make_shared<common::memory::StreamingChunkGuard>(gpu_recv_buffer_);
+          auto staged_ptr_or = slot_guard->acquire();
+          if (!staged_ptr_or.ok()) {
+            LOG(ERROR) << "Failed to get free chunk from GPU receive buffer: " << staged_ptr_or.status();
             processing_failed = true;
             break;
           }
 
-          int slot_id = *slot_result;
-          char* staged_ptr = gpu_recv_buffer_->get_chunk_ptr(slot_id);
+          char* staged_ptr = *staged_ptr_or;
+          const int slot_id = slot_guard->slot_id();
 
           VLOG(2) << "[MTcpTransport::recv_loop] Got buffer slot #" << slot_id << " for sub-chunk ("
                   << sub_offset_in_chunk << "/" << real_chunk_size << ") of lane #" << lane;
@@ -1185,6 +1186,7 @@ void MTcpTransport::recv_loop() {
           auto gpu_global_offset = offset + sub_offset_in_chunk;
           auto* gpu_ptr = tensor->get_addr<uint8_t>() + gpu_global_offset;
           auto recv_buffer = gpu_recv_buffer_.get(); // keep shared ownership for async copy
+          const size_t chunk_index = pool_chunk_size > 0 ? static_cast<size_t>(gpu_global_offset / pool_chunk_size) : 0;
 
           const int lane_for_async = lane;
           auto copy_future = std::async(
@@ -1196,8 +1198,10 @@ void MTcpTransport::recv_loop() {
                tensor,
                lane_for_async,
                slot_id,
+               slot_guard,
                recv_buffer,
-               gpu_global_offset]() mutable -> chunk_result_t {
+               gpu_global_offset,
+               chunk_index]() mutable -> chunk_result_t {
                 VLOG(2) << "[MTcpTransport::recv_loop] Async task lane=" << lane_for_async
                         << " waiting for sub-chunk recv to complete";
 
@@ -1205,7 +1209,6 @@ void MTcpTransport::recv_loop() {
                 if (result.status != misc::SUCCESS) {
                   LOG(ERROR) << "[MTcpTransport::recv_loop] Async task lane=" << lane_for_async
                              << " sub-chunk recv failed, returning buffer";
-                  CHECK_OK(recv_buffer->return_chunk(slot_id));
                   return result;
                 }
 
@@ -1229,9 +1232,16 @@ void MTcpTransport::recv_loop() {
                 tensorcast::common::DeviceGuard guard(device_id);
                 if (!guard.status().ok()) {
                   LOG(ERROR) << "Failed to set CUDA device: " << guard.status();
-                  CHECK_OK(recv_buffer->return_chunk(slot_id));
                   return {misc::TRANSPORT_FAILED, result.cost};
                 }
+
+                auto promote_status = slot_guard->promote_to_consumer(chunk_index, sub_chunk_size);
+                if (!promote_status.ok()) {
+                  LOG(ERROR) << "Failed to promote slot " << slot_guard->slot_id()
+                             << " for async copy: " << promote_status;
+                  return {misc::TRANSPORT_FAILED, result.cost};
+                }
+                const int promoted_slot = slot_guard->release_for_async();
 
                 // Schedule async H2D using AsyncCopyManager, wait for completion to respect semantics.
                 tensorcast::common::HostRegion h{
@@ -1240,19 +1250,23 @@ void MTcpTransport::recv_loop() {
                     .device_id = device_id, .dev_ptr = gpu_ptr, .length = static_cast<size_t>(sub_chunk_size)};
                 tensorcast::common::CopyOptions opts{
                     .tracing_stage = "H2D/Copy",
-                    .callbacks = {.on_copy_done = [recv_buffer, slot_id](absl::Status st) {
-                      absl::Status rc = recv_buffer->return_chunk(slot_id);
+                    .callbacks = {.on_copy_done = [recv_buffer, promoted_slot](absl::Status st) {
+                      absl::Status rc = recv_buffer->return_chunk(promoted_slot);
                       if (!rc.ok()) {
-                        LOG(WARNING) << "recv_buffer->return_chunk failed slot=" << slot_id << ": " << rc;
+                        LOG(WARNING) << "recv_buffer->return_chunk failed slot=" << promoted_slot << ": " << rc;
                       }
                       if (!st.ok()) {
-                        LOG(ERROR) << "AsyncCopyManager::submit_h2d failed slot=" << slot_id << ": " << st;
+                        LOG(ERROR) << "AsyncCopyManager::submit_h2d failed slot=" << promoted_slot << ": " << st;
                       }
                     }}};
                 auto hdl_or = tensorcast::common::AsyncCopyManager::instance().submit_h2d(h, d, opts);
                 if (!hdl_or.ok()) {
                   LOG(ERROR) << "Failed to schedule H2D copy: " << hdl_or.status();
-                  CHECK_OK(recv_buffer->return_chunk(slot_id));
+                  absl::Status rc = recv_buffer->return_chunk(promoted_slot);
+                  if (!rc.ok()) {
+                    LOG(WARNING) << "recv_buffer->return_chunk failed slot=" << promoted_slot
+                                 << " after submit error: " << rc;
+                  }
                   return {misc::TRANSPORT_FAILED, result.cost};
                 }
                 auto wait_st = hdl_or->wait();
@@ -1260,7 +1274,7 @@ void MTcpTransport::recv_loop() {
                   LOG(ERROR) << "H2D copy failed: " << wait_st;
                   return {misc::TRANSPORT_FAILED, result.cost};
                 }
-                VLOG(2) << "[MTcpTransport::recv_loop] H2D copy complete slot=" << slot_id
+                VLOG(2) << "[MTcpTransport::recv_loop] H2D copy complete slot=" << promoted_slot
                         << " bytes=" << sub_chunk_size << " gpu_off=" << gpu_global_offset;
                 return result;
               });

--- a/core/communicator/transport/mtcp_transport.cc
+++ b/core/communicator/transport/mtcp_transport.cc
@@ -1239,13 +1239,16 @@ void MTcpTransport::recv_loop() {
                 tensorcast::common::DeviceRegion d{
                     .device_id = device_id, .dev_ptr = gpu_ptr, .length = static_cast<size_t>(sub_chunk_size)};
                 tensorcast::common::CopyOptions opts{
-                    .tracing_stage = "H2D/Copy", .callbacks = {.on_copy_done = [recv_buffer, slot_id]() {
-                                                   absl::Status rc = recv_buffer->return_chunk(slot_id);
-                                                   if (!rc.ok()) {
-                                                     LOG(WARNING) << "recv_buffer->return_chunk failed slot=" << slot_id
-                                                                  << ": " << rc;
-                                                   }
-                                                 }}};
+                    .tracing_stage = "H2D/Copy",
+                    .callbacks = {.on_copy_done = [recv_buffer, slot_id](absl::Status st) {
+                      absl::Status rc = recv_buffer->return_chunk(slot_id);
+                      if (!rc.ok()) {
+                        LOG(WARNING) << "recv_buffer->return_chunk failed slot=" << slot_id << ": " << rc;
+                      }
+                      if (!st.ok()) {
+                        LOG(ERROR) << "AsyncCopyManager::submit_h2d failed slot=" << slot_id << ": " << st;
+                      }
+                    }}};
                 auto hdl_or = tensorcast::common::AsyncCopyManager::instance().submit_h2d(h, d, opts);
                 if (!hdl_or.ok()) {
                   LOG(ERROR) << "Failed to schedule H2D copy: " << hdl_or.status();

--- a/core/communicator/transport/tcp_context.cc
+++ b/core/communicator/transport/tcp_context.cc
@@ -62,14 +62,16 @@ misc::result_t TcpContext::open(const std::string& ip, uint16_t port, on_accept_
     return misc::SYS_ERROR;
   }
 
-  // Enable address/port reuse to avoid EADDRINUSE due to TIME_WAIT and reduce bind conflicts
+  // Always enable address reuse to avoid TIME_WAIT collisions.
   int one = 1;
   if (setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != 0) {
     PLOG(WARNING) << "failed to set SO_REUSEADDR";
   }
 
-  if (setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) != 0) {
-    PLOG(WARNING) << "failed to set SO_REUSEPORT";
+  if (so_reuseport_enabled_) {
+    if (setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) != 0) {
+      PLOG(WARNING) << "failed to set SO_REUSEPORT";
+    }
   }
 
   misc::CLEAR(local_addr_);

--- a/core/communicator/transport/tcp_context.h
+++ b/core/communicator/transport/tcp_context.h
@@ -28,6 +28,14 @@ class TcpContext {
   std::string get_local_ip() const;
   uint16_t listening_port() const;
 
+  void set_so_reuseport(bool enabled) {
+    so_reuseport_enabled_ = enabled;
+  }
+
+  bool so_reuseport() const {
+    return so_reuseport_enabled_;
+  }
+
   // Typed configuration injection
   void set_connect_timeout(int seconds) {
     connect_timeout_sec_ = seconds;
@@ -54,6 +62,7 @@ class TcpContext {
   struct sockaddr_in local_addr_{};
   on_accept_func_t on_accept_;
   int connect_timeout_sec_ = 10;
+  bool so_reuseport_enabled_ = true;
 
   friend class TcpTransport;
 };

--- a/core/store/BUILD
+++ b/core/store/BUILD
@@ -361,6 +361,7 @@ cc_test(
 cc_test(
     name = "multi_gpu_test",
     srcs = ["multi_gpu_test.cc"],
+    shard_count = 3,
     tags = [
         "multi_gpu",
         "requires_cuda",

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -240,13 +240,14 @@ stateDiagram-v2
 ### Async Copy Manager Integration
 
 - H2D/D2H transfers submit via `AsyncCopyManager` (ACM), which wraps `cudaMemcpyAsync` with traced host callbacks and forwards completions onto a dedicated CPU worker to avoid making CUDA Runtime calls inside `cudaLaunchHostFunc`.
-- StreamingPinnedBuffer slots stay owned by the pump consumer until ACM completion; the completion callback is the only place that returns slots, preventing early reuse while the GPU DMA is still active.
+- StreamingPinnedBuffer slots stay owned by the pump consumer until ACM completion; the completion callback is the only place that returns slots, preventing early reuse while the GPU DMA is still active. Callers that need post-callback state (e.g., VS writes) must also block on the callback’s completion signal before reporting success.
+- Use `StreamingChunkGuard` (from `core/common/memory/streaming_chunk_guard.h`) when staging chunks for AsyncCopyManager. The guard acquires slots, promotes them to consumer ownership, and guarantees cleanup if submission fails, so callers cannot forget the `promote_producer_slot_to_consumer` transition.
 - For H2D, UMA state should advance from the completion callback (if the caller needs it) using the `absl::Status` argument as proof of success; per-chunk `stream_synchronize` remains unnecessary.
 - ACM owns per-device non-blocking streams per direction (H2D/D2H/D2D) and routes all copies through them; external stream injection has been removed.
 
 #### ACM Usage Quick Guide
 
-- Submit one async copy per chunk via `AsyncCopyManager`, and return SPB slots (or wake dependents) inside the `on_copy_done` callback. Do not `cudaStreamSynchronize()` per chunk; the callback runs on a CPU worker after the CUDA stream callback fires.
+- Submit one async copy per chunk via `AsyncCopyManager`, and return SPB slots (or wake dependents) inside the `on_copy_done` callback. Do not `cudaStreamSynchronize()` per chunk; the callback runs on a CPU worker after the CUDA stream callback fires. Pump consumers dealing with non-owning state (e.g., `pump_ranges`) instead poll handles and finalize completions inline so the callback does not outlive stack-owned context.
 - H2D example (return slot + optional UMA advancement in callback):
   ```cpp
   using common::AsyncCopyManager;
@@ -283,7 +284,7 @@ stateDiagram-v2
        }}} );
   ```
 - Same-device D2D: use `submit_d2d` and wait on handles as needed. Cross-device D2D remains under `ReplicaLoadController` (peer or staged fallback).
-- Tests and CPU-only flows can use `submit_h2h` to exercise the async pump path without CUDA.
+- Tests and CPU-only flows can use `submit_h2h` to exercise the async pump path without CUDA; the copy is dispatched on ACM’s callback worker so CopyHandles complete asynchronously.
 
 ### Chunk States (UMA Authority)
 

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -239,34 +239,48 @@ stateDiagram-v2
 
 ### Async Copy Manager Integration
 
-- H2D/D2H transfers now submit via `AsyncCopyManager` (ACM), which wraps `cudaMemcpyAsync` with traced host callbacks.
-- SPB slots are returned in the ACM completion callback; per-chunk `stream_synchronize` calls have been removed.
-- For H2D, UMA state is advanced per CPU-block after a single barrier on the device stream (temporary behavior; will move into ACM callbacks).
+- H2D/D2H transfers submit via `AsyncCopyManager` (ACM), which wraps `cudaMemcpyAsync` with traced host callbacks and forwards completions onto a dedicated CPU worker to avoid making CUDA Runtime calls inside `cudaLaunchHostFunc`.
+- StreamingPinnedBuffer slots stay owned by the pump consumer until ACM completion; the completion callback is the only place that returns slots, preventing early reuse while the GPU DMA is still active.
+- For H2D, UMA state should advance from the completion callback (if the caller needs it) using the `absl::Status` argument as proof of success; per-chunk `stream_synchronize` remains unnecessary.
 - ACM owns per-device non-blocking streams per direction (H2D/D2H/D2D) and routes all copies through them; external stream injection has been removed.
 
 #### ACM Usage Quick Guide
 
-- Submit one async copy per chunk via `AsyncCopyManager`, and return SPB slots inside the host callback. Do not `stream_synchronize()` per chunk.
+- Submit one async copy per chunk via `AsyncCopyManager`, and return SPB slots (or wake dependents) inside the `on_copy_done` callback. Do not `cudaStreamSynchronize()` per chunk; the callback runs on a CPU worker after the CUDA stream callback fires.
 - H2D example (return slot + optional UMA advancement in callback):
   ```cpp
   using common::AsyncCopyManager;
   common::HostRegion h{.base = host_ptr, .length = bytes, .pinned = true};
   common::DeviceRegion d{.device_id = device_id, .dev_ptr = dst_dev, .length = bytes};
   auto hdl_or = AsyncCopyManager::instance().submit_h2d(
-      h, d, {.tracing_stage = "H2D/Copy",
-             .callbacks = {.on_copy_done = [spb, slot_id, maybe_uma]() {
-               (void)spb->return_chunk(slot_id);
-               if (maybe_uma) maybe_uma();
-             }}});
+      h,
+      d,
+      {.tracing_stage = "H2D/Copy",
+       .callbacks = {.on_copy_done = [spb, slot_id, maybe_uma](absl::Status st) {
+         if (st.ok()) {
+           (void)spb->return_chunk(slot_id);
+           if (maybe_uma) {
+             maybe_uma();
+           }
+         } else {
+           LOG(ERROR) << "async copy failed, slot=" << slot_id << ": " << st;
+         }
+       }}} );
   RETURN_IF_ERROR(hdl_or.status());
   ```
 - D2H example (stage into SPB, mark ready in callback for writer thread):
   ```cpp
   auto hdl_or = AsyncCopyManager::instance().submit_d2h(
-      src_dev, dst_host, {.tracing_stage = "D2H/Copy",
-                          .callbacks = {.on_copy_done = [spb, slot_id, gid, bytes]() {
-                            (void)spb->mark_chunk_ready(slot_id, gid, bytes);
-                          }}});
+      src_dev,
+      dst_host,
+      {.tracing_stage = "D2H/Copy",
+       .callbacks = {.on_copy_done = [spb, slot_id, gid, bytes](absl::Status st) {
+         if (!st.ok()) {
+           LOG(ERROR) << "async copy failed, gid=" << gid << ": " << st;
+           return;
+         }
+         (void)spb->mark_chunk_ready(slot_id, gid, bytes);
+       }}} );
   ```
 - Same-device D2D: use `submit_d2d` and wait on handles as needed. Cross-device D2D remains under `ReplicaLoadController` (peer or staged fallback).
 - Tests and CPU-only flows can use `submit_h2h` to exercise the async pump path without CUDA.

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -235,7 +235,7 @@ stateDiagram-v2
 
 
 - GPU allocations are lazily created via UMA on first use; VS CPU region is reserved at construction.
-  - Transfers and loading are pipelined via `TransferService` and `pump_ranges`, using a per-session `StreamingPinnedBuffer` backed by the shared `PinnedBufferPool`.
+- Transfers and loading are pipelined via `TransferService` and `pump_ranges`, using a per-session `StreamingPinnedBuffer` backed by the shared `PinnedBufferPool`. TransferService tracks every in-flight H2D submission and waits for the outstanding `AsyncCopyManager` handles before completing so GPU residency is fully committed prior to verification.
 
 ### Async Copy Manager Integration
 

--- a/core/store/loader/gpu_memory_sink.cc
+++ b/core/store/loader/gpu_memory_sink.cc
@@ -5,12 +5,15 @@
 #include <array>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <utility>
+#include <vector>
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/log/vlog_is_on.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/types/span.h"
 #include "core/common/async_copy_manager.h"
 #include "core/common/device_guard.h"
 #include "opentelemetry/metrics/meter.h"
@@ -72,6 +75,74 @@ inline void maybe_init_limits_(GpuSchedDev& dev) {
   // In V3 final state, use built-in defaults; no env overrides.
   (void)dev; // defaults already set in struct initializer
 }
+
+inline bool debug_copy_checks_enabled() {
+  static const bool enabled = []() {
+    const char* env = std::getenv("TENSORCAST_DEBUG_GPU_COPY");
+    return env != nullptr && env[0] != '\0' && env[0] != '0';
+  }();
+  return enabled;
+}
+
+std::string bytes_to_hex(absl::Span<const uint8_t> bytes) {
+  std::string out;
+  out.reserve(bytes.size() * 3);
+  for (size_t i = 0; i < bytes.size(); ++i) {
+    if (i != 0) {
+      out.push_back(' ');
+    }
+    absl::StrAppendFormat(&out, "%02x", bytes[i]);
+  }
+  return out;
+}
+
+struct DebugCopyPayload {
+  int device_id;
+  uint64_t gpu_offset;
+  size_t bytes;
+  char* gpu_ptr;
+  std::vector<uint8_t> host_head;
+  std::vector<uint8_t> host_tail;
+
+  void verify() const {
+    if (bytes == 0) {
+      return;
+    }
+    auto set_dev_status = tensorcast::cuda::set_device(device_id);
+    if (!set_dev_status.ok()) {
+      LOG(ERROR) << "GpuMemorySink debug: cudaSetDevice failed device=" << device_id << " status=" << set_dev_status;
+      return;
+    }
+    const size_t head_len = host_head.size();
+    if (head_len > 0) {
+      std::vector<uint8_t> gpu_head(head_len);
+      auto head_status = tensorcast::cuda::memcpy(gpu_head.data(), gpu_ptr, head_len, cudaMemcpyDeviceToHost);
+      if (!head_status.ok()) {
+        LOG(ERROR) << "GpuMemorySink debug: head sampling failed device=" << device_id << " offset=" << gpu_offset
+                   << " len=" << head_len << " status=" << head_status;
+      } else if (std::memcmp(gpu_head.data(), host_head.data(), head_len) != 0) {
+        LOG(ERROR) << "GpuMemorySink debug: head mismatch device=" << device_id << " offset=" << gpu_offset
+                   << " bytes=" << bytes << " host_head=[" << bytes_to_hex(absl::MakeConstSpan(host_head))
+                   << "] gpu_head=[" << bytes_to_hex(absl::MakeConstSpan(gpu_head)) << "]";
+      }
+    }
+    if (!host_tail.empty()) {
+      const size_t tail_len = host_tail.size();
+      std::vector<uint8_t> gpu_tail(tail_len);
+      auto tail_status =
+          tensorcast::cuda::memcpy(gpu_tail.data(), gpu_ptr + (bytes - tail_len), tail_len, cudaMemcpyDeviceToHost);
+      if (!tail_status.ok()) {
+        LOG(ERROR) << "GpuMemorySink debug: tail sampling failed device=" << device_id
+                   << " offset=" << (gpu_offset + bytes - tail_len) << " len=" << tail_len << " status=" << tail_status;
+      } else if (std::memcmp(gpu_tail.data(), host_tail.data(), tail_len) != 0) {
+        LOG(ERROR) << "GpuMemorySink debug: tail mismatch device=" << device_id
+                   << " offset=" << (gpu_offset + bytes - tail_len) << " bytes=" << bytes << " host_tail=["
+                   << bytes_to_hex(absl::MakeConstSpan(host_tail)) << "] gpu_tail=["
+                   << bytes_to_hex(absl::MakeConstSpan(gpu_tail)) << "]";
+      }
+    }
+  }
+};
 
 inline void sched_acquire(int device_id, size_t bytes) {
   if (!gpu_sched_enabled())
@@ -169,7 +240,11 @@ absl::Status GpuMemorySink::write_at(uint64_t offset, const void* src, size_t by
   return absl::OkStatus();
 }
 
-absl::StatusOr<common::CopyHandle> GpuMemorySink::write_at_async(uint64_t offset, const void* src, size_t bytes) {
+absl::StatusOr<common::CopyHandle> GpuMemorySink::write_at_async(
+    uint64_t offset,
+    const void* src,
+    size_t bytes,
+    const AsyncWriteOptions& options) {
   if (!overall_status_.ok()) {
     return overall_status_;
   }
@@ -190,9 +265,41 @@ absl::StatusOr<common::CopyHandle> GpuMemorySink::write_at_async(uint64_t offset
   char* gpu_dest = static_cast<char*>(options_.gpu_base_ptr.get()) + offset;
   common::HostRegion h{.base = src, .length = bytes, .pinned = true};
   common::DeviceRegion d{.device_id = options_.device_id, .dev_ptr = gpu_dest, .length = bytes};
-  common::CopyOptions copts;
-  copts.tracing_stage = "H2D/Copy";
-  copts.callbacks.on_copy_done = [dev_id = options_.device_id, bytes]() { sched_release(dev_id, bytes); };
+  common::CopyOptions effective_opts = options.copy_options.has_value() ? *options.copy_options : common::CopyOptions{};
+  if (effective_opts.tracing_stage == nullptr) {
+    effective_opts.tracing_stage = "H2D/Copy";
+  }
+  const bool debug_enabled = debug_copy_checks_enabled();
+  auto release_token = [dev_id = options_.device_id, bytes]() { sched_release(dev_id, bytes); };
+  std::shared_ptr<DebugCopyPayload> debug_payload;
+  if (debug_enabled && bytes > 0) {
+    const auto* host_ptr = static_cast<const uint8_t*>(src);
+    debug_payload = std::make_shared<DebugCopyPayload>();
+    debug_payload->device_id = options_.device_id;
+    debug_payload->gpu_offset = offset;
+    debug_payload->bytes = bytes;
+    debug_payload->gpu_ptr = gpu_dest;
+    const size_t head_len = std::min<size_t>(64, bytes);
+    debug_payload->host_head.assign(host_ptr, host_ptr + head_len);
+    if (bytes > head_len) {
+      const size_t tail_len = std::min<size_t>(64, bytes);
+      debug_payload->host_tail.assign(host_ptr + (bytes - tail_len), host_ptr + bytes);
+    }
+  }
+  auto user_cb = effective_opts.callbacks.on_copy_done;
+  effective_opts.callbacks.on_copy_done = [release_cb = std::move(release_token), debug_payload, user_cb](
+                                              absl::Status st) {
+    if (st.ok() && debug_payload) {
+      debug_payload->verify();
+    } else if (!st.ok() && debug_payload) {
+      LOG(ERROR) << "GpuMemorySink async copy failed before debug verify device=" << debug_payload->device_id
+                 << " offset=" << debug_payload->gpu_offset << " bytes=" << debug_payload->bytes << " status=" << st;
+    }
+    release_cb();
+    if (user_cb) {
+      user_cb(st);
+    }
+  };
 
   // Tail sampling guard – only emit when we are within the final 16 bytes of the allocation.
   constexpr size_t kTailProbeBytes = 16;
@@ -207,7 +314,7 @@ absl::StatusOr<common::CopyHandle> GpuMemorySink::write_at_async(uint64_t offset
     std::memcpy(host_tail.data(), src_bytes + bytes - host_tail_len, host_tail_len);
   }
 
-  auto hdl_or = common::AsyncCopyManager::instance().submit_h2d(h, d, copts);
+  auto hdl_or = common::AsyncCopyManager::instance().submit_h2d(h, d, effective_opts);
   if (!hdl_or.ok()) {
     // Release budget on immediate failure path
     sched_release(options_.device_id, bytes);

--- a/core/store/loader/gpu_memory_sink.h
+++ b/core/store/loader/gpu_memory_sink.h
@@ -30,7 +30,11 @@ class GpuMemorySink : public Sink, public PositionedSink, public AsyncPositioned
   // Positioned write into GPU base + offset
   absl::Status write_at(uint64_t offset, const void* src, size_t bytes) override;
 
-  absl::StatusOr<common::CopyHandle> write_at_async(uint64_t offset, const void* src, size_t bytes) override;
+  absl::StatusOr<common::CopyHandle> write_at_async(
+      uint64_t offset,
+      const void* src,
+      size_t bytes,
+      const AsyncWriteOptions& options = AsyncWriteOptions{}) override;
 
   absl::Status close() override;
 

--- a/core/store/loader/p2p_loader_tcp_test.cc
+++ b/core/store/loader/p2p_loader_tcp_test.cc
@@ -1,6 +1,8 @@
 // Copyright (c) 2025, TensorCast Team.
 
+#include <algorithm>
 #include <cstring>
+#include <random>
 #include <vector>
 #include "core/common/cuda_api.h"
 
@@ -28,6 +30,26 @@ using tensorcast::store::replica::ReplicaLoadController;
 using namespace tensorcast::store;
 using namespace tensorcast::testing;
 
+namespace {
+
+int randomized_port_hint(int canonical_base) {
+  constexpr int kMinPort = 1024;
+  constexpr int kMaxPort = 65000;
+  if (canonical_base <= 0) {
+    canonical_base = 50000;
+  }
+  thread_local std::mt19937 rng([]() {
+    std::random_device rd;
+    return std::mt19937(rd());
+  }());
+  std::uniform_int_distribution<int> dist(-4096, 4096);
+  int hint = canonical_base + dist(rng);
+  hint = std::clamp(hint, kMinPort, kMaxPort);
+  return hint;
+}
+
+} // namespace
+
 TEST_CASE("P2PLoader TCP Mode GPU Support", "[communicator][tcp][gpu][p2p_loader]") {
   SKIP_IF_NO_CUDA();
 
@@ -37,10 +59,11 @@ TEST_CASE("P2PLoader TCP Mode GPU Support", "[communicator][tcp][gpu][p2p_loader
     const std::string tensor_key = "artifact_key_gpu_gpu";
 
     // Find available ports for GPU to GPU P2P communication
-    int source_port = find_available_port(kGpuGpuPortBase);
+    const int gpu_gpu_base = randomized_port_hint(kGpuGpuPortBase);
+    int source_port = find_available_port(gpu_gpu_base);
     REQUIRE(source_port > 0);
 
-    int target_port = find_available_port(source_port + 1);
+    int target_port = find_available_port(randomized_port_hint(gpu_gpu_base + 1));
     REQUIRE(target_port > 0);
 
     // Set up source engine with GPU tensor
@@ -133,10 +156,11 @@ TEST_CASE("P2PLoader TCP Mode GPU Support", "[communicator][tcp][gpu][p2p_loader
     const std::string tensor_key = "artifact_key_gpu_cpu";
 
     // Find available ports for GPU to CPU P2P communication
-    int source_port = find_available_port(kGpuCpuPortBase);
+    const int gpu_cpu_base = randomized_port_hint(kGpuCpuPortBase);
+    int source_port = find_available_port(gpu_cpu_base);
     REQUIRE(source_port > 0); // "Failed to find available port for GPU-to-CPU P2P source engine"
 
-    int target_port = find_available_port(source_port + 1);
+    int target_port = find_available_port(randomized_port_hint(gpu_cpu_base + 1));
     REQUIRE(target_port > 0); // "Failed to find available port for GPU-to-CPU P2P target engine"
 
     // Similar test but with CPU target
@@ -239,9 +263,10 @@ TEST_CASE("P2PLoader TCP Mode GPU Support", "[communicator][tcp][gpu][p2p_loader
     const std::size_t pool_chunk_size = 64 * 1024 * 1024; // 64 MiB slices
     const std::size_t artifact_size = pool_chunk_size * 9 + 32; // non-aligned tail chunk
 
-    int source_port = find_available_port();
+    const int gpu_gpu_subchunk_base = randomized_port_hint(50000);
+    int source_port = find_available_port(gpu_gpu_subchunk_base);
     REQUIRE(source_port > 0);
-    int target_port = find_available_port(source_port + 1);
+    int target_port = find_available_port(randomized_port_hint(gpu_gpu_subchunk_base + 1));
     REQUIRE(target_port > 0);
 
     auto src_cfg = make_tcp_communicator_config(
@@ -362,9 +387,10 @@ TEST_CASE("P2PLoader TCP Mode GPU Support", "[communicator][tcp][gpu][p2p_loader
       const uint32_t stage_chunk_mb = static_cast<uint32_t>(stage_chunk_bytes / (1024 * 1024));
       const std::size_t artifact_size = stage_chunk_bytes * 6; // Requires >1 window when buffers_per_flow=2
 
-      int source_port = find_available_port();
+      const int credit_base = randomized_port_hint(50500);
+      int source_port = find_available_port(credit_base);
       REQUIRE(source_port > 0);
-      int target_port = find_available_port(source_port + 1);
+      int target_port = find_available_port(randomized_port_hint(credit_base + 1));
       REQUIRE(target_port > 0);
 
       auto src_cfg = make_tcp_communicator_config(
@@ -473,9 +499,10 @@ TEST_CASE("P2PLoader TCP Mode GPU Support", "[communicator][tcp][gpu][p2p_loader
       const std::size_t communicator_pool_bytes =
           stage_chunk_bytes * buffers_per_flow * (static_cast<std::size_t>(tcp_conn_count) + 1);
 
-      int source_port = find_available_port();
+      const int small_pool_base = randomized_port_hint(51000);
+      int source_port = find_available_port(small_pool_base);
       REQUIRE(source_port > 0);
-      int target_port = find_available_port(source_port + 1);
+      int target_port = find_available_port(randomized_port_hint(small_pool_base + 1));
       REQUIRE(target_port > 0);
 
       auto src_cfg = make_tcp_communicator_config(

--- a/core/store/loader/pump.cc
+++ b/core/store/loader/pump.cc
@@ -102,23 +102,33 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
 
   std::vector<InFlight> inflight;
   auto* async = dynamic_cast<AsyncPositionedSink*>(&dst);
+  auto finalize_inflight = [&](InFlight& entry, const absl::Status& st) {
+    const bool failed = !st.ok();
+    if (failed) {
+      record_copy_failure_("gpu");
+      {
+        absl::MutexLock lock(&state.status_mutex);
+        if (state.consumer_status.ok()) {
+          state.consumer_status = st;
+        }
+      }
+      state.should_stop.store(true, std::memory_order_release);
+    }
+    pool.return_chunk(entry.slot_id);
+    if (failed) {
+      pool.shutdown();
+      draining = true;
+    }
+    VLOG(2) << "pump_async_completion slot=" << entry.slot_id << " chunk_id=" << entry.global_chunk_id
+            << " dest_offset=" << entry.dest_offset << " bytes=" << entry.bytes << " status=" << st;
+  };
   auto flush_inflight = [&]() {
     if (inflight.empty()) {
       return;
     }
     for (auto& entry : inflight) {
-      auto st = entry.handle.wait();
-      if (!st.ok()) {
-        record_copy_failure_("gpu");
-        {
-          absl::MutexLock lock(&state.status_mutex);
-          if (state.consumer_status.ok()) {
-            state.consumer_status = st;
-          }
-        }
-        state.should_stop.store(true, std::memory_order_release);
-        pool.shutdown();
-      }
+      absl::Status st = entry.handle.wait();
+      finalize_inflight(entry, st);
     }
     inflight.clear();
   };
@@ -170,22 +180,6 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
       const int slot_id = chunk.slot_id;
       const uint64_t chunk_id = chunk.global_chunk_id;
       const size_t chunk_bytes = chunk.bytes_in_chunk;
-      copy_opts.callbacks.on_copy_done = [slot_id, chunk_id, chunk_bytes, dest_offset, &pool, &state](absl::Status st) {
-        if (!st.ok()) {
-          record_copy_failure_("gpu");
-          {
-            absl::MutexLock lock(&state.status_mutex);
-            if (state.consumer_status.ok()) {
-              state.consumer_status = st;
-            }
-          }
-          state.should_stop.store(true, std::memory_order_release);
-          pool.shutdown();
-        }
-        pool.return_chunk(slot_id);
-        VLOG(2) << "pump_async_completion slot=" << slot_id << " chunk_id=" << chunk_id
-                << " dest_offset=" << dest_offset << " bytes=" << chunk_bytes << " status=" << st;
-      };
       write_opts.copy_options = copy_opts;
       auto hdl_or = async->write_at_async(dest_offset, chunk.data_ptr, chunk.bytes_in_chunk, write_opts);
       if (!hdl_or.ok()) {
@@ -226,41 +220,22 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
     // Sweep completed in-flight operations and return their slots.
     // Drop completed handles whose wait() already succeeded via callback.
     if (!inflight.empty()) {
-      std::vector<size_t> done_idx;
-      done_idx.reserve(inflight.size());
-      for (size_t i = 0; i < inflight.size(); ++i) {
-        auto st = inflight[i].handle.wait(absl::ZeroDuration());
+      for (size_t i = 0; i < inflight.size();) {
+        absl::Status st = inflight[i].handle.wait(absl::ZeroDuration());
         if (absl::IsDeadlineExceeded(st)) {
+          ++i;
           continue;
         }
-        if (!st.ok()) {
-          record_copy_failure_("gpu");
-          absl::MutexLock lock(&state.status_mutex);
-          if (state.consumer_status.ok()) {
-            state.consumer_status = st;
-          }
-          state.should_stop.store(true, std::memory_order_release);
-          pool.shutdown();
-          draining = true;
-        }
-        done_idx.push_back(i);
-      }
-      for (size_t k = 0; k < done_idx.size(); ++k) {
-        size_t idx = done_idx[done_idx.size() - 1 - k];
-        inflight.erase(inflight.begin() + idx);
+        finalize_inflight(inflight[i], st);
+        inflight.erase(inflight.begin() + i);
       }
     }
   }
 
   // Drain any remaining in-flight operations at shutdown
   for (auto& item : inflight) {
-    auto st = item.handle.wait();
-    if (!st.ok()) {
-      absl::MutexLock lock(&state.status_mutex);
-      if (state.consumer_status.ok()) {
-        state.consumer_status = st;
-      }
-    }
+    absl::Status st = item.handle.wait();
+    finalize_inflight(item, st);
   }
 }
 

--- a/core/store/loader/pump.cc
+++ b/core/store/loader/pump.cc
@@ -14,6 +14,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
+#include "core/common/async_copy_manager.h"
 // Direct write grant handled via sink capability
 #include <cstdlib>
 // OpenTelemetry counters for copy failure tracking
@@ -94,6 +95,9 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
   struct InFlight {
     tensorcast::common::CopyHandle handle;
     int slot_id;
+    uint64_t global_chunk_id;
+    uint64_t dest_offset;
+    size_t bytes;
   };
 
   std::vector<InFlight> inflight;
@@ -104,7 +108,6 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
     }
     for (auto& entry : inflight) {
       auto st = entry.handle.wait();
-      pool.return_chunk(entry.slot_id);
       if (!st.ok()) {
         record_copy_failure_("gpu");
         {
@@ -161,7 +164,30 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
 
     if (async != nullptr) {
       // Submit async write and defer returning the slot until completion.
-      auto hdl_or = async->write_at_async(dest_offset, chunk.data_ptr, chunk.bytes_in_chunk);
+      AsyncPositionedSink::AsyncWriteOptions write_opts;
+      tensorcast::common::CopyOptions copy_opts;
+      copy_opts.tracing_stage = "Pump/H2D";
+      const int slot_id = chunk.slot_id;
+      const uint64_t chunk_id = chunk.global_chunk_id;
+      const size_t chunk_bytes = chunk.bytes_in_chunk;
+      copy_opts.callbacks.on_copy_done = [slot_id, chunk_id, chunk_bytes, dest_offset, &pool, &state](absl::Status st) {
+        if (!st.ok()) {
+          record_copy_failure_("gpu");
+          {
+            absl::MutexLock lock(&state.status_mutex);
+            if (state.consumer_status.ok()) {
+              state.consumer_status = st;
+            }
+          }
+          state.should_stop.store(true, std::memory_order_release);
+          pool.shutdown();
+        }
+        pool.return_chunk(slot_id);
+        VLOG(2) << "pump_async_completion slot=" << slot_id << " chunk_id=" << chunk_id
+                << " dest_offset=" << dest_offset << " bytes=" << chunk_bytes << " status=" << st;
+      };
+      write_opts.copy_options = copy_opts;
+      auto hdl_or = async->write_at_async(dest_offset, chunk.data_ptr, chunk.bytes_in_chunk, write_opts);
       if (!hdl_or.ok()) {
         record_copy_failure_("gpu");
         absl::MutexLock lock(&state.status_mutex);
@@ -175,7 +201,13 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
         // Switch to drain mode to return remaining ready chunks
         draining = true;
       } else {
-        inflight.push_back(InFlight{.handle = std::move(*hdl_or), .slot_id = chunk.slot_id});
+        inflight.push_back(
+            InFlight{
+                .handle = std::move(*hdl_or),
+                .slot_id = chunk.slot_id,
+                .global_chunk_id = chunk.global_chunk_id,
+                .dest_offset = dest_offset,
+                .bytes = chunk.bytes_in_chunk});
       }
     } else {
       auto status = dst.write_at(dest_offset, chunk.data_ptr, chunk.bytes_in_chunk);
@@ -192,16 +224,15 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
     }
 
     // Sweep completed in-flight operations and return their slots.
+    // Drop completed handles whose wait() already succeeded via callback.
     if (!inflight.empty()) {
       std::vector<size_t> done_idx;
       done_idx.reserve(inflight.size());
       for (size_t i = 0; i < inflight.size(); ++i) {
         auto st = inflight[i].handle.wait(absl::ZeroDuration());
         if (absl::IsDeadlineExceeded(st)) {
-          continue; // not yet complete
+          continue;
         }
-        // Return slot regardless of status; propagate first error
-        pool.return_chunk(inflight[i].slot_id);
         if (!st.ok()) {
           record_copy_failure_("gpu");
           absl::MutexLock lock(&state.status_mutex);
@@ -214,7 +245,6 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
         }
         done_idx.push_back(i);
       }
-      // Erase completed entries from inflight vector (from back to front)
       for (size_t k = 0; k < done_idx.size(); ++k) {
         size_t idx = done_idx[done_idx.size() - 1 - k];
         inflight.erase(inflight.begin() + idx);
@@ -225,7 +255,6 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
   // Drain any remaining in-flight operations at shutdown
   for (auto& item : inflight) {
     auto st = item.handle.wait();
-    pool.return_chunk(item.slot_id);
     if (!st.ok()) {
       absl::MutexLock lock(&state.status_mutex);
       if (state.consumer_status.ok()) {

--- a/core/store/loader/pump_async_test.cc
+++ b/core/store/loader/pump_async_test.cc
@@ -60,12 +60,15 @@ class TestBufferPool : public BufferPool {
       free_.push_back(i);
     }
   }
+
   size_t chunk_size() const override {
     return chunk_size_;
   }
+
   int capacity() const override {
     return capacity_;
   }
+
   absl::StatusOr<int> get_free_chunk() override {
     std::unique_lock<std::mutex> lk(mu_);
     free_cv_.wait(lk, [&] { return !free_.empty() || stopped_; });
@@ -75,6 +78,7 @@ class TestBufferPool : public BufferPool {
     free_.pop_front();
     return id;
   }
+
   void return_chunk(int slot_id) override {
     {
       std::lock_guard<std::mutex> lk(mu_);
@@ -84,6 +88,7 @@ class TestBufferPool : public BufferPool {
     free_cv_.notify_one();
     ready_cv_.notify_one();
   }
+
   absl::Status mark_chunk_ready(int slot_id, uint64_t gid, size_t bytes) override {
     void* p = get_chunk_data_ptr(slot_id);
     if (!p)
@@ -95,6 +100,7 @@ class TestBufferPool : public BufferPool {
     ready_cv_.notify_one();
     return absl::OkStatus();
   }
+
   absl::StatusOr<ReadyChunk> get_ready_chunk() override {
     std::unique_lock<std::mutex> lk(mu_);
     ready_cv_.wait(lk, [&] { return !ready_.empty() || stopped_; });
@@ -104,15 +110,18 @@ class TestBufferPool : public BufferPool {
     ready_.pop();
     return c;
   }
+
   void signal_production_complete() override {
     std::lock_guard<std::mutex> lk(mu_);
     stopped_ = true;
     ready_cv_.notify_all();
     free_cv_.notify_all();
   }
+
   void shutdown() override {
     signal_production_complete();
   }
+
   void* get_chunk_data_ptr(int slot_id) override {
     if (slot_id < 0 || slot_id >= capacity_)
       return nullptr;
@@ -148,25 +157,33 @@ class TestAsyncSink : public PositionedSink, public AsyncPositionedSink {
     sync_called_++;
     return absl::OkStatus();
   }
+
   absl::Status close() override {
     return absl::OkStatus();
   }
 
-  absl::StatusOr<tensorcast::common::CopyHandle> write_at_async(uint64_t, const void* src, size_t bytes) override {
+  absl::StatusOr<tensorcast::common::CopyHandle> write_at_async(
+      uint64_t,
+      const void* src,
+      size_t bytes,
+      const AsyncWriteOptions& options = AsyncWriteOptions{}) override {
     async_called_++;
     // Use H2H copy for a ready handle; this still goes through ACM and traces.
     tensorcast::common::HostRegion hsrc{.base = src, .length = bytes, .pinned = true};
     if (tmp_.size() < bytes)
       tmp_.resize(bytes);
     tensorcast::common::HostRegion hdst{.base = tmp_.data(), .length = bytes, .pinned = true};
-    auto hdl_or =
-        tensorcast::common::AsyncCopyManager::instance().submit_h2h(hsrc, hdst, {.tracing_stage = "H2H/Copy"});
+    tensorcast::common::CopyOptions copts = options.copy_options.value_or(tensorcast::common::CopyOptions{});
+    if (copts.tracing_stage == nullptr)
+      copts.tracing_stage = "H2H/Copy";
+    auto hdl_or = tensorcast::common::AsyncCopyManager::instance().submit_h2h(hsrc, hdst, copts);
     return hdl_or;
   }
 
   int async_called() const {
     return async_called_.load();
   }
+
   int sync_called() const {
     return sync_called_.load();
   }
@@ -189,7 +206,7 @@ TEST_CASE("Pump uses AsyncPositionedSink path", "[pump][async]") {
   REQUIRE(sink.async_called() > 0);
   REQUIRE(sink.sync_called() == 0);
   // Ensure slots have been returned at least once
-  REQUIRE(pool.returned_slots().size() > 0);
+  REQUIRE(!pool.returned_slots().empty());
 }
 
 TEST_CASE("Pump async path surfaces sink error", "[pump][async]") {
@@ -199,7 +216,11 @@ TEST_CASE("Pump async path surfaces sink error", "[pump][async]") {
   // Sink that fails on first async call
   class FailingAsyncSink : public TestAsyncSink {
    public:
-    absl::StatusOr<tensorcast::common::CopyHandle> write_at_async(uint64_t, const void*, size_t) override {
+    absl::StatusOr<tensorcast::common::CopyHandle> write_at_async(
+        uint64_t,
+        const void*,
+        size_t,
+        const AsyncWriteOptions& = AsyncWriteOptions{}) override {
       return absl::InternalError("async sink failure");
     }
   } sink;

--- a/core/store/loader/pump_async_test.cc
+++ b/core/store/loader/pump_async_test.cc
@@ -14,6 +14,8 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "core/common/async_copy_manager.h"
 #include "core/store/loader/buffer_pool.h"
@@ -147,9 +149,9 @@ class TestBufferPool : public BufferPool {
   std::vector<int> returned_;
 };
 
-// Async sink that exercises the AsyncPositionedSink path. Uses ACM::submit_h2h
-// to avoid requiring CUDA; this returns a ready handle but still validates
-// the pump branch and handle-driven return logic.
+// Async sink that exercises the AsyncPositionedSink path. Uses
+// ACM::submit_h2h to avoid requiring CUDA while still driving the async pump
+// branch and slot return logic via CopyHandles.
 class TestAsyncSink : public PositionedSink, public AsyncPositionedSink {
  public:
   absl::Status write_at(uint64_t, const void*, size_t) override {
@@ -194,6 +196,62 @@ class TestAsyncSink : public PositionedSink, public AsyncPositionedSink {
   std::vector<char> tmp_;
 };
 
+class DelayedAsyncSink : public PositionedSink, public AsyncPositionedSink {
+ public:
+  explicit DelayedAsyncSink(absl::Duration delay) : delay_(delay) {}
+
+  absl::Status write_at(uint64_t, const void*, size_t) override {
+    return absl::UnimplementedError("DelayedAsyncSink expects async write");
+  }
+
+  absl::Status close() override {
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<tensorcast::common::CopyHandle> write_at_async(
+      uint64_t,
+      const void* src,
+      size_t bytes,
+      const AsyncWriteOptions& options = AsyncWriteOptions{}) override {
+    tensorcast::common::HostRegion hsrc{.base = src, .length = bytes, .pinned = true};
+    if (scratch_.size() < bytes)
+      scratch_.resize(bytes);
+    tensorcast::common::HostRegion hdst{.base = scratch_.data(), .length = bytes, .pinned = true};
+    tensorcast::common::CopyOptions copy_opts = options.copy_options.value_or(tensorcast::common::CopyOptions{});
+    auto downstream = copy_opts.callbacks.on_copy_done;
+    copy_opts.callbacks.on_copy_done = [this, downstream](absl::Status st) {
+      const int now = inflight_.fetch_add(1, std::memory_order_acq_rel) + 1;
+      int observed = max_inflight_.load(std::memory_order_relaxed);
+      while (now > observed && !max_inflight_.compare_exchange_weak(observed, now, std::memory_order_relaxed)) {
+      }
+      if (delay_ > absl::ZeroDuration()) {
+        absl::SleepFor(delay_);
+      }
+      if (downstream) {
+        downstream(st);
+      }
+      inflight_.fetch_sub(1, std::memory_order_acq_rel);
+      callbacks_.fetch_add(1, std::memory_order_relaxed);
+    };
+    return tensorcast::common::AsyncCopyManager::instance().submit_h2h(hsrc, hdst, copy_opts);
+  }
+
+  int max_inflight() const {
+    return max_inflight_.load(std::memory_order_relaxed);
+  }
+
+  int callback_count() const {
+    return callbacks_.load(std::memory_order_relaxed);
+  }
+
+ private:
+  absl::Duration delay_;
+  std::vector<char> scratch_;
+  std::atomic<int> inflight_{0};
+  std::atomic<int> max_inflight_{0};
+  std::atomic<int> callbacks_{0};
+};
+
 TEST_CASE("Pump uses AsyncPositionedSink path", "[pump][async]") {
   const size_t total = 32 * 1024;
   TestSeekableSource src(total);
@@ -230,4 +288,25 @@ TEST_CASE("Pump async path surfaces sink error", "[pump][async]") {
   auto st = pump_ranges(src, sink, pool, absl::MakeSpan(ranges), /*concurrency=*/1);
   REQUIRE(!st.ok());
   REQUIRE(st.message().find("async sink failure") != std::string::npos);
+}
+
+TEST_CASE("Pump async tolerates delayed callbacks", "[pump][async][delay]") {
+  const size_t total = 64 * 1024;
+  TestSeekableSource src(total);
+  const absl::Duration delay = absl::Milliseconds(2);
+  DelayedAsyncSink sink(delay);
+  TestBufferPool pool(/*chunk_size=*/4096, /*capacity=*/2);
+  std::vector<Range> ranges{{0ULL, total}};
+
+  auto status = pump_ranges(src, sink, pool, absl::MakeSpan(ranges), /*concurrency=*/2);
+  REQUIRE(status.ok());
+  const int expected_chunks = static_cast<int>(total / pool.chunk_size());
+  const absl::Duration wait_step = absl::Milliseconds(1);
+  const absl::Time deadline = absl::Now() + absl::Milliseconds(50);
+  while (sink.callback_count() < expected_chunks && absl::Now() < deadline) {
+    absl::SleepFor(wait_step);
+  }
+  REQUIRE(sink.max_inflight() >= 1);
+  REQUIRE(pool.returned_slots().size() == total / pool.chunk_size());
+  REQUIRE(sink.callback_count() == expected_chunks);
 }

--- a/core/store/loader/sink.h
+++ b/core/store/loader/sink.h
@@ -4,6 +4,8 @@
 
 #include <cstddef>
 
+#include <optional>
+
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
@@ -47,11 +49,21 @@ class AsyncPositionedSink {
  public:
   virtual ~AsyncPositionedSink() = default;
 
+  struct AsyncWriteOptions {
+    // Optional async copy tuning propagated into AsyncCopyManager. When unset,
+    // sink implementations will synthesize defaults (e.g., tracing stage).
+    std::optional<common::CopyOptions> copy_options;
+  };
+
   // Asynchronously write bytes at destination-global offset. The returned
   // handle becomes ready when the sink-side transfer has completed (e.g.,
   // after an H2D cudaMemcpyAsync finishes). Implementations should schedule
   // copies via AsyncCopyManager to ensure unified tracing and stream usage.
-  virtual absl::StatusOr<common::CopyHandle> write_at_async(uint64_t offset, const void* src, size_t bytes) = 0;
+  virtual absl::StatusOr<common::CopyHandle> write_at_async(
+      uint64_t offset,
+      const void* src,
+      size_t bytes,
+      const AsyncWriteOptions& options = AsyncWriteOptions{}) = 0;
 };
 
 // Optional capability: destination can plan direct writes into its VA ranges.

--- a/core/store/loading/chunk_aware_loading_strategy.cc
+++ b/core/store/loading/chunk_aware_loading_strategy.cc
@@ -249,7 +249,6 @@ absl::Status ChunkAwareLoadingStrategy::execute_local_cpu_copy(
   // Copy plan ranges using ACM; UMA ledger is finalized via commit() below.
   size_t completed = 0;
   absl::Status copy_status = absl::OkStatus();
-  absl::Mutex first_err_mu;
   absl::Status first_err = absl::OkStatus();
   common::CopyHandle last_handle;
   bool last_set = false;

--- a/core/store/replica/BUILD
+++ b/core/store/replica/BUILD
@@ -84,6 +84,7 @@ sc_cc_library(
         "//core/common:async_copy_manager_lib",
         "//core/common:cuda_api_lib",
         "//core/common:memory_location_lib",
+        "//core/common:streaming_chunk_guard_lib",
         "//core/common:streaming_pinned_buffer_lib",
         "//core/common:virtual_address_space_lib",
         "//core/store:device_types",

--- a/core/store/replica/transfer_helpers.cc
+++ b/core/store/replica/transfer_helpers.cc
@@ -100,14 +100,17 @@ absl::Status perform_copy_cpu_to_gpu_streaming(
       common::HostRegion h{.base = host_ptr, .length = step, .pinned = true};
       common::DeviceRegion d{.device_id = static_cast<int>(device_id), .dev_ptr = dst_device, .length = step};
       common::CopyOptions opts{
-          .tracing_stage = "H2D/Copy", .callbacks = {.on_copy_done = [streaming_buf, slot_id, remaining]() {
-                                         absl::Status rc = streaming_buf->return_chunk(slot_id);
-                                         if (!rc.ok()) {
-                                           LOG(WARNING) << "StreamingPinnedBuffer::return_chunk failed slot=" << slot_id
-                                                        << ": " << rc;
-                                         }
-                                         (void)remaining->fetch_sub(1, std::memory_order_acq_rel);
-                                       }}};
+          .tracing_stage = "H2D/Copy",
+          .callbacks = {.on_copy_done = [streaming_buf, slot_id, remaining](absl::Status st) {
+            absl::Status rc = streaming_buf->return_chunk(slot_id);
+            if (!rc.ok()) {
+              LOG(WARNING) << "StreamingPinnedBuffer::return_chunk failed slot=" << slot_id << ": " << rc;
+            }
+            if (!st.ok()) {
+              LOG(ERROR) << "AsyncCopyManager::submit_h2d failed slot=" << slot_id << ": " << st;
+            }
+            (void)remaining->fetch_sub(1, std::memory_order_acq_rel);
+          }}};
       auto hdl_or = common::AsyncCopyManager::instance().submit_h2d(h, d, opts);
       if (!hdl_or.ok()) {
         // Return the slot immediately on submission failure
@@ -187,20 +190,24 @@ absl::Status perform_copy_gpu_to_cpu_streaming(
                              chunk_offset,
                              current_chunk_size,
                              first_error,
-                             first_error_mu]() {
-              // Write to VS then return slot; record first VS error if any
-              absl::Status st = virtual_addr_space->write_at(artifact_id, chunk_offset, host_ptr, current_chunk_size);
-              if (!st.ok()) {
+                             first_error_mu](absl::Status copy_status) {
+              if (copy_status.ok()) {
+                absl::Status st = virtual_addr_space->write_at(artifact_id, chunk_offset, host_ptr, current_chunk_size);
+                if (!st.ok()) {
+                  absl::MutexLock lk(first_error_mu.get());
+                  if (first_error->ok()) {
+                    *first_error = st;
+                  }
+                }
+              } else {
                 absl::MutexLock lk(first_error_mu.get());
                 if (first_error->ok()) {
-                  *first_error = st;
+                  *first_error = copy_status;
                 }
               }
-              {
-                absl::Status rc = streaming_buf->return_chunk(slot_id);
-                if (!rc.ok()) {
-                  LOG(WARNING) << "StreamingPinnedBuffer::return_chunk failed slot=" << slot_id << ": " << rc;
-                }
+              absl::Status rc = streaming_buf->return_chunk(slot_id);
+              if (!rc.ok()) {
+                LOG(WARNING) << "StreamingPinnedBuffer::return_chunk failed slot=" << slot_id << ": " << rc;
               }
             }}};
     auto hdl_or = common::AsyncCopyManager::instance().submit_d2h(s, h, opts);

--- a/core/store/replica/transfer_helpers.cc
+++ b/core/store/replica/transfer_helpers.cc
@@ -65,6 +65,9 @@ absl::Status perform_copy_cpu_to_gpu_streaming(
     }
   }
   const size_t num_va_chunks = (total_size + va_chunk - 1) / va_chunk;
+  const size_t total_copy_chunks = (total_size + copy_chunk - 1) / copy_chunk;
+  std::vector<common::CopyHandle> copy_handles;
+  copy_handles.reserve(total_copy_chunks); // Track every async H2D so we can wait for completion at the end.
   for (size_t va_idx = 0; va_idx < num_va_chunks; ++va_idx) {
     const size_t va_off = va_idx * va_chunk;
     const size_t this_len = std::min(va_chunk, total_size - va_off);
@@ -76,8 +79,6 @@ absl::Status perform_copy_cpu_to_gpu_streaming(
     const int num_subchunks = static_cast<int>((this_len + copy_chunk - 1) / copy_chunk);
     auto remaining = std::make_shared<std::atomic<int>>(num_subchunks);
     size_t copied = 0;
-    common::CopyHandle last_hdl;
-    bool last_set = false;
     while (copied < this_len) {
       size_t step = std::min(copy_chunk, this_len - copied);
       common::memory::StreamingChunkGuard guard(streaming_buf);
@@ -124,17 +125,16 @@ absl::Status perform_copy_cpu_to_gpu_streaming(
         }
         return hdl_or.status();
       }
-      last_hdl = std::move(*hdl_or);
-      last_set = true;
+      copy_handles.emplace_back(std::move(*hdl_or));
 
       copied += step;
     }
-    // Ensure callbacks for the last submitted chunk are executed
-    if (last_set) {
-      auto wst = last_hdl.wait();
-      if (!wst.ok()) {
-        return wst;
-      }
+  }
+
+  for (auto& handle : copy_handles) {
+    auto wait_status = handle.wait();
+    if (!wait_status.ok()) {
+      return wait_status;
     }
   }
 

--- a/core/store/replica/transfer_helpers.cc
+++ b/core/store/replica/transfer_helpers.cc
@@ -9,9 +9,11 @@
 
 #include "absl/log/absl_check.h"
 #include "absl/log/log.h"
+#include "absl/synchronization/blocking_counter.h"
 #include "absl/synchronization/mutex.h"
 #include "core/common/async_copy_manager.h"
 #include "core/common/memory/memory_location.h"
+#include "core/common/memory/streaming_chunk_guard.h"
 #include "core/store/replica/chunk_meta.h"
 
 namespace tensorcast::store::replica {
@@ -78,22 +80,24 @@ absl::Status perform_copy_cpu_to_gpu_streaming(
     bool last_set = false;
     while (copied < this_len) {
       size_t step = std::min(copy_chunk, this_len - copied);
-      // Acquire a free chunk slot
-      auto slot_or = streaming_buf->get_free_chunk();
-      if (!slot_or.ok()) {
-        return slot_or.status();
+      common::memory::StreamingChunkGuard guard(streaming_buf);
+      auto host_ptr_or = guard.acquire();
+      if (!host_ptr_or.ok()) {
+        return host_ptr_or.status();
       }
-      int slot_id = *slot_or;
-      char* host_ptr = streaming_buf->get_chunk_ptr(slot_id);
-      if (host_ptr == nullptr) {
-        ABSL_CHECK_OK(streaming_buf->return_chunk(slot_id));
-        return absl::InternalError("Failed to get chunk pointer from streaming buffer");
-      }
+      char* host_ptr = *host_ptr_or;
 
       // Copy from CPU VA (prefer UMA grant base if available) to pinned chunk
       void* src_host = grant_base_addr != 0 ? reinterpret_cast<void*>(grant_base_addr + va_off + copied)
                                             : static_cast<char*>(vs_base.get()) + va_off + copied;
       std::memcpy(host_ptr, src_host, step);
+
+      const size_t chunk_index = (va_off + copied) / copy_chunk;
+      auto promote_status = guard.promote_to_consumer(chunk_index, step);
+      if (!promote_status.ok()) {
+        return promote_status;
+      }
+      const int slot_id = guard.release_for_async();
 
       // Async copy H2D via ACM; return SPB slot in host callback
       void* dst_device = static_cast<char*>(gpu_ptr.get()) + va_off + copied;
@@ -113,8 +117,11 @@ absl::Status perform_copy_cpu_to_gpu_streaming(
           }}};
       auto hdl_or = common::AsyncCopyManager::instance().submit_h2d(h, d, opts);
       if (!hdl_or.ok()) {
-        // Return the slot immediately on submission failure
-        ABSL_CHECK_OK(streaming_buf->return_chunk(slot_id));
+        absl::Status rc = streaming_buf->return_chunk(slot_id);
+        if (!rc.ok()) {
+          LOG(WARNING) << "StreamingPinnedBuffer::return_chunk failed after submit_h2d error slot=" << slot_id << ": "
+                       << rc;
+        }
         return hdl_or.status();
       }
       last_hdl = std::move(*hdl_or);
@@ -146,6 +153,7 @@ absl::Status perform_copy_gpu_to_cpu_streaming(
   ABSL_CHECK_GT(total_size, 0) << "Total size must be positive";
 
   size_t chunk_size = streaming_buf->chunk_size();
+  ABSL_CHECK_GT(chunk_size, 0) << "StreamingPinnedBuffer chunk size must be positive";
   size_t offset = 0;
 
   // Track first error observed in host callbacks (e.g., VS write failures)
@@ -157,21 +165,26 @@ absl::Status perform_copy_gpu_to_cpu_streaming(
     return device_status;
   }
 
+  const size_t total_chunks = (total_size + chunk_size - 1) / chunk_size;
+  auto pending_callbacks = std::make_shared<absl::BlockingCounter>(static_cast<ptrdiff_t>(total_chunks));
+
   std::vector<common::CopyHandle> handles;
   while (offset < total_size) {
     size_t current_chunk_size = std::min(chunk_size, total_size - offset);
 
-    // Acquire a free chunk slot
-    auto slot_or = streaming_buf->get_free_chunk();
-    if (!slot_or.ok()) {
-      return slot_or.status();
+    common::memory::StreamingChunkGuard guard(streaming_buf);
+    auto host_ptr_or = guard.acquire();
+    if (!host_ptr_or.ok()) {
+      return host_ptr_or.status();
     }
-    int slot_id = *slot_or;
-    char* host_ptr = streaming_buf->get_chunk_ptr(slot_id);
-    if (host_ptr == nullptr) {
-      ABSL_CHECK_OK(streaming_buf->return_chunk(slot_id));
-      return absl::InternalError("Failed to get chunk pointer from streaming buffer");
+    char* host_ptr = *host_ptr_or;
+    const size_t chunk_index = chunk_size > 0 ? offset / chunk_size : 0;
+
+    auto promote_status = guard.promote_to_consumer(chunk_index, current_chunk_size);
+    if (!promote_status.ok()) {
+      return promote_status;
     }
+    const int slot_id = guard.release_for_async();
 
     // Async D2H via ACM; upon completion, write into VS and return the slot
     void* src_device = static_cast<char*>(gpu_ptr.get()) + offset;
@@ -190,7 +203,8 @@ absl::Status perform_copy_gpu_to_cpu_streaming(
                              chunk_offset,
                              current_chunk_size,
                              first_error,
-                             first_error_mu](absl::Status copy_status) {
+                             first_error_mu,
+                             pending_callbacks](absl::Status copy_status) {
               if (copy_status.ok()) {
                 absl::Status st = virtual_addr_space->write_at(artifact_id, chunk_offset, host_ptr, current_chunk_size);
                 if (!st.ok()) {
@@ -209,10 +223,15 @@ absl::Status perform_copy_gpu_to_cpu_streaming(
               if (!rc.ok()) {
                 LOG(WARNING) << "StreamingPinnedBuffer::return_chunk failed slot=" << slot_id << ": " << rc;
               }
+              pending_callbacks->DecrementCount();
             }}};
     auto hdl_or = common::AsyncCopyManager::instance().submit_d2h(s, h, opts);
     if (!hdl_or.ok()) {
-      ABSL_CHECK_OK(streaming_buf->return_chunk(slot_id));
+      absl::Status rc = streaming_buf->return_chunk(slot_id);
+      if (!rc.ok()) {
+        LOG(WARNING) << "StreamingPinnedBuffer::return_chunk failed after submit_d2h error slot=" << slot_id << ": "
+                     << rc;
+      }
       return hdl_or.status();
     }
     handles.emplace_back(std::move(*hdl_or));
@@ -227,6 +246,9 @@ absl::Status perform_copy_gpu_to_cpu_streaming(
       return wst;
     }
   }
+
+  pending_callbacks->Wait();
+
   {
     absl::MutexLock lk(first_error_mu.get());
     if (!first_error->ok()) {

--- a/core/testing/README.md
+++ b/core/testing/README.md
@@ -1,0 +1,9 @@
+# core/testing
+
+Shared C++ utilities that back TensorCast's integration and concurrency tests.
+
+## TempArtifactFixture
+
+- Creates RFC-0007 compliant artifacts for disk-based StoreEngine tests.
+- Fixture roots now include a unique hex suffix derived from time, thread id, and a counter (e.g., `/tmp/store_engine_multi_gpu_b2_<suffix>`) so parallel runs never collide or wipe each other's artifacts.
+- Paths are automatically cleaned up when the fixture goes out of scope.

--- a/core/testing/concurrency_utils.h
+++ b/core/testing/concurrency_utils.h
@@ -3,9 +3,13 @@
 // Shared utilities for StoreEngine concurrency tests.
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <filesystem>
 #include <latch>
 #include <mutex>
 #include <random>
+#include <sstream>
 #include <thread>
 #include <vector>
 
@@ -115,8 +119,7 @@ class ConcurrentLoadTracker {
 // Test fixture for creating temporary replica files
 class TempArtifactFixture {
  public:
-  explicit TempArtifactFixture(const std::string& test_name)
-      : root_path_(std::filesystem::temp_directory_path() / ("store_engine_" + test_name)) {
+  explicit TempArtifactFixture(const std::string& test_name) : root_path_(make_unique_root(test_name)) {
     std::filesystem::create_directories(root_path_);
   }
 
@@ -145,6 +148,17 @@ class TempArtifactFixture {
   }
 
  private:
+  static std::filesystem::path make_unique_root(const std::string& test_name) {
+    const auto base = std::filesystem::temp_directory_path();
+    // Isolate fixture directories per test run to avoid cross-test interference when running in parallel.
+    static std::atomic<uint64_t> fixture_counter{0};
+    const auto now_ticks = static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+    const auto thread_hash = static_cast<uint64_t>(std::hash<std::thread::id>{}(std::this_thread::get_id()));
+    std::ostringstream oss;
+    oss << std::hex << now_ticks << "_" << fixture_counter.fetch_add(1) << "_" << thread_hash;
+    return base / ("store_engine_" + test_name + "_" + oss.str());
+  }
+
   std::filesystem::path root_path_;
 };
 

--- a/core/testing/test_helpers.cc
+++ b/core/testing/test_helpers.cc
@@ -6,8 +6,15 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <unordered_set>
 #include <vector>
 
 #include "absl/log/log.h"
@@ -34,34 +41,161 @@ bool verify_pattern(const void* data, std::size_t size, uint8_t seed) {
   return true;
 }
 
-int find_available_port(int base_port, int max_attempts) {
-  for (int attempt = 0; attempt < max_attempts; ++attempt) {
-    int port = base_port + attempt;
+namespace {
 
-    // Try to bind to the port
-    int sock = socket(AF_INET, SOCK_STREAM, 0);
-    if (sock < 0) {
-      LOG(ERROR) << "Failed to create socket";
-      return -1;
+constexpr int kDefaultPortMin = 32768;
+constexpr int kDefaultPortMax = 61000;
+
+struct EphemeralRange {
+  int min_port;
+  int max_port;
+};
+
+EphemeralRange load_ephemeral_range() {
+  std::ifstream range_file("/proc/sys/net/ipv4/ip_local_port_range");
+  if (!range_file.is_open()) {
+    return {kDefaultPortMin, kDefaultPortMax};
+  }
+
+  int min_port = kDefaultPortMin;
+  int max_port = kDefaultPortMax;
+  range_file >> min_port >> max_port;
+  if (min_port <= 0 || max_port <= min_port) {
+    return {kDefaultPortMin, kDefaultPortMax};
+  }
+  return {min_port, max_port};
+}
+
+int try_bind_port(int port) {
+  int sock = socket(AF_INET, SOCK_STREAM, 0);
+  if (sock < 0) {
+    PLOG(ERROR) << "Failed to create socket while probing port";
+    return -1;
+  }
+
+  int optval = 1;
+  if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) != 0) {
+    PLOG(WARNING) << "Failed to set SO_REUSEADDR while probing port";
+  }
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+  addr.sin_port = htons(port);
+
+  if (bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+    if (port == 0) {
+      socklen_t len = sizeof(addr);
+      if (getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &len) == 0) {
+        port = ntohs(addr.sin_port);
+      }
     }
-
-    // Allow reuse of address
-    int optval = 1;
-    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
-
-    struct sockaddr_in addr;
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-    addr.sin_port = htons(port);
-
-    if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) == 0) {
-      // Port is available
-      close(sock);
-      LOG(INFO) << "Found available port: " << port;
-      return port;
-    }
-
     close(sock);
+    return port;
+  }
+
+  close(sock);
+  return -1;
+}
+
+std::vector<int> build_candidate_ports(int base_port, int max_attempts) {
+  EphemeralRange range = load_ephemeral_range();
+  const int range_span = range.max_port - range.min_port + 1;
+  if (range_span <= 0) {
+    return {};
+  }
+
+  thread_local std::mt19937 rng([]() {
+    std::random_device rd;
+    return std::mt19937(rd());
+  }());
+  std::uniform_int_distribution<int> dist(range.min_port, range.max_port);
+
+  auto clamp_to_range = [&](int port) {
+    if (port < range.min_port) {
+      return range.min_port;
+    }
+    if (port > range.max_port) {
+      return range.max_port;
+    }
+    return port;
+  };
+
+  std::unordered_set<int> seen;
+  seen.reserve(static_cast<size_t>(max_attempts) * 2);
+  std::vector<int> candidates;
+  candidates.reserve(max_attempts);
+
+  auto try_add = [&](int port) {
+    if (port < range.min_port || port > range.max_port) {
+      return false;
+    }
+    if (seen.insert(port).second) {
+      candidates.push_back(port);
+      return true;
+    }
+    return false;
+  };
+
+  if (base_port <= 0) {
+    for (int attempt = 0; attempt < max_attempts && static_cast<int>(candidates.size()) < max_attempts; ++attempt) {
+      try_add(dist(rng));
+    }
+  } else {
+    int clamped_base = clamp_to_range(base_port);
+    // Apply a jitter so repeated callers with the same base do not concentrate on a single port.
+    int jitter = std::uniform_int_distribution<int>(-512, 512)(rng);
+    int jittered = clamp_to_range(clamped_base + jitter);
+    try_add(jittered);
+
+    // Expand symmetrically around the jittered base.
+    for (int delta = 1; static_cast<int>(candidates.size()) < max_attempts; ++delta) {
+      bool added = false;
+      if (try_add(jittered + delta)) {
+        added = true;
+      }
+      if (static_cast<int>(candidates.size()) >= max_attempts) {
+        break;
+      }
+      if (try_add(jittered - delta)) {
+        added = true;
+      }
+      if (!added && (jittered + delta > range.max_port && jittered - delta < range.min_port)) {
+        break;
+      }
+    }
+  }
+
+  // If we still do not have enough candidates, mix in random ports to broaden the search window.
+  int safety_budget = range_span * 2;
+  while (static_cast<int>(candidates.size()) < max_attempts && safety_budget-- > 0) {
+    try_add(dist(rng));
+  }
+
+  std::shuffle(candidates.begin(), candidates.end(), rng);
+
+  return candidates;
+}
+
+} // namespace
+
+int find_available_port(int base_port, int max_attempts) {
+  max_attempts = std::max(1, max_attempts);
+  auto candidates = build_candidate_ports(base_port, max_attempts);
+
+  for (int port : candidates) {
+    int bound = try_bind_port(port);
+    if (bound > 0) {
+      LOG(INFO) << "Found available port: " << bound;
+      return bound;
+    }
+  }
+
+  // Fallback: let kernel choose any ephemeral port.
+  int auto_port = try_bind_port(0);
+  if (auto_port > 0) {
+    LOG(INFO) << "Found available ephemeral port via kernel assignment: " << auto_port;
+    return auto_port;
   }
 
   LOG(ERROR) << "Failed to find available port after " << max_attempts << " attempts";
@@ -80,6 +214,7 @@ void configure_tcp_stager_defaults(
   st->set_stage_chunk_mb_gpu(gpu_chunk_mb);
   st->set_stage_chunk_mb_cpu(cpu_chunk_mb);
   st->set_buffers_per_flow(buffers_per_flow);
+  cfg->mutable_transport()->set_so_reuseport(false);
 }
 
 tensorcast::communicator::v1::CommunicatorConfig make_tcp_communicator_config(

--- a/core/testing/test_helpers.h
+++ b/core/testing/test_helpers.h
@@ -18,12 +18,15 @@ std::vector<uint8_t> create_test_pattern(std::size_t size, uint8_t seed);
 // Helper to verify data pattern
 bool verify_pattern(const void* data, std::size_t size, uint8_t seed);
 
-// Helper to find an available port starting from base_port
-// Returns the first available port, or -1 if none found
+// Helper to find an available TCP port. The search randomizes candidate order
+// even when a base_port hint is supplied, expanding into nearby ephemeral
+// ranges to reduce collisions across concurrent tests. Returns the first
+// available port, or -1 if none found.
 int find_available_port(int base_port = 50000, int max_attempts = 1000);
 
 // Configure TCP communicator staging defaults for tests. Ensures the GPU/CPU
-// stagers and buffer pipeline satisfy Communicator constructor invariants.
+// stagers and buffer pipeline satisfy Communicator constructor invariants and
+// forces TCP listeners to disable SO_REUSEPORT for deterministic binding.
 void configure_tcp_stager_defaults(
     tensorcast::communicator::v1::CommunicatorConfig* cfg,
     uint32_t gpu_chunk_mb = 16,

--- a/docs/designs/0005-async-copy-manager.md
+++ b/docs/designs/0005-async-copy-manager.md
@@ -40,21 +40,29 @@ struct DeviceRegion { int device_id; void* dev_ptr; size_t length; };struct Copy
  public:
   static AsyncCopyManager& instance();  // Each submit wraps exactly one cudaMemcpyAsync on ACM’s internal stream
   // and attaches a lightweight host callback to finalize resources/state.
-  absl::StatusOr<CopyHandle> submit_h2d(const HostRegion& src,
-                                        const DeviceRegion& dst,
-                                        const CopyOptions& opts = {});  absl::StatusOr<CopyHandle> submit_d2h(const DeviceRegion& src,
-                                        const HostRegion& dst,
-                                        const CopyOptions& opts = {});  absl::StatusOr<CopyHandle> submit_d2d(const DeviceRegion& src,
-                                        const DeviceRegion& dst,
-                                        const CopyOptions& opts = {});  // H2H path is synchronous memcpy with immediate handle completion to
-  // exercise pipeline logic in environments without CUDA.
-  absl::StatusOr<CopyHandle> submit_h2h(const HostRegion& src,
-                                        const HostRegion& dst,
-                                        const CopyOptions& opts = {});  void shutdown();
+  absl::StatusOr<CopyHandle> submit_h2d(
+      const HostRegion& src,
+      const DeviceRegion& dst,
+      const CopyOptions& opts = {});
+  absl::StatusOr<CopyHandle> submit_d2h(
+      const DeviceRegion& src,
+      const HostRegion& dst,
+      const CopyOptions& opts = {});
+  absl::StatusOr<CopyHandle> submit_d2d(
+      const DeviceRegion& src,
+      const DeviceRegion& dst,
+      const CopyOptions& opts = {});  // H2H path enqueues its memcpy on the ACM callback worker so the handle
+  // completes asynchronously, mirroring other directions for CPU-only tests.
+  absl::StatusOr<CopyHandle> submit_h2h(
+      const HostRegion& src,
+      const HostRegion& dst,
+      const CopyOptions& opts = {});
+  void shutdown();
 };} // namespace tensorcast::common
 ```Submission semantics
 - Exactly one device copy per call; chunking is handled by planners before submission.
 - The host callback is attached via `cudaLaunchHostFunc` and is intentionally lightweight: return SPB slots, notify UMA/VS chunk completion, enqueue follow-on work. To comply with CUDA's restriction on host callbacks, it performs no CUDA runtime calls and simply records completion metadata. If `cudaLaunchHostFunc` is unavailable (older drivers, restricted runtimes), ACM falls back to a detached thread that `cudaStreamSynchronize`s before firing the callback, ensuring data is resident before slots recycle. Runtime errors surface through `CopyHandle::wait()`; submission-time errors surface via `StatusOr`.
+- Pure host (`submit_h2h`) copies are executed on the ACM callback worker so they honor the same asynchronous completion semantics (copy, status resolution, and callbacks) used for CUDA-backed directions.
 - Callbacks receive an `absl::Status` describing the stream completion result; `CopyHandle::wait()` (or `ok()`) runs the CUDA runtime checks (`cudaSetDevice`, `cudaGetLastError`) on the caller thread before returning, so asynchronous failures still surface even when host callbacks execute on restricted threads.
 - FAKE CUDA backend enqueues copies on a lightweight worker thread and fires callbacks asynchronously to mirror stream ordering while still running entirely on CPU memory. This keeps staging credit and slot recycling behaviour aligned with the real runtime.
 

--- a/docs/designs/0013-unified-staging-flow-control.md
+++ b/docs/designs/0013-unified-staging-flow-control.md
@@ -144,6 +144,7 @@ sequenceDiagram
   ```
 - `StreamingPinnedBuffer::try_get_free_chunk()` is used when `StageMode::kTry` to avoid blocking the staging loop. If no buffer is available, the window parks until a lease returns.
 - `MemoryStager::stage()` gains an overload accepting `StageMode`; existing callers continue to pass `StageMode::kBlocking`, while implementations add a non-blocking fast path for `StageMode::kTry`.
+- `StreamingPinnedBuffer` tracks an explicit slot lifecycle (`Free → ProducerOwned → Ready → ConsumerOwned`) and rejects out-of-order transitions. This guards against premature slot recycling if async completions lag. The regression test `//core/common:streaming_pinned_buffer_test` exercises those invariants so pump/transport regressions surface quickly.
 
 ### ACK / Completion Handling
 

--- a/proto/tensorcast/communicator/v1/communicator_config.proto
+++ b/proto/tensorcast/communicator/v1/communicator_config.proto
@@ -32,6 +32,7 @@ message TransportConfig {
   int32 tcp_conn_count = 1; // default: 8
   int32 tcp_tos = 2; // default: 0 (no change)
   int32 connect_timeout_sec = 3; // default: 10
+  optional bool so_reuseport = 4; // default: true (Communicator treats unset as true)
 }
 
 message AffinityConfig {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> AsyncCopyManager now delivers absl::Status to on_copy_done via a dedicated CPU worker, and all callers (pump, sinks, transport, checkpoint, replica helpers) are updated to use statusful callbacks with improved error handling and optional debug verification.
> 
> - **Async Copy Manager**:
>   - Introduces CPU worker thread/queue to run `on_copy_done` outside CUDA host callbacks; adds graceful shutdown.
>   - Changes `CopyCallbacks::on_copy_done` to `std::function<void(absl::Status)>`; passes completion status for H2D/D2D/D2H/H2H.
>   - Minor API/docs: notes on avoiding CUDA calls in host callbacks; stream helpers unchanged.
> - **Callers Updated**:
>   - **Pump/AsyncPositionedSink**: new `AsyncWriteOptions` with optional `CopyOptions`; return pool slots in statusful callbacks; improved error propagation and logging.
>   - **GpuMemorySink**: `write_at_async` accepts `AsyncWriteOptions`; integrates per-GPU scheduling release in callback; optional head/tail verification when `TENSORCAST_DEBUG_GPU_COPY` is set.
>   - **MTCP transport**: H2D completion now logs errors and returns SPB slots in statusful callbacks.
>   - **Replica transfer helpers**: H2D/D2H callbacks now handle status; D2H writes to VS only on success.
>   - **Streaming tensor writer**: D2H completion callback now handles status and chunk return on error.
> - **Verification/Logging**:
>   - Artifact verification logs detailed segment mismatch diagnostics with sampled head/tail bytes.
> - **Docs/Comments**:
>   - Store README and trace/cuda headers updated to reflect statusful callbacks and callback-threading behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4989ce05edf9efb5422f984bed2d372e12b82e82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->