### PR TITLE
refactor(api): modernize TensorCast API with Store session management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,7 +349,7 @@ if (fd < 0) {
 - Keep functions small and focused
 - Use explicit, named imports for utilities
 - Use `dataclasses` or Pydantic models for complex data structures
-- Use absolute imports for in-repo modules: `from tensorcast.xxx.yyy import Z`; avoid relative imports like `from .xxx import Z`
+- Binding: Use absolute imports for all in-repo modules: `from tensorcast.xxx.yyy import Z`. NEVER use relative imports (`from .xxx import Z`, `from ..yyy import Z`).
 
 
 ### Commenting & Self-Documentation

--- a/README.md
+++ b/README.md
@@ -142,32 +142,32 @@ ctx = init(address="local", daemon_config_path="examples/config/store_daemon_con
 ctx = init(address="127.0.0.1:50052")
 
 # Context is process-scoped and is automatically closed at process exit (atexit).
-# Call tensorcast.startup.shutdown() to close early if needed.
+# Call tensorcast.shutdown() to close early if needed.
 ```
 
-Call `tensorcast.init(...)` once per process before constructing client sessions. The preferred
-entry point for artifact registration and loading is the `Store` session API:
+Call `tensorcast.init(...)` once per process before interacting with the daemon. The user-facing
+API is intentionally lightweight—operate through the top-level helpers and let TensorCast manage
+the session state for you:
 
 ```python
-from tensorcast.api import FallbackOptions, Store
+import tensorcast as tc
+import torch
 
-# Derive the daemon endpoint from init() or supply one explicitly.
-store = Store("127.0.0.1:50052")
+tc.init(address="auto")
 
-# Register tensors without copying when they already live on the requested device.
-registered = store.register(state_dict, key="demo:model:001")
+state_dict = {"layer.weight": torch.randn(8, 8, device="cuda")}
 
-# Materialise tensors by key or artifact id. Fallback policies can be expressed declaratively.
-state = store.get(key="demo:model:001", fallback=FallbackOptions(prefer_disk=True))
+registered = tc.register(state_dict, key="demo:model:001")
+latest = tc.get(key="demo:model:001", device="cuda:0")
 
-# In-place materialisation fills user-provided tensors directly.
-store.get_into(target_buffers, artifact_id=registered.artifact_id)
+buffers = {"layer.weight": torch.empty_like(state_dict["layer.weight"])}
+tc.get_into(buffers, artifact_id=registered.artifact_id, device="cuda:0")
 ```
 
-Legacy module-level helpers (`register_artifact`, `get_artifact_sync`, `get_artifact_async`, …)
-have been removed now that the Store session API is fully rolled out. All client integrations
-must instantiate `Store` directly to access registration and retrieval verbs along with
-observability hooks (OpenTelemetry spans + `tc_store_*` metrics).
+For advanced scenarios (async verbs, fine-grained inspection, or direct access to diagnostics) use
+`tc.store()` to obtain the underlying `Store` session object. That object exposes the complete
+surface described in [docs/designs/0014-store-session-api-modernization.md](docs/designs/0014-store-session-api-modernization.md),
+including async futures, retry telemetry, and session metadata.
 
 Notes on signals and cleanup:
 - The SDK does not override your process SIGINT/SIGTERM by default. Child processes are still cleaned up reliably via Linux PDEATHSIG when the parent really exits.

--- a/core/checkpoint/docs/verification-integration.md
+++ b/core/checkpoint/docs/verification-integration.md
@@ -57,7 +57,7 @@ with open(verification_path, "w") as f:
 - Support multi-partition file format (`tensor.data_0`, `tensor.data_1`, ...)
 - Save verification information to `verification.json`
 
-### 2. Replica Loading Phase (`tensorcast/api/_loader.py`)
+### 2. Replica Loading Phase (`tensorcast/api/services/materialize.py` + `Store.load_dict_*`)
 
 ```python
 # In load_dict_non_blocking function

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -68,7 +68,7 @@ graph TD
 ### 3. User Process Worker
 **Role**: PyTorch client process accessing artifacts
 
-- **Interface**: Uses `tensorcast.api.Store` verbs (`get`, `get_into`) to request artifacts via daemon `MaterializeByKey` (RFC‑0017).
+- **Interface**: Uses the functional facade (`tensorcast.get`, `tensorcast.get_into`) backed by the shared Store to request artifacts via daemon `MaterializeByKey` (RFC‑0017).
 - **Memory Access**: Maps CUDA IPC handles for zero‑copy GPU access; falls back to RAM/DISK as needed
 - **Lifecycle**: Confirms, references, and unloads replicas via daemon RPCs
 

--- a/docs/designs/0003-unified-memory-registration-avbs-lip.md
+++ b/docs/designs/0003-unified-memory-registration-avbs-lip.md
@@ -73,7 +73,7 @@ Behavioral notes
 - Runs Begin → Feed (for Lease) → optional KeepAlive → Commit.
 - vram_coalesced: Daemon allocates coalesced VRAM; client writes via IPC; Commit registers COALESCED_VRAM.
 - vram_leased: Currently only `lease_in_place=True` (LIP) is implemented and registered at Commit (ephemeral, TTL/KeepAlive). The `lease_in_place=False` (materialize to COALESCED_VRAM at Commit) variant is not implemented in this release.
-- API users must call `tensorcast.startup.init()` before invoking `register_artifact`; the helper reuses the singleton daemon client established during initialization.
+- API users must call `tensorcast.init()` before invoking registration helpers; the runtime reuses the singleton daemon client established during initialization.
 
 ## Control Plane RPCs (Unified)
 

--- a/docs/designs/0014-store-session-api-modernization.md
+++ b/docs/designs/0014-store-session-api-modernization.md
@@ -11,6 +11,8 @@ related_code: ["tensorcast/api", "tensorcast/global_store", "daemon", "core/stor
 
 We evolve the TensorCast client API from a monolithic `register_artifact()` function into an explicit Store session object that owns the daemon connection and surfaces four verbs: `register`, `put`, `get`, and `get_into`. The first release keeps the public surface minimal: the `Store` constructor requires the daemon endpoint (`tcp://ip:port` or `unix://` socket) plus an optional `StoreOptions` bundle, and each verb exposes a concise signature with optional key-based addressing. All lease duration, keepalive cadence, caching, and device selection policies are centrally managed by the Store using repository defaults so that users do not supply per-call tuning parameters, while retrieval verbs can describe disk and P2P fallback behavior explicitly when VRAM replicas are unavailable.
 
+The shipping SDK exposes these capabilities through functional module-level helpers (`tensorcast.init`, `tensorcast.register`, `tensorcast.put`, `tensorcast.get`, `tensorcast.get_into`). Those helpers delegate to a single process-wide Store instance managed by the runtime; the Store remains an internal session holder that advanced users may access via `tensorcast.store()` for asynchronous verbs or diagnostics, but typical workflows never construct it directly.
+
 The API provides paired synchronous and asynchronous methods (e.g., `register` / `register_async`) backed by the same future infrastructure introduced in Design 0005, avoiding flag-based mode switches and improving type safety. The design reuses the AVBS/Canonical Index/lease semantics from Design 0003 while giving the SDK a clearer ownership boundary over daemon sessions and replica coordination.
 
 # Goals / Non-Goals
@@ -31,6 +33,21 @@ Non-Goals
 - Modeling Fake-CUDA specific behaviors; the fallback design assumes production CUDA hardware.
 
 # Architecture & Interfaces
+
+## Public facade
+
+```python
+import tensorcast as tc
+
+tc.init(address="auto")
+artifact = tc.register(tensors=model_state_dict, key="model/latest")
+latest = tc.get(key="model/latest", device="cuda:0")
+tc.get_into(buffers, artifact_id=artifact.artifact_id, device="cuda:0")
+```
+
+- `tc.init(...)` establishes the daemon session and creates the shared Store.
+- `tc.register`, `tc.put`, `tc.get`, and `tc.get_into` are thin wrappers that route to the Store while keeping the API surface functional and stateless for callers.
+- `tc.store()` exposes the underlying Store when advanced integrations need asynchronous verbs, telemetry, or direct lease management; routine code should not instantiate `Store` manually.
 
 ## Type aliases and helper classes
 
@@ -183,6 +200,8 @@ Responsibilities
 - `retry_overrides`: mapping from method name (`"register"`, `"get"`, etc.) to `RetryPolicy` to adjust deadlines/backoff without rewriting the built-in policy tables.
 
 The first-version Store treats all local CUDA devices as in-scope; explicit device scoping is deferred. When new GPUs appear, the Store refreshes device metadata lazily on demand.
+
+While the Store remains the canonical implementation of the session API, production callers acquire the shared instance through `tensorcast.init()` / `tensorcast.store()` rather than constructing it directly.
 
 ## Register (by-reference registration)
 
@@ -374,28 +393,22 @@ Default deadlines and SDK-managed retries:
 ## Usage example
 
 ```python
-store = Store(
-    daemon_endpoint="unix:///var/run/tensorcastd.sock",
-    opts=StoreOptions(
-        fallback=FallbackOptions(
-            disk_path="/var/lib/tensorcast/artifacts",
-            prefer_disk=False,
-        ),
-    ),
-)
+import tensorcast as tc
 
-registered = store.register(tensors=model_state_dict, key="model/latest")
+tc.init(address="auto")
+artifact = tc.register(tensors=model_state_dict, key="model/latest")
+restored = tc.get(key="model/latest", device="cuda:0")
+tc.get_into(buffers, artifact_id=artifact.artifact_id, device="cuda:1")
 
-future = store.get_async(artifact_id=registered.artifact_id, device="cuda:1")
+# Advanced: access async verbs through the shared Store when needed.
+store = tc.store()
+future = store.get_async(artifact_id=artifact.artifact_id, device="cuda:1")
 next_state = future.result()
-
-# Bypass P2P and force disk-backed materialization for a single request.
-disk_only = store.get(
-    key="model/snapshot-100",
-    device="cuda:0",
-    fallback=FallbackOptions(disk_path="/mnt/fast-cache", prefer_disk=True, allow_p2p=False),
-)
 ```
+
+These helpers reuse the single process-wide Store instance created by `tc.init()`. Advanced callers
+can drop down to `tc.store()` for asynchronous operations, telemetry, or fine-grained lease control,
+but the public contract exposed to applications is the functional interface shown above.
 
 ## Key mapping cache
 
@@ -452,7 +465,7 @@ Error semantics
 # Compatibility & Acceptance Criteria
 
 Compatibility
-- Module-level helpers such as `register_artifact`, `get_artifact_sync`, and `get_artifact_async` have been removed; the session-oriented Store API is the sole public entry point.
+- Module-level helpers such as `register_artifact`, `get_artifact_sync`, and `get_artifact_async` have been removed. The supported public surface is the functional facade (`tensorcast.init/register/put/get/get_into`), which delegates to the shared Store. Direct `Store` construction remains available for advanced scenarios but is no longer required.
 - No daemon or Global Store RPC changes are required; wire compatibility is preserved.
 
 Acceptance Criteria
@@ -466,7 +479,7 @@ Acceptance Criteria
 This roadmap executes the modernization incrementally while holding current production contracts.
 
 ## Phase 0 – Baseline & Contract Verification
-- Inventory public entry points in `tensorcast/api/__init__.py`, `_register.py`, `_loader.py`, examples, and docs to freeze current behavior and doc-sync surfaces.
+- Inventory public entry points in `tensorcast/api/__init__.py`, `_register.py`, `_runtime.py`, `_load_engine.py`, `_loader.py`, `_materialize.py`, examples, and docs to freeze current behavior and doc-sync surfaces.
 - Add short-lived structured tracing around `register_artifact`, `get_artifact_sync`, and `get_artifact_async` paths to capture daemon/global-store RPC envelopes and lease keepalive cadence.
 - Capture parity fixtures from `tests/python/test_register_vram_leased_and_dvmp_stream.py` and `tests/python/test_register_lease_in_place_helper.py` to guard against accidental regression during refactors.
 - Align stakeholders (SDK, daemon, global_store) on sequencing, publish the migration schedule, and verify no pending protocol changes compete with this work.
@@ -490,8 +503,8 @@ This roadmap executes the modernization incrementally while holding current prod
 - Add cache of key→artifact-id resolutions inside the Store using TTL hints from the Global Store to minimize redundant RPCs.
 
 ## Phase 4 – Observability, Documentation, and Migration Support
-- Finalize removal of module-level helpers (`register_artifact`, `get_artifact_sync`, `get_artifact_async`) so that the Store object is the only public entry point; keep `load_dict_*` utilities for disk-path workflows.
-- Update `README.md`, `docs/internals/model-loading.md`, `docs/internals/save_dict_flow.md`, and relevant examples to highlight the session-first usage pattern and describe migration steps.
+- Finalize removal of legacy helpers (`register_artifact`, `get_artifact_sync`, `get_artifact_async`) and surface the functional facade (`tensorcast.register`, etc.) backed by the shared Store; keep `load_dict_*` utilities for disk-path workflows.
+- Update `README.md`, `docs/internals/model-loading.md`, `docs/internals/save_dict_flow.md`, and relevant examples to highlight the functional entry points while documenting how to obtain the `Store` for advanced scenarios.
 - Expand SDK metrics/OTEL exporters to report Store verb latency, retry counts, cancellation, and fallback decisions; ensure dashboards in `docs/architecture/architecture-overview.md` reflect the new signals.
 - Remove temporary tracing added in Phase 0 once dashboards confirm parity, keeping only steady-state telemetry.
 

--- a/docs/internals/model-loading.md
+++ b/docs/internals/model-loading.md
@@ -11,7 +11,7 @@ This diagram shows the complete artifact loading workflow in TensorCast, includi
 ## System Components
 
 - **InferenceInstance**: Python + CXX EXT
-- Entrypoint: `tensorcast/api/store.py::Store.get` / `Store.get_into`
+- Entrypoint: `tensorcast.get` / `tensorcast.get_into` (facade over the process Store)
   - CLI class: `client.py::DaemonCtl`
   - CXX: `checkpoint_py.cc`
 
@@ -26,11 +26,10 @@ This diagram shows the complete artifact loading workflow in TensorCast, includi
 
 ## Runtime Initialization
 
-All client processes must call `tensorcast.startup.init(...)` before constructing Store sessions.
-Initialization pins a daemon endpoint that the `tensorcast.api.Store` object reuses when opening its
-gRPC channel pool. The Store owns retry policy, lease keepalive, and fallback orchestration for the
-process. Legacy module-level helpers still work, but they create a hidden Store internally and emit
-deprecation warnings.
+All client processes call `tensorcast.init(...)` to establish the daemon session. Initialization pins
+the daemon endpoint and constructs the shared Store used by the module-level helpers. The Store owns
+retry policy, lease keepalive, and fallback orchestration for the process. Advanced integrations can
+access it via `tensorcast.store()`, but day-to-day usage goes through the functional helpers.
 
 ## Artifact Loading Sequence
 
@@ -117,24 +116,24 @@ with begin_register_artifact_sdk(..., ttl_ms=5000) as handle:
 - Commit returns RFC-0007 content-addressed descriptor (artifact_id = mi2:index_multihash:data_multihash).
 - Same-machine consumers always materialize to daemon-owned coalesced VRAM (CUDA IPC) for zero-copy use.
 
-### Store Session Helpers
+### Client Facade & Store helpers
 
-- `Store.register(...)` (lease-in-place) and `Store.put(...)` (daemon-owned coalesced VRAM) return
-  a `RegisteredArtifact` describing the canonical index, replica metadata, and lease handle when
-  applicable. Both methods accept synchronous and asynchronous variants (e.g., `register_async`).
-- `Store.get(...)` returns a materialised `dict[str, torch.Tensor]` by artifact id or key with
-  retry-aware fallback handling. `Store.get_async(...)` exposes an `ArtifactFuture` that supports
-  `result()`, cancellation, and completion callbacks.
-- `Store.get_into(...)` populates caller-provided tensors in-place. The Store validates shapes,
+- `tensorcast.register(...)` (lease-in-place) and `tensorcast.put(...)` (daemon-owned coalesced VRAM)
+  return a `RegisteredArtifact` describing the canonical index, replica metadata, and lease handle
+  when applicable. Both functions call into the shared Store and offer async variants via
+  `tensorcast.store().register_async(...)`.
+- `tensorcast.get(...)` returns a materialised `dict[str, torch.Tensor]` by artifact id or key with
+  retry-aware fallback handling. `tensorcast.store().get_async(...)` exposes an `ArtifactFuture`
+  that supports `result()`, cancellation, and completion callbacks.
+- `tensorcast.get_into(...)` populates caller-provided tensors in-place. The Store validates shapes,
   strides, and device placement before mutating buffers, zero-fills PAD segments to keep tensors
   consistent on failure or cancellation, and unloads any daemon-backed VRAM replica as soon as the
-  copy (or validation error) completes. The asynchronous variant mirrors this behaviour so temporary
-  replicas never linger beyond the transfer lifecycle.
+  copy (or validation error) completes. Asynchronous flows are available via `tensorcast.store()`.
 - `StoreOptions` and per-call `FallbackOptions` express disk/P2P strategies without sprinkling
   policy flags across call sites.
 - Low-level workflows remain available via
   `tensorcast.api.begin_register_artifact_sdk(...)` for scenarios that need explicit control over
-  lease feeding, although most integrations should rely on `Store.register_async` and its
+  lease feeding, although most integrations should rely on the functional facade and the Store’s
   cancellation hooks.
 
 ### Python SDK Updates
@@ -144,10 +143,9 @@ with begin_register_artifact_sdk(..., ttl_ms=5000) as handle:
   - `PlanType.VRAM_LEASED` (aliases: `"lease"`)
 - `RegisterArtifactOptions` is now a frozen dataclass with slots for immutability.
 - Loading helpers with fixed return types now forward to the Store session:
-  - Synchronous: `Store.get(...) -> dict[str, torch.Tensor]`
-  - Asynchronous: `Store.get_async(...) -> ArtifactFuture[dict[str, torch.Tensor]]`
-  - Legacy shims (`load_dict_sync`, `get_artifact_sync`, etc.) call into a cached Store and should be
-    considered transitional.
+  - Synchronous: `tensorcast.get(...) -> dict[str, torch.Tensor]`
+  - Asynchronous: `tensorcast.store().get_async(...) -> ArtifactFuture[dict[str, torch.Tensor]]`
+  - Utilities (`load_dict_sync`, etc.) call into the shared Store for compatibility.
 - `ArtifactFuture.done() / result(timeout) / cancel()` mirror the standard `concurrent.futures`
   contract. Cancellation propagates to daemon RPCs (`AbortRegisteredArtifact`, `RevokeRegisteredArtifact`)
   and records telemetry for observability.
@@ -164,48 +162,11 @@ with begin_register_artifact_sdk(..., ttl_ms=5000) as handle:
 - Idempotent success on duplicates: if the same `mi2:` artifact already has a replica on the same device, the daemon reclaims the new allocation and returns `OK` with the existing descriptor plus `existed=true`.
 - Join/Lease semantics for duplicates: when `existed=true`, the daemon also joins a lightweight reference for the caller’s PID. If a TTL was provided at `BeginRegisterArtifact`, `KeepAliveRegisterArtifact` can extend the TTL, and the unified `SessionLifecycleTask` drops the joined reference when the TTL expires. This mirrors the lifecycle of a self-created replica.
 
-### SDK Module Layout
-
-The SDK is organized under `tensorcast/api`. New internal modules:
-
-- `tensorcast/api/_config.py` — constants, PlanType, options, global addresses
-- `tensorcast/api/_errors.py` — custom exceptions
-- `tensorcast/api/_otel.py` — observability helpers
-- `tensorcast/api/_device.py` — device resolution and UUID mapping
-- `tensorcast/api/_indices.py` — index build/parse helpers
-- `tensorcast/api/_io_disk.py` — disk save/load helpers
-- `tensorcast/api/_loader.py` — Loader strategy and LoadHandle
-- `tensorcast/api/_register.py` — RegisteredArtifact + plan registrars
-
-Public entry points are exported from `tensorcast/api/__init__.py` and should be imported via `tensorcast.api`.
-
-The Store session API consolidates retrieval verbs (`Store.get`, `Store.get_into`) so callers can express
-fallback policies declaratively. When `FallbackOptions.prefer_disk` is set—or when only disk access is
-permitted (`allow_p2p=False`)—the Store validates the on-disk canonical index before materializing tensors
-and emits telemetry indicating whether the request was served from disk or via the daemon’s P2P path.
-These disk fallbacks reuse the existing `_io_disk` helpers to avoid duplicating validation logic.
 
 ### Client Reuse & Resiliency
 
-- The Python SDK establishes a single gRPC client per process during `tensorcast.startup.init()` and
-  subsequent API calls access it through `tensorcast.startup.current_client()`. This guarantees that
-  all helpers interact with the same daemon session and prevents accidental cross-daemon usage.
+- The Python SDK establishes a single gRPC client per process during `tensorcast.init()`; all
+  subsequent API calls reuse the same Store session obtained via `tensorcast.store()`. This ensures
+  every helper targets the same daemon endpoint and prevents accidental cross-daemon usage.
 - The underlying client enables gRPC keepalive and performs a light retry with channel refresh on transient errors (`UNAVAILABLE`, `INTERNAL`, `UNKNOWN`, `DEADLINE_EXCEEDED`).
 - In registration flows, `RegisteredArtifact` holds a cached client for its lifetime (keepalive thread, commit/abort/revoke, and feed helpers reuse the same channel).
-
-### Migration Notes
-
-- Module-level helpers such as `register_artifact`, `get_artifact_sync`, and `get_artifact_async`
-  have been removed. All registration and retrieval flows must use a `Store` instance directly.
-- Alignment guidance for existing codebases:
-  - `register_artifact(state_dict, options=...)` → `Store.register(state_dict, options=...)`
-  - `register_artifact(..., plan="vram_coalesced")` → `Store.put(...)`
-  - `get_artifact_sync(key=..., device_id=...)` → `Store.get(key=..., device=...)`
-  - `get_artifact_async(...)` → `Store.get_async(...)`
-- Observability lives on the Store verbs. Attach tracing or metrics around `Store.register`/
-  `Store.get` instead of the removed helpers to benefit from OpenTelemetry span fields and
-  `tc_store_*` counters.
-- The Store constructor accepts the same daemon endpoints as `tensorcast.startup.init()` (e.g.,
-  `"127.0.0.1:50052"`, `"unix:///tmp/tensorcastd.sock"`). Code that previously relied on global
-  state should accept a `Store` instance explicitly or construct one using the daemon address that
-  `tensorcast.startup.init()` exposes.

--- a/docs/internals/save_dict_flow.md
+++ b/docs/internals/save_dict_flow.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 
 This document explains how **tensorcast** persists a PyTorch `state_dict` using the Python helper
 `save_dict` and the underlying C++ Checkpoint subsystem. Registration into the distributed Store is
-handled by the session API (`Store.put` / `Store.register`); `save_dict` remains the path for
+handled by the session API (surfaced as `tensorcast.put` / `tensorcast.register`); `save_dict` remains the path for
 materialising disk checkpoints that the Store can subsequently ingest when disk fallback is
 requested.
 

--- a/docs/plans/0014-store-session-api-modernization.md
+++ b/docs/plans/0014-store-session-api-modernization.md
@@ -11,7 +11,7 @@ Deliver the Store-centric artifact session API described in Design 0014: ship a 
 
 # Draft Execution Insights
 
-- Existing helpers in `tensorcast/api/_register.py` and `_loader.py` already implement most daemon/Global Store flows but assume a singleton runtime context (`startup.require_initialized()`). We can refactor these flows into composable primitives consumed by the new `Store` without rewriting RPC wiring.
+- Existing helpers in `tensorcast/api/_register.py` and `_loader.py` already implement most daemon/Global Store flows but now reuse the process-scoped Store (`tensorcast.store()`). We can refactor these flows into composable primitives consumed by the new `Store` without rewriting RPC wiring.
 - Asynchronous paths (`get_artifact_async`, `load_dict_async`) currently return bespoke `LoadHandle` objects. Converging on a shared `ArtifactFuture` backed by `concurrent.futures.Future` simplifies cancellation semantics but requires a lightweight executor scoped per `Store`.
 - Lease keepalive threads in `RegisteredArtifact` / `RegisteredLease` rely on ad hoc threading; encapsulating them inside the Store with lifecycle hooks avoids per-call duplication and lets us guarantee clean cancellation on future completion.
 - Global Store lookups (canonical index fetch) currently deserialize JSON; we can reuse that logic but cache results inside the Store using a TTL keyed by artifact id to minimize repeated RPCs.

--- a/examples/get_artifact_by_key.py
+++ b/examples/get_artifact_by_key.py
@@ -2,18 +2,17 @@
 
 import torch
 
-from tensorcast import startup
-from tensorcast.api import FallbackOptions, Store
+import tensorcast as tc
+from tensorcast import FallbackOptions
 
 
 def main() -> None:
-    ctx = startup.init()
-    store = Store(ctx.address)
+    tc.init(address="127.0.0.1:50052")
 
     # Prefer daemon MaterializeByKey path (no client-side disk fallback)
     fallback = FallbackOptions(prefer_disk=False, allow_p2p=True)
     device = "cuda:0" if torch.cuda.is_available() else "cpu"
-    state_dict = store.get(key="demo:model:001", device=device, fallback=fallback)
+    state_dict = tc.get(key="demo:model:001", device=device, fallback=fallback)
 
     total_params = sum(int(t.numel()) for t in state_dict.values())
     print("Loaded params:", total_params)

--- a/examples/register_artifact.py
+++ b/examples/register_artifact.py
@@ -5,12 +5,10 @@ import gc
 import torch
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 
-from tensorcast import init
-from tensorcast.api import Store
+import tensorcast as tc
 from tensorcast.testing.dict import assert_state_dict_equal
-from tensorcast.types import ArtifactDescriptor
 
-ctx = init(address="127.0.0.1:50052")
+tc.init(address="127.0.0.1:50052")
 
 hf_model_name = "Qwen/Qwen3-0.6B"
 # Load a artifact from HuggingFace artifact hub.
@@ -20,14 +18,8 @@ artifact = AutoModelForCausalLM.from_pretrained(
 
 state_dict = artifact.state_dict()
 
-# Create a Store session scoped to this process
-store = Store(ctx.address)
-
-device_arg = "cuda:0" if torch.cuda.is_available() else None
-registered = store.put(state_dict, device=device_arg)
+registered = tc.put(state_dict, device=0)
 saved_dict = registered.state_dict
-commit_info = registered.registration_result.descriptor
-assert isinstance(commit_info, ArtifactDescriptor)
 assert saved_dict is not None
 
 # Validate equality between the original and registered dicts

--- a/examples/register_artifact_with_key.py
+++ b/examples/register_artifact_with_key.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import torch
 
 import tensorcast as tc
-from tensorcast import RegisterArtifactOptions
+from tensorcast import PlanType, RegisterArtifactOptions
 
 
 def main() -> None:
@@ -23,7 +23,7 @@ def main() -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     opts = RegisterArtifactOptions(
-        plan="vram_coalesced",
+        plan=PlanType.VRAM_COALESCED,
         disk_path=str(out_dir),  # validate/record disk source
     )
     registered = tc.put(

--- a/examples/register_artifact_with_key.py
+++ b/examples/register_artifact_with_key.py
@@ -4,15 +4,13 @@ from pathlib import Path
 
 import torch
 
-from tensorcast import startup
-from tensorcast.api import Store
-from tensorcast.api._config import RegisterArtifactOptions
+import tensorcast as tc
+from tensorcast import RegisterArtifactOptions
 
 
 def main() -> None:
-    # Connect to the Store Daemon (assumes tensorcast.startup.init() env/config)
-    ctx = startup.init()
-    store = Store(ctx.address)
+    # Connect to the Store Daemon
+    tc.init(address="127.0.0.1:50052")
 
     # Create a tiny dummy state_dict
     state_dict: dict[str, torch.Tensor] = {
@@ -28,15 +26,13 @@ def main() -> None:
         plan="vram_coalesced",
         disk_path=str(out_dir),  # validate/record disk source
     )
-    device_arg = "cuda:0" if torch.cuda.is_available() else None
-    registered = store.put(
+    registered = tc.put(
         state_dict,
         key="demo:model:001",
         options=opts,
-        device=device_arg,
+        device=0,
     )
-    desc = registered.registration_result.descriptor
-    print("Committed artifact_id:", desc.artifact_id)
+    print("Committed artifact_id:", registered.artifact_id)
 
 
 if __name__ == "__main__":

--- a/examples/test_get.py
+++ b/examples/test_get.py
@@ -1,0 +1,11 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+import torch
+
+import tensorcast as tc
+
+tc.init(address="127.0.0.1:50052")
+
+device = "cuda:0" if torch.cuda.is_available() else "cpu"
+state_dict = tc.get(key="test:model:001", device=device)
+print(state_dict)

--- a/examples/test_register.py
+++ b/examples/test_register.py
@@ -1,0 +1,44 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+import time
+
+import torch
+from transformers.models.auto.modeling_auto import AutoModelForCausalLM
+
+import tensorcast as tc
+from tensorcast import RegisterArtifactOptions
+from tensorcast.testing.dict import assert_state_dict_equal
+
+hf_model_name = "Qwen/Qwen3-0.6B"
+
+model = AutoModelForCausalLM.from_pretrained(
+    hf_model_name,
+    torch_dtype=torch.bfloat16,
+    trust_remote_code=True,
+    device_map="cuda:0",
+)
+
+# Print every tensor size
+# for name, param in artifact.state_dict().items():
+#     MB = 1024 * 1024
+#     if param.numel() * param.dtype.itemsize > 1 * MB:
+#         continue
+#     print(f"{name}: {param.numel()}, {param.dtype}")
+
+# print("=" * 100)
+
+state_dict = model.state_dict()
+
+tc.init(address="127.0.0.1:50052")
+opts = RegisterArtifactOptions(plan="vram_coalesced", key="test:model:001")
+res = tc.register(state_dict, options=opts)
+saved_dict = res.state_dict
+assert saved_dict is not None
+
+# Validate equality between the original and registered dicts
+assert_state_dict_equal(state_dict, saved_dict)
+print("All tensors match ✅")
+
+
+while True:
+    time.sleep(1)

--- a/examples/test_register.py
+++ b/examples/test_register.py
@@ -6,7 +6,7 @@ import torch
 from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 
 import tensorcast as tc
-from tensorcast import RegisterArtifactOptions
+from tensorcast import PlanType, RegisterArtifactOptions
 from tensorcast.testing.dict import assert_state_dict_equal
 
 hf_model_name = "Qwen/Qwen3-0.6B"
@@ -30,7 +30,7 @@ model = AutoModelForCausalLM.from_pretrained(
 state_dict = model.state_dict()
 
 tc.init(address="127.0.0.1:50052")
-opts = RegisterArtifactOptions(plan="vram_coalesced", key="test:model:001")
+opts = RegisterArtifactOptions(plan=PlanType.VRAM_COALESCED, key="test:model:001")
 res = tc.register(state_dict, options=opts)
 saved_dict = res.state_dict
 assert saved_dict is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ select = [
     "F",
     "SIM1",
     "W",
+    "TID252",
     # Not included in flake8
     "PERF",
     "PLE",

--- a/tensorcast/__init__.py
+++ b/tensorcast/__init__.py
@@ -94,17 +94,53 @@ _install_c_extension_bootstrap()
 # -----------------------------------------------------------------------------
 
 from tensorcast._version import __version__  # noqa: E402
-
-# Import functions from the canonical startup module
-from tensorcast.startup import (  # noqa: E402
-    init,
-    is_initialized,
-    shutdown,
+from tensorcast.api import (  # noqa: E402
+    ArtifactDescriptor,
+    ArtifactError,
+    ArtifactFuture,
+    FallbackOptions,
+    GetArtifactOptions,
+    LoadHandle,
+    PlanType,
+    RegisterArtifactOptions,
+    RegisteredArtifact,
+    RegisteredLease,
+    RegistrationResult,
+    Store,
+    StoreOptions,
+    begin_register_artifact_sdk,
+    build_indices_from_safetensors,
+    calculate_tensor_device_offsets,
+    load_dict_async,
+    load_dict_from_disk,
+    load_dict_sync,
+    save_dict,
 )
+from tensorcast.startup import init, is_initialized, shutdown  # noqa: E402
 
 __all__ = [
     "__version__",
     "init",
     "is_initialized",
     "shutdown",
+    "Store",
+    "StoreOptions",
+    "RegisteredArtifact",
+    "ArtifactError",
+    "ArtifactFuture",
+    "FallbackOptions",
+    "LoadHandle",
+    "load_dict_sync",
+    "load_dict_async",
+    "save_dict",
+    "load_dict_from_disk",
+    "begin_register_artifact_sdk",
+    "RegisteredLease",
+    "RegistrationResult",
+    "PlanType",
+    "RegisterArtifactOptions",
+    "GetArtifactOptions",
+    "calculate_tensor_device_offsets",
+    "build_indices_from_safetensors",
+    "ArtifactDescriptor",
 ]

--- a/tensorcast/api/_config.py
+++ b/tensorcast/api/_config.py
@@ -7,7 +7,7 @@ import threading
 from dataclasses import dataclass
 from enum import Enum
 
-from ._errors import InvalidPlan
+from tensorcast.api._errors import InvalidPlan
 
 # Module-level constants
 DEFAULT_ALIGN: int = 8
@@ -88,7 +88,9 @@ class RegisterArtifactOptions:
     disk_path: str | None = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "plan", PlanType.parse(self.plan))
+        # Ensure plan is a PlanType; callers must pass PlanType per API contract.
+        if not isinstance(self.plan, PlanType):
+            raise TypeError("RegisterArtifactOptions.plan must be a PlanType")
 
 
 @dataclass(slots=True, frozen=True)

--- a/tensorcast/api/_config.py
+++ b/tensorcast/api/_config.py
@@ -74,7 +74,7 @@ class PlanType(Enum):
 
 @dataclass(slots=True, frozen=True)
 class RegisterArtifactOptions:
-    plan: PlanType | str = PlanType.VRAM_COALESCED
+    plan: PlanType = PlanType.VRAM_COALESCED
     p2p_prefer: str = "vram"
     max_inflight_bytes: int = 512 * 1024 * 1024
     release_on_tensor_commit: bool = True

--- a/tensorcast/api/_load_engine.py
+++ b/tensorcast/api/_load_engine.py
@@ -1,0 +1,253 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import Callable, Protocol, cast
+
+import torch
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind
+
+from tensorcast._C import get_cuda_memory_ptr, restore_tensors
+from tensorcast.api._errors import DaemonUnavailable
+from tensorcast.api._indices import (
+    TensorDeviceOffsets,
+    TensorMetaIndex,
+    calculate_tensor_device_offsets,
+    load_tensor_indices_from_dir,
+)
+from tensorcast.api._io_disk import load_dict_from_disk
+from tensorcast.api._runtime_handle import RuntimeHandle
+from tensorcast.api._utils import ensure_artifact_descriptor_safe
+from tensorcast.daemon_ctl import DaemonCtl
+from tensorcast.observability.otel import ensure_client_otel, set_span_attributes
+from tensorcast.proto.daemon.v1 import store_daemon_pb2
+
+if torch.__version__ is None:  # pragma: no cover
+    raise RuntimeError("torch must be importable before using tensorcast.api loaders")
+
+
+class LoadHandle:
+    class _StateDictProxy(dict[str, torch.Tensor]):
+        def __init__(self, inner: dict[str, torch.Tensor], ready_evt: threading.Event):
+            super().__init__()
+            self._inner = inner
+            self._ready = ready_evt
+
+        def _ensure_ready(self) -> None:
+            if not self._ready.is_set():
+                raise DaemonUnavailable(
+                    "state_dict not ready; call wait() or result() before tensor access"
+                )
+
+        def __getitem__(self, k: str) -> torch.Tensor:
+            self._ensure_ready()
+            return self._inner[k]
+
+        def items(self):
+            self._ensure_ready()
+            return self._inner.items()
+
+        def keys(self):
+            self._ensure_ready()
+            return self._inner.keys()
+
+        def values(self):
+            self._ensure_ready()
+            return self._inner.values()
+
+    def __init__(
+        self, state_dict: dict[str, torch.Tensor], confirm_fn: Callable[[], bool]
+    ):
+        self._state = state_dict
+        self._confirm = confirm_fn
+        self._ready = threading.Event()
+        self._proxy = LoadHandle._StateDictProxy(state_dict, self._ready)
+
+    def ready(self) -> bool:
+        return self._ready.is_set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        ok = self._confirm()
+        if ok:
+            self._ready.set()
+        return ok
+
+    def result(self) -> dict[str, torch.Tensor]:
+        if not self.ready():
+            ok = self.wait()
+            if not ok:
+                raise DaemonUnavailable("Artifact loading failed during confirmation")
+        return self._state
+
+    @property
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        return self._proxy
+
+
+class Loader(Protocol):
+    def load(self) -> dict[str, torch.Tensor] | LoadHandle:  # pragma: no cover - prot
+        ...
+
+
+class DiskLoader:
+    def __init__(self, *, artifact_dir: Path, device_id: int) -> None:
+        self._artifact_dir = artifact_dir
+        self._device_id = device_id
+
+    def load(self) -> dict[str, torch.Tensor]:
+        return load_dict_from_disk(self._artifact_dir, device_id=self._device_id)
+
+
+class DaemonLoader:
+    def __init__(
+        self,
+        *,
+        runtime: RuntimeHandle,
+        disk_path: str | os.PathLike,
+        replica_uuid: str,
+        device_uuid: str,
+        device_id: int,
+        artifact_dir: Path,
+        tensor_meta_index: TensorMetaIndex,
+        tensor_device_offsets: TensorDeviceOffsets,
+        pinned_allocation_timeout_ms: int,
+        wait_for_completion: bool,
+        enable_verification: bool,
+    ) -> None:
+        self.runtime = runtime
+        self.disk_path = str(disk_path)
+        self.replica_uuid = replica_uuid
+        self.device_uuid = device_uuid
+        self.device_id = int(device_id)
+        self.artifact_dir = artifact_dir
+        self.tensor_meta_index = tensor_meta_index
+        self.tensor_device_offsets = tensor_device_offsets
+        self.pinned_allocation_timeout_ms = int(pinned_allocation_timeout_ms)
+        self.wait_for_completion = bool(wait_for_completion)
+        self.enable_verification = bool(enable_verification)
+        self.tracer = trace.get_tracer(__name__)
+
+    @property
+    def client(self) -> DaemonCtl:
+        return self.runtime.client
+
+    def load(
+        self,
+    ) -> dict[str, torch.Tensor] | tuple[dict[str, torch.Tensor], Callable[[], bool]]:
+        with self.tracer.start_as_current_span(
+            "Client/LoadDictDaemon", kind=SpanKind.INTERNAL
+        ):
+            ensure_client_otel("tensorcast-client", role="client")
+            set_span_attributes(
+                {
+                    "tc.disk.path": str(self.disk_path),
+                    "tc.device.id": int(self.device_id),
+                    "tc.source": "daemon",
+                    "tc.pinned_allocation_timeout_ms": int(
+                        self.pinned_allocation_timeout_ms
+                    ),
+                    "tc.wait_for_completion": bool(self.wait_for_completion),
+                }
+            )
+            result = self.client.load_into_gpu(
+                str(self.disk_path),
+                self.replica_uuid,
+                self.device_uuid,
+                pinned_allocation_timeout_ms=self.pinned_allocation_timeout_ms,
+                wait_for_completion=self.wait_for_completion,
+            )
+
+        if self.wait_for_completion:
+            cuda_memory_handle = result
+            load_status = None
+        else:
+            cuda_memory_handle, load_status = cast(tuple[bytes, object], result)
+
+        cuda_memory_ptr = get_cuda_memory_ptr(self.device_id, cuda_memory_handle)
+        state_dict = restore_tensors(
+            self.tensor_meta_index,
+            {self.device_id: cuda_memory_ptr},
+            self.tensor_device_offsets,
+            True,
+        )
+
+        if self.enable_verification:
+            verification_timeout_ms = self.pinned_allocation_timeout_ms + 30000
+            t = threading.Thread(
+                target=_monitor_verification,
+                args=(
+                    self.client,
+                    self.disk_path,
+                    self.replica_uuid,
+                    verification_timeout_ms,
+                ),
+                daemon=True,
+            )
+            t.start()
+
+        ensure_artifact_descriptor_safe(self.artifact_dir)
+
+        if self.wait_for_completion:
+            return state_dict
+
+        def confirm_load() -> bool:
+            try:
+                if (
+                    load_status
+                    and load_status
+                    == store_daemon_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_FAILED
+                ):
+                    return False
+                return self.client.confirm_replica_loaded(
+                    str(self.disk_path),
+                    self.replica_uuid,
+                )
+            except Exception:
+                return False
+
+        return state_dict, confirm_load
+
+
+def prepare_artifact_layout(
+    artifact_dir: Path, *, device_id: int
+) -> tuple[TensorMetaIndex, TensorDeviceOffsets]:
+    tensor_meta_index, tensor_data_index = load_tensor_indices_from_dir(artifact_dir)
+    tensor_device_offsets, _ = calculate_tensor_device_offsets(
+        tensor_data_index, device_id
+    )
+    return tensor_meta_index, tensor_device_offsets
+
+
+def _monitor_verification(
+    ctl: DaemonCtl,
+    identifier: str,
+    replica: str,
+    timeout: int,
+) -> None:  # pragma: no cover
+    try:
+        resp = ctl.wait_artifact_verification(
+            artifact_identifier=identifier,
+            replica_uuid=replica,
+            timeout_ms=timeout,
+        )
+        if resp is None:
+            return
+        if (
+            resp.status
+            == store_daemon_pb2.VerificationStatus.VERIFICATION_STATUS_FAILED
+        ):
+            os._exit(1)
+    except Exception:
+        pass
+
+
+__all__ = [
+    "DaemonLoader",
+    "DiskLoader",
+    "LoadHandle",
+    "prepare_artifact_layout",
+]

--- a/tensorcast/api/_loader.py
+++ b/tensorcast/api/_loader.py
@@ -2,445 +2,46 @@
 
 from __future__ import annotations
 
-import json
-import os
-import threading
-from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Protocol, cast
+from typing import Callable, cast
 
 import torch
-from opentelemetry import trace
-from opentelemetry.trace import SpanKind
 
-from tensorcast import startup
-from tensorcast._C import (
-    get_cuda_memory_ptr,
-    restore_tensors,
+from tensorcast.api._config import DEFAULT_PINNED_TIMEOUT_MS
+from tensorcast.api._device import device_uuid_for, resolve_device
+from tensorcast.api._errors import DaemonUnavailable
+from tensorcast.api._io_disk import load_dict_from_disk
+from tensorcast.api._load_engine import (
+    DaemonLoader,
+    LoadHandle,
+    prepare_artifact_layout,
 )
-from tensorcast.client_runtime import client_defaults, daemon_target_default
-
-if TYPE_CHECKING:  # for static type checkers only
-    from tensorcast.daemon_ctl import DaemonCtl
-from tensorcast.observability.otel import ensure_client_otel, set_span_attributes
-from tensorcast.proto.daemon.v1 import store_daemon_pb2
-
-# Avoid importing Global Store client/protos in API layer
-from ._config import (
-    DEFAULT_PINNED_TIMEOUT_MS,
-    GetArtifactOptions,
+from tensorcast.api._runtime import (
+    apply_client_load_defaults_if_present,
+    require_runtime,
 )
-from ._device import device_uuid_for, resolve_device
-from ._errors import DaemonUnavailable, IndexParseError
-from ._indices import (
-    TensorDataIndex,
-    TensorDeviceOffsets,
-    TensorMetaIndex,
-    calculate_tensor_device_offsets,
-    load_tensor_indices_from_dir,
-)
-from ._io_disk import load_dict_from_disk
-from ._utils import ensure_artifact_descriptor_safe, new_uuid
-
-
-class LoadHandle:
-    class _StateDictProxy(dict[str, torch.Tensor]):
-        def __init__(self, inner: dict[str, torch.Tensor], ready_evt: threading.Event):
-            super().__init__()
-            self._inner = inner
-            self._ready = ready_evt
-
-        def _ensure_ready(self) -> None:
-            if not self._ready.is_set():
-                raise DaemonUnavailable(
-                    "state_dict not ready; call wait() or result() before tensor access"
-                )
-
-        def __getitem__(self, k: str) -> torch.Tensor:
-            self._ensure_ready()
-            return self._inner[k]
-
-        def items(self):
-            self._ensure_ready()
-            return self._inner.items()
-
-        def keys(self):
-            self._ensure_ready()
-            return self._inner.keys()
-
-        def values(self):
-            self._ensure_ready()
-            return self._inner.values()
-
-    def __init__(
-        self, state_dict: dict[str, torch.Tensor], confirm_fn: Callable[[], bool]
-    ):
-        self._state = state_dict
-        self._confirm = confirm_fn
-        self._ready = threading.Event()
-        self._proxy = LoadHandle._StateDictProxy(state_dict, self._ready)
-
-    def ready(self) -> bool:
-        return self._ready.is_set()
-
-    def wait(self, timeout: float | None = None) -> bool:
-        ok = self._confirm()
-        if ok:
-            self._ready.set()
-        return ok
-
-    def result(self) -> dict[str, torch.Tensor]:
-        if not self.ready():
-            ok = self.wait()
-            if not ok:
-                raise DaemonUnavailable("Artifact loading failed during confirmation")
-        return self._state
-
-    @property
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        return self._proxy
-
-
-class Loader(Protocol):
-    def load(
-        self,
-    ) -> dict[str, torch.Tensor] | LoadHandle:  # pragma: no cover - protocol
-        ...
-
-
-class DiskLoader:
-    def __init__(self, *, artifact_dir: Path, device_id: int) -> None:
-        self._artifact_dir = artifact_dir
-        self._device_id = device_id
-
-    def load(self) -> dict[str, torch.Tensor]:
-        return load_dict_from_disk(self._artifact_dir, device_id=self._device_id)
-
-
-class DaemonLoader:
-    def __init__(
-        self,
-        *,
-        client: DaemonCtl,
-        tracer: trace.Tracer,
-        disk_path: str | os.PathLike,
-        replica_uuid: str,
-        device_uuid: str,
-        device_id: int,
-        artifact_dir: Path,
-        tensor_meta_index: TensorMetaIndex,
-        tensor_device_offsets: TensorDeviceOffsets,
-        pinned_allocation_timeout_ms: int,
-        wait_for_completion: bool,
-        enable_verification: bool,
-    ) -> None:
-        self.client = client
-        self.tracer = tracer
-        self.disk_path = str(disk_path)
-        self.replica_uuid = replica_uuid
-        self.device_uuid = device_uuid
-        self.device_id = int(device_id)
-        self.artifact_dir = artifact_dir
-        self.tensor_meta_index = tensor_meta_index
-        self.tensor_device_offsets = tensor_device_offsets
-        self.pinned_allocation_timeout_ms = int(pinned_allocation_timeout_ms)
-        self.wait_for_completion = bool(wait_for_completion)
-        self.enable_verification = bool(enable_verification)
-
-    def load(
-        self,
-    ) -> dict[str, torch.Tensor] | tuple[dict[str, torch.Tensor], Callable[[], bool]]:
-        with self.tracer.start_as_current_span(
-            "Client/LoadDictDaemon", kind=SpanKind.INTERNAL
-        ):
-            set_span_attributes(
-                {
-                    "tc.disk.path": str(self.disk_path),
-                    "tc.device.id": int(self.device_id),
-                    "tc.source": "daemon",
-                    "tc.pinned_allocation_timeout_ms": int(
-                        self.pinned_allocation_timeout_ms
-                    ),
-                    "tc.wait_for_completion": bool(self.wait_for_completion),
-                }
-            )
-            result = self.client.load_into_gpu(
-                str(self.disk_path),
-                self.replica_uuid,
-                self.device_uuid,
-                pinned_allocation_timeout_ms=self.pinned_allocation_timeout_ms,
-                wait_for_completion=self.wait_for_completion,
-            )
-
-        if self.wait_for_completion:
-            cuda_memory_handle = result
-            load_status = None
-        else:
-            cuda_memory_handle, load_status = cast(tuple[bytes, object], result)
-
-        cuda_memory_ptr = get_cuda_memory_ptr(self.device_id, cuda_memory_handle)
-        state_dict = restore_tensors(
-            self.tensor_meta_index,
-            {self.device_id: cuda_memory_ptr},
-            self.tensor_device_offsets,
-            True,
-        )
-
-        if self.enable_verification:
-            verification_timeout_ms = self.pinned_allocation_timeout_ms + 30000
-            t = threading.Thread(
-                target=_monitor_verification,
-                args=(
-                    self.client,
-                    self.disk_path,
-                    self.replica_uuid,
-                    verification_timeout_ms,
-                ),
-                daemon=True,
-            )
-            t.start()
-
-        ensure_artifact_descriptor_safe(self.artifact_dir)
-
-        if self.wait_for_completion:
-            return state_dict
-
-        def confirm_load() -> bool:
-            try:
-                if (
-                    load_status
-                    and load_status
-                    == store_daemon_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_FAILED
-                ):
-                    return False
-                return self.client.confirm_replica_loaded(
-                    str(self.disk_path),
-                    self.replica_uuid,
-                )
-            except Exception:
-                return False
-
-        return state_dict, confirm_load
-
-
-@dataclass(frozen=True)
-class MaterializedArtifact:
-    artifact_id: str
-    state_dict: dict[str, torch.Tensor]
-    canonical_index_bytes: bytes
-    replica_uuid: str
-    disk_path: str | None = None
-
-
-def materialize_artifact(
-    *,
-    client: DaemonCtl,
-    daemon_address: str,
-    device_id: int | torch.device,
-    artifact_id: str | None,
-    key: str | None,
-    options: GetArtifactOptions | None = None,
-) -> MaterializedArtifact:
-    if (artifact_id is None and key is None) or (artifact_id and key):
-        raise ValueError("Exactly one of artifact_id or key must be provided")
-
-    ensure_client_otel("tensorcast-client", role="client")
-    tracer = trace.get_tracer(__name__)
-
-    opts = options or GetArtifactOptions()
-    if not opts.wait_for_completion:
-        raise DaemonUnavailable(
-            "wait_for_completion=False is not supported for materialize_artifact"
-        )
-
-    dev_id = resolve_device(device_id)
-    (
-        pinned_ms,
-        enable_ver,
-        wait_for_completion,
-    ) = _apply_client_defaults_if_present(
-        opts.pinned_allocation_timeout_ms,
-        opts.enable_verification,
-        opts.wait_for_completion,
-        runtime_address=daemon_address,
-    )
-
-    opts = replace(
-        opts,
-        pinned_allocation_timeout_ms=pinned_ms,
-        enable_verification=enable_ver,
-        wait_for_completion=wait_for_completion,
-    )
-
-    replica_uuid = new_uuid()
-    disk_path: str | None = None
-
-    with tracer.start_as_current_span(
-        "Client/MaterializeArtifact", kind=SpanKind.INTERNAL
-    ):
-        if artifact_id is not None:
-            handle_bytes = client.materialize_by_artifact_id(
-                artifact_id,
-                replica_uuid,
-                device_uuid_for(dev_id),
-                pinned_allocation_timeout_ms=opts.pinned_allocation_timeout_ms,
-                wait_for_completion=opts.wait_for_completion,
-            )
-            resolved_artifact_id = artifact_id
-        else:
-            mat_result = client.materialize_by_key(
-                key or "",
-                replica_uuid,
-                dev_id,
-                pinned_allocation_timeout_ms=opts.pinned_allocation_timeout_ms,
-                wait_for_completion=opts.wait_for_completion,
-            )
-            handle_bytes, disk_path, resolved_artifact_id = cast(
-                tuple[bytes, str, str], mat_result
-            )
-
-    idx_bytes = client.get_artifact_index_by_id(resolved_artifact_id)
-    if not idx_bytes:
-        raise IndexParseError(
-            f"Failed to fetch canonical index for artifact_id={resolved_artifact_id}"
-        )
-
-    try:
-        index_obj = json.loads(idx_bytes)
-    except Exception as exc:  # noqa: BLE001
-        raise IndexParseError("Invalid canonical index JSON from Global Store") from exc
-
-    tensor_meta_index: TensorMetaIndex = {}
-    tensor_data_index: TensorDataIndex = {}
-    for name, meta in index_obj.items():
-        if len(meta) != 6:
-            raise IndexParseError(
-                f"Invalid canonical index entry for '{name}': expected 6 fields [offset,size,shape,stride,dtype,storage_offset], got {len(meta)}"
-            )
-        offset, size, shape, stride, dtype, storage_offset = meta
-        tensor_meta_index[name] = (shape, stride, dtype, storage_offset)
-        tensor_data_index[name] = (int(offset), int(size))
-
-    tensor_device_offsets, _ = calculate_tensor_device_offsets(
-        tensor_data_index, dev_id
-    )
-
-    cuda_memory_ptr = get_cuda_memory_ptr(dev_id, handle_bytes)
-    state_dict = restore_tensors(
-        tensor_meta_index,
-        {dev_id: cuda_memory_ptr},
-        tensor_device_offsets,
-        True,
-    )
-
-    if opts.enable_verification:
-        verification_timeout_ms = opts.pinned_allocation_timeout_ms + 30000
-        t = threading.Thread(
-            target=_monitor_verification,
-            args=(
-                client,
-                resolved_artifact_id,
-                replica_uuid,
-                verification_timeout_ms,
-            ),
-            daemon=True,
-        )
-        t.start()
-
-    return MaterializedArtifact(
-        artifact_id=resolved_artifact_id,
-        state_dict=state_dict,
-        canonical_index_bytes=idx_bytes,
-        replica_uuid=replica_uuid,
-        disk_path=disk_path,
-    )
-
-
-def _monitor_verification(
-    ctl: DaemonCtl,
-    identifier: str,
-    replica: str,
-    timeout: int,
-) -> None:  # pragma: no cover
-    try:
-        resp = ctl.wait_artifact_verification(
-            artifact_identifier=identifier,
-            replica_uuid=replica,
-            timeout_ms=timeout,
-        )
-        if resp is None:
-            return
-        if (
-            resp.status
-            == store_daemon_pb2.VerificationStatus.VERIFICATION_STATUS_FAILED
-        ):
-            os._exit(1)
-    except Exception:
-        pass
-
-
-def _apply_client_defaults_if_present(
-    pinned_allocation_timeout_ms: int,
-    enable_verification: bool,
-    wait_for_completion: bool,
-    *,
-    runtime_address: str,
-) -> tuple[int, bool, bool]:
-    cfg_timeout_ms, cfg_enable_ver, cfg_wait = client_defaults()
-    cfg_target = daemon_target_default()
-    if cfg_target and cfg_target != runtime_address:
-        raise RuntimeError(
-            "ClientConfig daemon target does not match initialized daemon address. "
-            "Call tensorcast.startup.init() with the desired daemon first."
-        )
-
-    if (
-        pinned_allocation_timeout_ms == DEFAULT_PINNED_TIMEOUT_MS
-        and cfg_timeout_ms is not None
-    ):
-        pinned_allocation_timeout_ms = int(cfg_timeout_ms)
-    if enable_verification is True and cfg_enable_ver is not None:
-        enable_verification = bool(cfg_enable_ver)
-    if wait_for_completion is True and cfg_wait is not None:
-        wait_for_completion = bool(cfg_wait)
-
-    return pinned_allocation_timeout_ms, enable_verification, wait_for_completion
+from tensorcast.api._utils import new_uuid
 
 
 def load_dict_sync(
     *,
-    disk_path: str | os.PathLike | None = None,
+    disk_path: str | Path | None = None,
     device_id: int | torch.device = 0,
-    storage_path: str | os.PathLike | None = None,
+    storage_path: str | Path | None = None,
     enable_verification: bool = True,
     pinned_allocation_timeout_ms: int = DEFAULT_PINNED_TIMEOUT_MS,
 ) -> dict[str, torch.Tensor]:
-    """Synchronously load an artifact directory into GPU memory.
+    runtime = require_runtime()
 
-    Always returns a state_dict with fixed type.
-    """
-    ensure_client_otel("tensorcast-client", role="client")
-    tracer = trace.get_tracer(__name__)
-    runtime_ctx = startup.require_initialized()
-    client = runtime_ctx.client
-
-    # Unified path semantics: user-provided disk_path is the artifact root.
-
-    device_id_int: int = resolve_device(device_id)
+    device_id_int = resolve_device(device_id)
     if disk_path is None:
         raise ValueError("disk_path must be provided")
 
-    raw_disk_path = Path(str(disk_path))
-    artifact_dir = raw_disk_path
-    tensor_meta_index, tensor_data_index = load_tensor_indices_from_dir(artifact_dir)
-
-    tensor_device_offsets, _ = calculate_tensor_device_offsets(
-        tensor_data_index, device_id_int
+    artifact_dir = Path(str(disk_path))
+    tensor_meta_index, tensor_device_offsets = prepare_artifact_layout(
+        artifact_dir, device_id=device_id_int
     )
 
-    device_uuid = device_uuid_for(device_id_int)
-    replica_uuid = new_uuid()
-    # Use torch cuda check
     if not torch.cuda.is_available():
         return load_dict_from_disk(artifact_dir, device_id=device_id_int)
 
@@ -448,64 +49,58 @@ def load_dict_sync(
         pinned_allocation_timeout_ms,
         enable_verification,
         _wait_for_completion,
-    ) = _apply_client_defaults_if_present(
+    ) = apply_client_load_defaults_if_present(
         pinned_allocation_timeout_ms,
         enable_verification,
         True,
-        runtime_address=runtime_ctx.address,
+        runtime_address=runtime.address,
     )
+
+    loader = DaemonLoader(
+        runtime=runtime,
+        disk_path=str(disk_path),
+        replica_uuid=new_uuid(),
+        device_uuid=device_uuid_for(device_id_int),
+        device_id=device_id_int,
+        artifact_dir=artifact_dir,
+        tensor_meta_index=tensor_meta_index,
+        tensor_device_offsets=tensor_device_offsets,
+        pinned_allocation_timeout_ms=pinned_allocation_timeout_ms,
+        wait_for_completion=True,
+        enable_verification=enable_verification,
+    )
+
     try:
-        loader = DaemonLoader(
-            client=client,
-            tracer=tracer,
-            disk_path=str(disk_path),
-            replica_uuid=replica_uuid,
-            device_uuid=device_uuid,
-            device_id=device_id_int,
-            artifact_dir=artifact_dir,
-            tensor_meta_index=tensor_meta_index,
-            tensor_device_offsets=tensor_device_offsets,
-            pinned_allocation_timeout_ms=pinned_allocation_timeout_ms,
-            wait_for_completion=True,
-            enable_verification=enable_verification,
-        )
         result = loader.load()
-        if isinstance(result, tuple):
-            state, _ = result
-            return state
-        return result
-    except RuntimeError as e:
-        if "Local StoreDaemon" in str(e) or "not available" in str(e):
+    except RuntimeError as exc:
+        if "Local StoreDaemon" in str(exc) or "not available" in str(exc):
             return load_dict_from_disk(artifact_dir, device_id=device_id_int)
-        raise DaemonUnavailable(str(e)) from e
+        raise DaemonUnavailable(str(exc)) from exc
+
+    if isinstance(result, tuple):
+        state, _ = result
+        return state
+    return result
 
 
 def load_dict_async(
-    disk_path: str | os.PathLike | None = None,
+    disk_path: str | Path | None = None,
     device_id: int | torch.device = 0,
-    storage_path: str | os.PathLike | None = None,
+    storage_path: str | Path | None = None,
     enable_verification: bool = True,
     pinned_allocation_timeout_ms: int = DEFAULT_PINNED_TIMEOUT_MS,
 ) -> LoadHandle:
-    ensure_client_otel("tensorcast-client", role="client")
-    tracer = trace.get_tracer(__name__)
-    runtime_ctx = startup.require_initialized()
-    client = runtime_ctx.client
+    runtime = require_runtime()
 
-    # Unified path semantics: user-provided disk_path is the artifact root.
-
-    device_id_int: int = resolve_device(device_id)
+    device_id_int = resolve_device(device_id)
     if disk_path is None:
         raise ValueError("disk_path must be provided")
 
-    raw_disk_path = Path(str(disk_path))
-    artifact_dir = raw_disk_path
-    tensor_meta_index, tensor_data_index = load_tensor_indices_from_dir(artifact_dir)
-    tensor_device_offsets, _ = calculate_tensor_device_offsets(
-        tensor_data_index, device_id_int
+    artifact_dir = Path(str(disk_path))
+    tensor_meta_index, tensor_device_offsets = prepare_artifact_layout(
+        artifact_dir, device_id=device_id_int
     )
-    device_uuid = device_uuid_for(device_id_int)
-    replica_uuid = new_uuid()
+
     if not torch.cuda.is_available():
         state = load_dict_from_disk(artifact_dir, device_id=device_id_int)
 
@@ -517,20 +112,19 @@ def load_dict_async(
     (
         pinned_allocation_timeout_ms,
         enable_verification,
-        _,
-    ) = _apply_client_defaults_if_present(
+        _wait_for_completion,
+    ) = apply_client_load_defaults_if_present(
         pinned_allocation_timeout_ms,
         enable_verification,
         False,
-        runtime_address=runtime_ctx.address,
+        runtime_address=runtime.address,
     )
 
     loader = DaemonLoader(
-        client=client,
-        tracer=tracer,
+        runtime=runtime,
         disk_path=str(disk_path),
-        replica_uuid=replica_uuid,
-        device_uuid=device_uuid,
+        replica_uuid=new_uuid(),
+        device_uuid=device_uuid_for(device_id_int),
         device_id=device_id_int,
         artifact_dir=artifact_dir,
         tensor_meta_index=tensor_meta_index,
@@ -539,7 +133,12 @@ def load_dict_async(
         wait_for_completion=False,
         enable_verification=enable_verification,
     )
+
     state, confirm = cast(
-        tuple[dict[str, torch.Tensor], Callable[[], bool]], loader.load()
+        tuple[dict[str, torch.Tensor], Callable[[], bool]],
+        loader.load(),
     )
     return LoadHandle(state, confirm)
+
+
+__all__ = ["LoadHandle", "load_dict_async", "load_dict_sync"]

--- a/tensorcast/api/_materialize.py
+++ b/tensorcast/api/_materialize.py
@@ -1,0 +1,163 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass, replace
+from typing import cast
+
+import torch
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind
+
+from tensorcast._C import get_cuda_memory_ptr, restore_tensors
+from tensorcast.api._config import GetArtifactOptions
+from tensorcast.api._device import device_uuid_for, resolve_device
+from tensorcast.api._errors import DaemonUnavailable, IndexParseError
+from tensorcast.api._indices import (
+    TensorDataIndex,
+    TensorMetaIndex,
+    calculate_tensor_device_offsets,
+)
+from tensorcast.api._load_engine import _monitor_verification
+from tensorcast.api._runtime import apply_client_load_defaults_if_present
+from tensorcast.api._utils import new_uuid
+from tensorcast.daemon_ctl import DaemonCtl
+from tensorcast.observability.otel import ensure_client_otel
+
+
+@dataclass(frozen=True)
+class MaterializedArtifact:
+    artifact_id: str
+    state_dict: dict[str, torch.Tensor]
+    canonical_index_bytes: bytes
+    replica_uuid: str
+    disk_path: str | None = None
+
+
+def materialize_artifact(
+    *,
+    client: DaemonCtl,
+    daemon_address: str,
+    device_id: int | torch.device,
+    artifact_id: str | None,
+    key: str | None,
+    options: GetArtifactOptions | None = None,
+) -> MaterializedArtifact:
+    if (artifact_id is None and key is None) or (artifact_id and key):
+        raise ValueError("Exactly one of artifact_id or key must be provided")
+
+    ensure_client_otel("tensorcast-client", role="client")
+    tracer = trace.get_tracer(__name__)
+
+    opts = options or GetArtifactOptions()
+    if not opts.wait_for_completion:
+        raise DaemonUnavailable(
+            "wait_for_completion=False is not supported for materialize_artifact"
+        )
+
+    dev_id = resolve_device(device_id)
+    (
+        pinned_ms,
+        enable_ver,
+        wait_for_completion,
+    ) = apply_client_load_defaults_if_present(
+        opts.pinned_allocation_timeout_ms,
+        opts.enable_verification,
+        opts.wait_for_completion,
+        runtime_address=daemon_address,
+    )
+
+    opts = replace(
+        opts,
+        pinned_allocation_timeout_ms=pinned_ms,
+        enable_verification=enable_ver,
+        wait_for_completion=wait_for_completion,
+    )
+
+    replica_uuid = new_uuid()
+    disk_path: str | None = None
+
+    with tracer.start_as_current_span(
+        "Client/MaterializeArtifact", kind=SpanKind.INTERNAL
+    ):
+        if artifact_id is not None:
+            handle_bytes = client.materialize_by_artifact_id(
+                artifact_id,
+                replica_uuid,
+                device_uuid_for(dev_id),
+                pinned_allocation_timeout_ms=opts.pinned_allocation_timeout_ms,
+                wait_for_completion=opts.wait_for_completion,
+            )
+            resolved_artifact_id = artifact_id
+        else:
+            mat_result = client.materialize_by_key(
+                key or "",
+                replica_uuid,
+                dev_id,
+                pinned_allocation_timeout_ms=opts.pinned_allocation_timeout_ms,
+                wait_for_completion=opts.wait_for_completion,
+            )
+            handle_bytes, disk_path, resolved_artifact_id = cast(
+                tuple[bytes, str, str], mat_result
+            )
+
+    idx_bytes = client.get_artifact_index_by_id(resolved_artifact_id)
+    if not idx_bytes:
+        raise IndexParseError(
+            f"Failed to fetch canonical index for artifact_id={resolved_artifact_id}"
+        )
+
+    try:
+        index_obj = json.loads(idx_bytes)
+    except Exception as exc:  # noqa: BLE001
+        raise IndexParseError("Invalid canonical index JSON from Global Store") from exc
+
+    tensor_meta_index: TensorMetaIndex = {}
+    tensor_data_index: TensorDataIndex = {}
+    for name, meta in index_obj.items():
+        if len(meta) != 6:
+            raise IndexParseError(
+                f"Invalid canonical index entry for '{name}': expected 6 fields [offset,size,shape,stride,dtype,storage_offset], got {len(meta)}"
+            )
+        offset, size, shape, stride, dtype, storage_offset = meta
+        tensor_meta_index[name] = (shape, stride, dtype, storage_offset)
+        tensor_data_index[name] = (int(offset), int(size))
+
+    tensor_device_offsets, _ = calculate_tensor_device_offsets(
+        tensor_data_index, dev_id
+    )
+
+    cuda_memory_ptr = get_cuda_memory_ptr(dev_id, handle_bytes)
+    state_dict = restore_tensors(
+        tensor_meta_index,
+        {dev_id: cuda_memory_ptr},
+        tensor_device_offsets,
+        True,
+    )
+
+    if opts.enable_verification:
+        verification_timeout_ms = opts.pinned_allocation_timeout_ms + 30000
+        t = threading.Thread(
+            target=_monitor_verification,
+            args=(
+                client,
+                resolved_artifact_id,
+                replica_uuid,
+                verification_timeout_ms,
+            ),
+            daemon=True,
+        )
+        t.start()
+
+    return MaterializedArtifact(
+        artifact_id=resolved_artifact_id,
+        state_dict=state_dict,
+        canonical_index_bytes=idx_bytes,
+        replica_uuid=replica_uuid,
+        disk_path=disk_path,
+    )
+
+
+__all__ = ["MaterializedArtifact", "materialize_artifact"]

--- a/tensorcast/api/_register.py
+++ b/tensorcast/api/_register.py
@@ -11,13 +11,12 @@ from collections.abc import Callable
 from concurrent.futures import CancelledError
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import torch
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind
 
-from tensorcast import startup
 from tensorcast._C import (
     get_cuda_memory_handle,
     get_cuda_memory_ptr,
@@ -42,6 +41,7 @@ from tensorcast.api._indices import (
     build_v2_index_bytes,
 )
 from tensorcast.api._io_disk import save_dict
+from tensorcast.api._runtime import require_runtime
 from tensorcast.api._utils import validate_disk_index_matches
 from tensorcast.observability.otel import ensure_client_otel
 from tensorcast.types import (
@@ -271,9 +271,9 @@ def begin_register_artifact_sdk(
     daemon_address: str | None = None,
 ) -> tuple[RegisteredArtifact, Handshake]:
     if client is None:
-        runtime_ctx = startup.require_initialized()
-        ctl = runtime_ctx.client
-        daemon_addr = runtime_ctx.address
+        runtime = require_runtime()
+        ctl = runtime.client
+        daemon_addr = runtime.address
     else:
         ctl = client
         resolved_addr = daemon_address or client.server_address
@@ -502,7 +502,7 @@ def _prepare_build(
 def make_plan_model(
     options: RegisterArtifactOptions, total_size_bytes: int | None = None
 ) -> CoalescedPlan | LeasePlan:
-    plan_type = cast(PlanType, options.plan)
+    plan_type = options.plan
     if plan_type is PlanType.VRAM_COALESCED:
         return CoalescedPlan(
             kind="coalesced",
@@ -633,9 +633,9 @@ def _register_artifact_core(
     on_begin: Callable[[RegisteredArtifact], None] | None = None,
 ) -> RegistrationResult:
     if client is None:
-        runtime_ctx = startup.require_initialized()
-        ctl = runtime_ctx.client
-        addr = runtime_ctx.address
+        runtime = require_runtime()
+        ctl = runtime.client
+        addr = runtime.address
     else:
         ctl = client
         resolved_addr = daemon_address or client.server_address
@@ -668,7 +668,7 @@ def _register_artifact_core(
             in_place=True,
         )
     else:
-        plan_type = cast(PlanType, options.plan)
+        plan_type = options.plan
         plan_model = make_plan_model(options, layout.total_size)
 
     # Plan input-mode constraints

--- a/tensorcast/api/_runtime.py
+++ b/tensorcast/api/_runtime.py
@@ -1,0 +1,62 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from tensorcast import startup
+from tensorcast.api._runtime_handle import RuntimeHandle
+from tensorcast.daemon_ctl import DaemonCtl
+
+
+def is_initialized() -> bool:
+    return startup.is_initialized()
+
+
+def require_runtime() -> RuntimeHandle:
+    ctx = startup.require_initialized()
+    return RuntimeHandle(address=ctx.address, client=ctx.client)
+
+
+def require_client() -> DaemonCtl:
+    return require_runtime().client
+
+
+def apply_client_load_defaults_if_present(
+    pinned_allocation_timeout_ms: int,
+    enable_verification: bool,
+    wait_for_completion: bool,
+    *,
+    runtime_address: str,
+) -> Tuple[int, bool, bool]:
+    from tensorcast.api._config import DEFAULT_PINNED_TIMEOUT_MS
+    from tensorcast.client_runtime import client_defaults, daemon_target_default
+
+    cfg_timeout_ms, cfg_enable_ver, cfg_wait = client_defaults()
+    cfg_target = daemon_target_default()
+    if cfg_target and cfg_target != runtime_address:
+        raise RuntimeError(
+            "ClientConfig daemon target does not match initialized daemon address. "
+            "Call tensorcast.startup.init() with the desired daemon first."
+        )
+
+    if (
+        pinned_allocation_timeout_ms == DEFAULT_PINNED_TIMEOUT_MS
+        and cfg_timeout_ms is not None
+    ):
+        pinned_allocation_timeout_ms = int(cfg_timeout_ms)
+    if enable_verification is True and cfg_enable_ver is not None:
+        enable_verification = bool(cfg_enable_ver)
+    if wait_for_completion is True and cfg_wait is not None:
+        wait_for_completion = bool(cfg_wait)
+
+    return pinned_allocation_timeout_ms, enable_verification, wait_for_completion
+
+
+__all__ = [
+    "RuntimeHandle",
+    "apply_client_load_defaults_if_present",
+    "is_initialized",
+    "require_client",
+    "require_runtime",
+]

--- a/tensorcast/api/_runtime_handle.py
+++ b/tensorcast/api/_runtime_handle.py
@@ -1,0 +1,18 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tensorcast.daemon_ctl import DaemonCtl
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeHandle:
+    """Lightweight view over the active TensorCast runtime context."""
+
+    address: str
+    client: DaemonCtl
+
+
+__all__ = ["RuntimeHandle"]

--- a/tensorcast/api/store.py
+++ b/tensorcast/api/store.py
@@ -37,7 +37,10 @@ from tensorcast.api._indices import (
     load_tensor_indices_from_dir,
 )
 from tensorcast.api._io_disk import load_dict_from_disk
-from tensorcast.api._loader import MaterializedArtifact, materialize_artifact
+from tensorcast.api._materialize import (
+    MaterializedArtifact,
+    materialize_artifact,
+)
 from tensorcast.api._register import (
     RegisteredArtifact as _RegisterHandle,
 )

--- a/tensorcast/global_store/services/chunk_service.py
+++ b/tensorcast/global_store/services/chunk_service.py
@@ -4,10 +4,11 @@
 
 from typing import List, Optional
 
+from tensorcast.global_store.repositories.chunk_directory_repository import (
+    ChunkDirectoryRepository,
+)
 from tensorcast.logger import init_logger
 from tensorcast.proto.global_store.v1 import global_store_pb2
-
-from ..repositories.chunk_directory_repository import ChunkDirectoryRepository
 
 logger = init_logger(__name__)
 

--- a/tests/python/global_store/test_models.py
+++ b/tests/python/global_store/test_models.py
@@ -2,9 +2,11 @@
 
 """Tests for Global Store domain models."""
 
+from uuid import uuid4
+
 import pytest
 
-from tensorcast.global_store.models import Replica, Worker, Transport, MemoryType
+from tensorcast.global_store.models import MemoryType, Replica, Transport, Worker
 
 
 class TestModels:
@@ -139,8 +141,8 @@ class TestModels:
     def test_transport_creation(self):
         """Test Transport creation."""
         transport = Transport(
-            transport_id="transport_1",
-            replica_id="replica_1",
+            transport_id=uuid4(),
+            replica_id=uuid4(),
             artifact_id="test_artifact",
             source_node_id="source_node",
             source_address="192.168.1.2",

--- a/tests/python/test_register_lease_in_place_helper.py
+++ b/tests/python/test_register_lease_in_place_helper.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 from tensorcast import startup
-from tensorcast.api import RegisterArtifactOptions, Store
+from tensorcast.api import PlanType, RegisterArtifactOptions, Store
 from tensorcast.api.store import RegisteredArtifact as StoreRegisteredArtifact
 from tests.python.utils.daemon import start_daemon_binary
 
@@ -37,7 +37,7 @@ def test_register_artifact_lease_in_place_helper(tmp_path: Path):
             a = torch.arange(0, 32, dtype=torch.uint8, device=dev)
             b = torch.full((64,), 0x77, dtype=torch.uint8, device=dev)
             state = {"a": a, "b": b}
-            opts = RegisterArtifactOptions(plan="vram_leased", lease_in_place=True)
+            opts = RegisterArtifactOptions(plan=PlanType.VRAM_LEASED, lease_in_place=True)
             res = store.register(state, options=opts, ttl_ms=2000)
             assert isinstance(res, StoreRegisteredArtifact)
             assert res.registration_result is not None

--- a/tests/python/test_register_lease_in_place_helper.py
+++ b/tests/python/test_register_lease_in_place_helper.py
@@ -41,7 +41,8 @@ def test_register_artifact_lease_in_place_helper(tmp_path: Path):
             res = store.register(state, options=opts, ttl_ms=2000)
             assert isinstance(res, StoreRegisteredArtifact)
             assert res.registration_result is not None
-            desc, lease = res.registration_result.descriptor, res.lease
+            desc = res.registration_result.descriptor
+            lease = res.registration_result.lease
             assert desc.artifact_id.startswith("mi2:")
             # Keepalive thread should be running; sleep to allow a keepalive tick
             time.sleep(0.5)

--- a/tests/python/test_register_vram_leased_and_dvmp_stream.py
+++ b/tests/python/test_register_vram_leased_and_dvmp_stream.py
@@ -11,7 +11,7 @@ import torch
 
 from tensorcast import startup
 from tensorcast._C import get_cuda_memory_handle
-from tensorcast.api import RegisterArtifactOptions, Store
+from tensorcast.api import PlanType, RegisterArtifactOptions, Store
 from tensorcast.api._register import begin_register_artifact_sdk
 from tensorcast.api.store import RegisteredArtifact as StoreRegisteredArtifact
 from tensorcast.daemon_ctl import DaemonCtl
@@ -48,7 +48,7 @@ def test_register_vram_leased_commit(tmp_path: Path):
             t2 = torch.zeros((8, 8), dtype=torch.float32, device=device)
             state = {"t1": t1, "t2": t2}
 
-            opts = RegisterArtifactOptions(plan="vram_leased", lease_in_place=True)
+            opts = RegisterArtifactOptions(plan=PlanType.VRAM_LEASED, lease_in_place=True)
             # For lease: do not pass device_id so SDK infers and uses CUDA path
             res = store.register(state, options=opts)
             assert isinstance(res, StoreRegisteredArtifact)

--- a/tests/python/test_store_session_api.py
+++ b/tests/python/test_store_session_api.py
@@ -8,15 +8,15 @@ import threading
 import time
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import pytest
 import torch
 
 from tensorcast.api import store as store_mod
 from tensorcast.api._config import GetArtifactOptions, PlanType, RegisterArtifactOptions
-from tensorcast.api._loader import MaterializedArtifact
-from tensorcast.api._register import RegistrationResult
+from tensorcast.api._materialize import MaterializedArtifact
+from tensorcast.api._register import BuildContext, CoalescedLayout, RegistrationResult
 from tensorcast.api.store import (
     ArtifactError,
     ArtifactFuture,
@@ -135,8 +135,21 @@ class FakeEnvironment:
         )
         index_bytes = json.dumps(index, separators=(",", ":"), sort_keys=True).encode("utf-8")
         device = 0 if device_id is None else int(device_id)
-        build = SimpleNamespace(device_id=device)
-        layout = SimpleNamespace(total_size=offset)
+        build_ns = SimpleNamespace(
+            device_id=device,
+            input_mode="cuda" if device_id is None else "cpu",
+            tensor_meta_index={},
+            tensor_source_index={},
+        )
+        build = cast(BuildContext, build_ns)
+        layout_ns = SimpleNamespace(
+            total_size=offset,
+            device_id=device,
+            offsets={},
+            unique_chunks=[],
+        )
+        layout = cast(CoalescedLayout, layout_ns)
+        plan_enum = PlanType.parse(plan)
         return RegistrationResult(
             state_dict=dict(artifact),
             descriptor=descriptor,
@@ -144,7 +157,7 @@ class FakeEnvironment:
             build=build,
             layout=layout,
             index_bytes=index_bytes,
-            plan=plan,
+            plan=plan_enum,
         )
 
     def fake_register(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the Python SDK to a functional facade over a shared Store, refactors loading/materialization into dedicated modules, and updates docs/examples/tests accordingly.
> 
> - **API (Python SDK)**:
>   - Add functional facade: `tensorcast.init`, `tensorcast.register`, `tensorcast.put`, `tensorcast.get`, `tensorcast.get_into`; expose `tc.store()` for advanced use.
>   - Refactor runtime access (`tensorcast/api/_runtime.py`, `_runtime_handle.py`) and re-export API types via `tensorcast/__init__.py`.
>   - Tighten types: `RegisterArtifactOptions.plan` now `PlanType` (not `str`).
> - **Loading/Materialization**:
>   - Extract loader engine to `tensorcast/api/_load_engine.py` (DiskLoader/DaemonLoader, LoadHandle) and split materialization to `tensorcast/api/_materialize.py`.
>   - Simplify `_loader.py` to use new runtime/engine helpers and apply client defaults centrally.
> - **Store session**:
>   - `Store` now uses `_materialize.materialize_artifact`; minor internal adjustments and retries/telemetry unchanged.
> - **Docs**:
>   - Update README, architecture, designs, and internals to prefer the functional facade over direct `Store` construction; clarify shutdown and advanced access via `tc.store()`.
>   - Fix paths/references (e.g., verification integration, loader/materialize locations) and migration guidance.
> - **Examples/Tests**:
>   - Rewrite examples to use `import tensorcast as tc` and functional calls.
>   - Add small sample scripts (`examples/test_get.py`, `examples/test_register.py`).
>   - Update tests to new modules/APIs; tweak types (e.g., UUID-based transports).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf1ab1c43ec537ac910286b89994dc418c1528cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->