### PR TITLE
feat(daemon): enhance lease-in-place registration with storage and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ external
 *_pb2.pyi
 
 tensorcast/schema.sql
+docs/drafts

--- a/core/common/cuda_real.cc
+++ b/core/common/cuda_real.cc
@@ -378,15 +378,14 @@ absl::Status get_ipc_mem_handle(cudaIpcMemHandle_t* handle, void* dev_ptr) {
 }
 
 absl::Status open_ipc_mem_handle(void** dev_ptr, cudaIpcMemHandle_t handle, unsigned int flags) {
-  LOG(INFO) << "open_ipc_mem_handle: " << dev_ptr << " " << flags;
+  const std::string handle_hex = to_hex_string(handle);
   // Detect the invalid same-process usage early and return a clear error.
   // Opening a CUDA IPC memory handle in the same process that exported it is
   // not a valid CUDA usage (IPC is cross-process only). Avoid surfacing
   // misleading device/context errors from the runtime.
   {
     absl::MutexLock lock(&g_ipc_map_mu);
-    const std::string key = to_hex_string(handle);
-    auto it = g_exported_ipc_map.find(key);
+    auto it = g_exported_ipc_map.find(handle_hex);
     if (it != g_exported_ipc_map.end() && it->second.pid == getpid()) {
       LOG(ERROR) << "cudaIpcOpenMemHandle called on a handle exported in the same process; this is invalid. "
                  << "Use the original device pointer within the exporting process, or a non-IPC path.";
@@ -396,6 +395,7 @@ absl::Status open_ipc_mem_handle(void** dev_ptr, cudaIpcMemHandle_t handle, unsi
     }
   }
   SC_RETURN_IF_CUDA_ERROR(cudaIpcOpenMemHandle(dev_ptr, handle, flags));
+  LOG(INFO) << "open_ipc_mem_handle: handle=0x" << handle_hex << " ptr=" << *dev_ptr << " flags=" << flags;
   return absl::OkStatus();
 }
 

--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -96,13 +96,20 @@ sc_cc_library(
 
 sc_cc_library(
     name = "lip_manager_lib",
-    srcs = ["lip_manager.cc"],
-    hdrs = ["lip_manager.h"],
+    srcs = [
+        "lip_manager.cc",
+        "lip_metadata_utils.cc",
+    ],
+    hdrs = [
+        "lip_manager.h",
+        "lip_metadata_utils.h",
+    ],
     deps = [
         ":cuda_ipc_raii_hdr",
         ":types_hdr",
         "//core/common:artifact_hash_lib",
         "//core/store:store_engine",
+        "//core/store/loader:canonical_index",
         "//core/store/loader:segment_plan_source",
         "//core/store/loader:source_hash",
         "@abseil-cpp//absl/container:flat_hash_map",
@@ -131,6 +138,15 @@ cc_binary(
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/strings",
         "@gsl",
+    ],
+)
+
+cc_test(
+    name = "lip_metadata_utils_test",
+    srcs = ["lip_metadata_utils_test.cc"],
+    deps = [
+        ":lip_manager_lib",
+        "@catch2//:catch2_main",
     ],
 )
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -74,6 +74,7 @@ Contract highlights:
 
 - Thin service: only validation, orchestration, status mapping. No duplicated engine logic.
 - RAII for external resources (e.g., CUDA IPC) to prevent leaks and double-close.
+- Canonical index rebuild mirrors the SDK path: storage-level offsets and lengths are emitted for every alias so tensor views dedupe across disk, coalesced VRAM, and LIP flows.
 - TTL for every ephemeral map; all TTL updates and cleanup run under BackgroundScheduler.
 - Consistent deadlines: user timeouts are clamped to RPC deadlines.
 - Observability is best-effort and never changes control flow; high-cardinality fields are gated.

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -78,6 +78,7 @@ Contract highlights:
 - Consistent deadlines: user timeouts are clamped to RPC deadlines.
 - Observability is best-effort and never changes control flow; high-cardinality fields are gated.
 - Idempotent unload and lock cleanup; expired tokens are unlocked automatically.
+- Lease-in-place commits rebuild the canonical tensor index from the fed `storage_entries` and `tensor_aliases`, emitting `tc_register_storage_count` / `tc_register_tensor_count` metrics so rollouts can confirm dedupe efficacy.
 
 ## Directory Layout (What lives here)
 

--- a/daemon/grpc_service_impl.cc
+++ b/daemon/grpc_service_impl.cc
@@ -25,8 +25,9 @@ absl::StatusOr<std::vector<uint8_t>> StoreDaemonServiceImpl::lip_copy_to_new_coa
     int target_device_id,
     const std::string& canonical_index_json,
     uint64_t total_size,
-    absl::Span<const LeaseSegMeta> segments) {
-  return lip_mgr_->copy_to_new_coalesced(target_device_id, canonical_index_json, total_size, segments);
+    absl::Span<const LeaseSegMeta> segments,
+    absl::Span<const RegisterStorageMeta> storages) {
+  return lip_mgr_->copy_to_new_coalesced(target_device_id, canonical_index_json, total_size, segments, storages);
 }
 
 Status StoreDaemonServiceImpl::MaterializeReplica(

--- a/daemon/grpc_service_impl.h
+++ b/daemon/grpc_service_impl.h
@@ -287,7 +287,8 @@ class StoreDaemonServiceImpl final : public v1::StoreDaemonService::Service {
       int target_device_id,
       const std::string& canonical_index_json,
       uint64_t total_size,
-      absl::Span<const LeaseSegMeta> segments);
+      absl::Span<const LeaseSegMeta> segments,
+      absl::Span<const RegisterStorageMeta> storages);
 
   Options opts_;
 

--- a/daemon/lip_bridge.cc
+++ b/daemon/lip_bridge.cc
@@ -28,7 +28,11 @@ absl::StatusOr<bool> LipBridge::try_satisfy_from_lip(
     return absl::FailedPreconditionError("lease_in_place not supported for same device_id consumers");
   }
   auto hbytes_or = lip_.copy_to_new_coalesced(
-      target_device_id, lip_src->index_data, lip_src->total_size, absl::MakeSpan(lip_src->segments));
+      target_device_id,
+      lip_src->index_data,
+      lip_src->total_size,
+      absl::MakeSpan(lip_src->segments),
+      absl::MakeSpan(lip_src->storages));
   if (!hbytes_or.ok())
     return hbytes_or.status();
 

--- a/daemon/lip_manager.cc
+++ b/daemon/lip_manager.cc
@@ -2,18 +2,24 @@
 
 #include "daemon/lip_manager.h"
 
+#include <cstdint>
 #include <optional>
 
 #include <unistd.h>
 #include <algorithm>
+#include <utility>
+#include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/time/time.h"
 #include "core/common/artifact_hash.h"
+#include "core/store/loader/canonical_index.h"
 #include "core/store/loader/segment_plan_source.h"
 #include "core/store/loader/source_hash.h"
 #include "daemon/cuda_ipc_raii.h"
+#include "daemon/lip_metadata_utils.h"
 #include "nlohmann/json.hpp"
 
 namespace tensorcast::daemon {
@@ -22,7 +28,30 @@ absl::StatusOr<std::vector<uint8_t>> LipManager::copy_to_new_coalesced(
     int target_device_id,
     const std::string& canonical_index_json,
     uint64_t total_size,
-    absl::Span<const LeaseSegMeta> segments) {
+    absl::Span<const LeaseSegMeta> segments,
+    absl::Span<const RegisterStorageMeta> storages) {
+  if (storages.empty()) {
+    return absl::InvalidArgumentError("lip copy requires storage metadata");
+  }
+  absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_handle;
+  storage_by_handle.reserve(storages.size());
+  for (const auto& storage : storages) {
+    storage_by_handle.emplace(storage.handle_bytes, &storage);
+  }
+  for (const auto& seg : segments) {
+    auto it = storage_by_handle.find(seg.handle_bytes);
+    if (it == storage_by_handle.end()) {
+      return absl::InvalidArgumentError("segment handle missing matching RegisterStorage entry");
+    }
+    if (seg.length != it->second->storage_length) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat(
+              "segment length (%llu) does not match storage_length (%llu) for storage_id=%s",
+              static_cast<uint64_t>(seg.length),
+              static_cast<uint64_t>(it->second->storage_length),
+              it->second->storage_id));
+    }
+  }
   // Begin destination allocation on target device
   store::StoreEngine::ArtifactRegistration areg;
   areg.artifact_id = absl::StrCat("mem_reg:", absl::ToUnixNanos(absl::Now()));
@@ -159,6 +188,28 @@ absl::StatusOr<std::string> LipManager::create_staged_export(
   const size_t chunk_size = engine.get_artifact_chunk_bytes();
   if (chunk_size == 0) {
     return absl::FailedPreconditionError("invalid chunk_size (0)");
+  }
+
+  if (!lip.storages.empty()) {
+    absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_handle;
+    storage_by_handle.reserve(lip.storages.size());
+    for (const auto& storage : lip.storages) {
+      storage_by_handle.emplace(storage.handle_bytes, &storage);
+    }
+    for (const auto& seg : lip.segments) {
+      auto it = storage_by_handle.find(seg.handle_bytes);
+      if (it == storage_by_handle.end()) {
+        return absl::InvalidArgumentError("staged export missing storage metadata for a segment handle");
+      }
+      if (seg.length != it->second->storage_length) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat(
+                "segment length (%llu) does not match storage_length (%llu) for storage_id=%s",
+                static_cast<uint64_t>(seg.length),
+                static_cast<uint64_t>(it->second->storage_length),
+                it->second->storage_id));
+      }
+    }
   }
 
   struct OpenedSeg {
@@ -420,9 +471,30 @@ absl::StatusOr<CommitLeaseResult> LipManager::commit_lease_in_place(
     uint64_t total_size,
     const std::string& index_data,
     const std::string& index_key_hex,
-    std::vector<LeaseSegMeta>&& segments) {
-  // Validate canonical index presence via one of the two inputs
-  if (index_data.empty() && index_key_hex.empty()) {
+    std::vector<LeaseSegMeta>&& segments,
+    std::vector<RegisterStorageMeta>&& storages,
+    std::vector<RegisterTensorAliasMeta>&& aliases) {
+  std::string canonical_index_json = index_data;
+  if (!storages.empty() && !aliases.empty()) {
+    auto rebuilt_or = build_canonical_index_from_metadata(
+        absl::MakeSpan(segments), absl::MakeSpan(storages), absl::MakeSpan(aliases), device_id);
+    if (!rebuilt_or.ok()) {
+      return rebuilt_or.status();
+    }
+    const std::string& rebuilt = *rebuilt_or;
+    if (canonical_index_json.empty()) {
+      canonical_index_json = rebuilt;
+    } else {
+      auto stable_or = store::loader::rebuild_stable_canonical_index(canonical_index_json, device_id);
+      if (stable_or.ok() && *stable_or != rebuilt) {
+        LOG(WARNING) << "Rebuilt canonical index differs from client-provided data; "
+                     << "preferring rebuilt version for registration_id=" << registration_id;
+      }
+      canonical_index_json = rebuilt;
+    }
+  }
+
+  if (canonical_index_json.empty() && index_key_hex.empty()) {
     return absl::FailedPreconditionError("canonical index is required for LIP commit");
   }
 
@@ -520,7 +592,8 @@ absl::StatusOr<CommitLeaseResult> LipManager::commit_lease_in_place(
 
   // Compute multihashes
   auto index_mh_or = common::compute_index_multihash(
-      index_data.empty() ? std::optional<std::string>() : std::optional<std::string>(index_data), index_key_hex);
+      canonical_index_json.empty() ? std::optional<std::string>() : std::optional<std::string>(canonical_index_json),
+      index_key_hex);
   if (!index_mh_or.ok())
     return index_mh_or.status();
   auto data_mh_or = store::loader::compute_data_multihash_from_seekable_source(src, total_size);
@@ -582,8 +655,10 @@ absl::StatusOr<CommitLeaseResult> LipManager::commit_lease_in_place(
   lease.expiry = std::chrono::steady_clock::now() + std::chrono::milliseconds(lease.ttl_ms);
   lease.epoch = epoch;
   lease.total_size = total_size;
-  lease.index_data = index_data;
+  lease.index_data = canonical_index_json;
   lease.segments = std::move(segments);
+  lease.storages = std::move(storages);
+  lease.aliases = std::move(aliases);
   lease.verification_json = out.verification_json;
 
   {

--- a/daemon/lip_manager.h
+++ b/daemon/lip_manager.h
@@ -29,7 +29,8 @@ class LipManager {
       int target_device_id,
       const std::string& canonical_index_json,
       uint64_t total_size,
-      absl::Span<const LeaseSegMeta> segments);
+      absl::Span<const LeaseSegMeta> segments,
+      absl::Span<const RegisterStorageMeta> storages);
 
   // Register staged export for the given LIP lease over specified chunk indices.
   // Returns an opaque lock token which can be used to release the export via
@@ -69,7 +70,9 @@ class LipManager {
       uint64_t total_size,
       const std::string& index_data, // canonical index JSON (may be empty)
       const std::string& index_key_hex, // precomputed index sha256 hex (may be empty)
-      std::vector<LeaseSegMeta>&& segments);
+      std::vector<LeaseSegMeta>&& segments,
+      std::vector<RegisterStorageMeta>&& storages,
+      std::vector<RegisterTensorAliasMeta>&& aliases);
 
  private:
   std::shared_ptr<store::StoreEngine> engine_;

--- a/daemon/lip_metadata_utils.cc
+++ b/daemon/lip_metadata_utils.cc
@@ -46,8 +46,8 @@ absl::StatusOr<std::string> build_canonical_index_from_metadata(
   ordered_names.reserve(aliases.size());
   std::unordered_map<std::string, uint64_t> offsets;
   offsets.reserve(aliases.size());
-  std::unordered_map<std::string, uint64_t> logical_sizes;
-  logical_sizes.reserve(aliases.size());
+  std::unordered_map<std::string, uint64_t> storage_sizes;
+  storage_sizes.reserve(aliases.size());
   std::unordered_map<std::string, store::loader::CanonicalTensorMeta> metas;
   metas.reserve(aliases.size());
 
@@ -79,8 +79,10 @@ absl::StatusOr<std::string> build_canonical_index_from_metadata(
     }
 
     ordered_names.push_back(name);
-    offsets.emplace(name, base_dst + alias.storage_offset);
-    logical_sizes.emplace(name, alias.logical_length);
+    // Emit storage-level destination offset for every alias to keep canonical
+    // index bytes stable across LIP and disk registrations.
+    offsets.emplace(name, base_dst);
+    storage_sizes.emplace(name, storage_meta->storage_length);
     store::loader::CanonicalTensorMeta meta;
     meta.shape = alias.shape;
     meta.stride = alias.stride;
@@ -90,7 +92,7 @@ absl::StatusOr<std::string> build_canonical_index_from_metadata(
   }
 
   std::sort(ordered_names.begin(), ordered_names.end());
-  return store::loader::build_canonical_index_json(ordered_names, offsets, logical_sizes, metas);
+  return store::loader::build_canonical_index_json(ordered_names, offsets, storage_sizes, metas);
 }
 
 } // namespace tensorcast::daemon

--- a/daemon/lip_metadata_utils.cc
+++ b/daemon/lip_metadata_utils.cc
@@ -1,0 +1,96 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "daemon/lip_metadata_utils.h"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "core/store/loader/canonical_index.h"
+
+namespace tensorcast::daemon {
+
+absl::StatusOr<std::string> build_canonical_index_from_metadata(
+    absl::Span<const LeaseSegMeta> segments,
+    absl::Span<const RegisterStorageMeta> storages,
+    absl::Span<const RegisterTensorAliasMeta> aliases,
+    int device_id) {
+  if (storages.empty() || aliases.empty()) {
+    return std::string{};
+  }
+
+  absl::flat_hash_map<std::string, uint64_t> handle_to_dst;
+  handle_to_dst.reserve(segments.size());
+  for (const auto& seg : segments) {
+    handle_to_dst.emplace(seg.handle_bytes, seg.dst_offset);
+  }
+
+  absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_id;
+  storage_by_id.reserve(storages.size());
+  for (const auto& storage : storages) {
+    storage_by_id.emplace(storage.storage_id, &storage);
+  }
+
+  absl::flat_hash_map<std::string, const RegisterTensorAliasMeta*> alias_by_name;
+  alias_by_name.reserve(aliases.size());
+  for (const auto& alias : aliases) {
+    if (!alias_by_name.emplace(alias.name, &alias).second) {
+      return absl::InvalidArgumentError(absl::StrCat("duplicate tensor alias name: ", alias.name));
+    }
+  }
+
+  std::vector<std::string> ordered_names;
+  ordered_names.reserve(aliases.size());
+  std::unordered_map<std::string, uint64_t> offsets;
+  offsets.reserve(aliases.size());
+  std::unordered_map<std::string, uint64_t> logical_sizes;
+  logical_sizes.reserve(aliases.size());
+  std::unordered_map<std::string, store::loader::CanonicalTensorMeta> metas;
+  metas.reserve(aliases.size());
+
+  for (const auto& [name, alias_ptr] : alias_by_name) {
+    const RegisterTensorAliasMeta& alias = *alias_ptr;
+    auto storage_it = storage_by_id.find(alias.storage_id);
+    if (storage_it == storage_by_id.end()) {
+      return absl::InvalidArgumentError(absl::StrCat("missing storage entry for alias storage_id=", alias.storage_id));
+    }
+    const RegisterStorageMeta* storage_meta = storage_it->second;
+    auto dst_it = handle_to_dst.find(storage_meta->handle_bytes);
+    if (dst_it == handle_to_dst.end()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("missing segment entry for storage handle (id=", alias.storage_id, ")"));
+    }
+    const uint64_t base_dst = dst_it->second;
+    if (alias.storage_offset + alias.logical_length > storage_meta->storage_length) {
+      return absl::OutOfRangeError(
+          absl::StrCat(
+              "alias ",
+              alias.name,
+              " exceeds storage bounds (offset=",
+              alias.storage_offset,
+              ", length=",
+              alias.logical_length,
+              ", storage_length=",
+              storage_meta->storage_length,
+              ")"));
+    }
+
+    ordered_names.push_back(name);
+    offsets.emplace(name, base_dst + alias.storage_offset);
+    logical_sizes.emplace(name, alias.logical_length);
+    store::loader::CanonicalTensorMeta meta;
+    meta.shape = alias.shape;
+    meta.stride = alias.stride;
+    meta.dtype = alias.dtype;
+    meta.storage_offset = alias.storage_offset;
+    metas.emplace(name, std::move(meta));
+  }
+
+  std::sort(ordered_names.begin(), ordered_names.end());
+  return store::loader::build_canonical_index_json(ordered_names, offsets, logical_sizes, metas);
+}
+
+} // namespace tensorcast::daemon

--- a/daemon/lip_metadata_utils.h
+++ b/daemon/lip_metadata_utils.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#pragma once
+
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "daemon/types.h"
+
+namespace tensorcast::daemon {
+
+// Build canonical index JSON from deduplicated storage metadata and tensor aliases.
+// Returns Ok("") when aliases/storages are empty (legacy clients).
+absl::StatusOr<std::string> build_canonical_index_from_metadata(
+    absl::Span<const LeaseSegMeta> segments,
+    absl::Span<const RegisterStorageMeta> storages,
+    absl::Span<const RegisterTensorAliasMeta> aliases,
+    int device_id);
+
+} // namespace tensorcast::daemon

--- a/daemon/lip_metadata_utils_test.cc
+++ b/daemon/lip_metadata_utils_test.cc
@@ -1,0 +1,67 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "daemon/lip_metadata_utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using tensorcast::daemon::build_canonical_index_from_metadata;
+using tensorcast::daemon::LeaseSegMeta;
+using tensorcast::daemon::RegisterStorageMeta;
+using tensorcast::daemon::RegisterTensorAliasMeta;
+
+TEST_CASE("BuildCanonicalIndexFromMetadata generates stable JSON", "[daemon][lip]") {
+  std::vector<LeaseSegMeta> segments = {
+      LeaseSegMeta{.device_id = 0, .handle_bytes = "handle-a", .base_offset = 0, .length = 1024, .dst_offset = 0},
+  };
+  std::vector<RegisterStorageMeta> storages = {
+      RegisterStorageMeta{.storage_id = "s0", .device_id = 0, .handle_bytes = "handle-a", .storage_length = 1024},
+  };
+  std::vector<RegisterTensorAliasMeta> aliases;
+  RegisterTensorAliasMeta a;
+  a.name = "a_tensor";
+  a.storage_id = "s0";
+  a.storage_offset = 0;
+  a.logical_length = 512;
+  a.shape = {128, 1};
+  a.stride = {1, 1};
+  a.dtype = "torch.float32";
+  aliases.push_back(a);
+
+  RegisterTensorAliasMeta b;
+  b.name = "b_view";
+  b.storage_id = "s0";
+  b.storage_offset = 256;
+  b.logical_length = 256;
+  b.shape = {128, 1};
+  b.stride = {1, 1};
+  b.dtype = "torch.float32";
+  aliases.push_back(b);
+
+  auto canon_or = build_canonical_index_from_metadata(segments, storages, aliases, /*device_id=*/0);
+  REQUIRE(canon_or.ok());
+  REQUIRE(
+      *canon_or ==
+      R"({"a_tensor":[0,512,[128,1],[1,1],"torch.float32",0],"b_view":[256,256,[128,1],[1,1],"torch.float32",256]})");
+}
+
+TEST_CASE("BuildCanonicalIndexFromMetadata detects mismatched storage", "[daemon][lip]") {
+  std::vector<LeaseSegMeta> segments = {
+      LeaseSegMeta{.device_id = 0, .handle_bytes = "seg", .base_offset = 0, .length = 256, .dst_offset = 0},
+  };
+  std::vector<RegisterStorageMeta> storages = {
+      RegisterStorageMeta{.storage_id = "s0", .device_id = 0, .handle_bytes = "other", .storage_length = 256},
+  };
+  std::vector<RegisterTensorAliasMeta> aliases = {
+      RegisterTensorAliasMeta{
+          .name = "tensor",
+          .storage_id = "s0",
+          .storage_offset = 0,
+          .logical_length = 256,
+          .shape = {64, 1},
+          .stride = {1, 1},
+          .dtype = "torch.float32",
+      },
+  };
+  auto canon_or = build_canonical_index_from_metadata(segments, storages, aliases, /*device_id=*/0);
+  REQUIRE_FALSE(canon_or.ok());
+}

--- a/daemon/lip_metadata_utils_test.cc
+++ b/daemon/lip_metadata_utils_test.cc
@@ -39,9 +39,68 @@ TEST_CASE("BuildCanonicalIndexFromMetadata generates stable JSON", "[daemon][lip
 
   auto canon_or = build_canonical_index_from_metadata(segments, storages, aliases, /*device_id=*/0);
   REQUIRE(canon_or.ok());
+  // Both aliases share a storage, so offsets/sizes mirror the storage itself.
   REQUIRE(
       *canon_or ==
-      R"({"a_tensor":[0,512,[128,1],[1,1],"torch.float32",0],"b_view":[256,256,[128,1],[1,1],"torch.float32",256]})");
+      R"({"a_tensor":[0,1024,[128,1],[1,1],"torch.float32",0],"b_view":[0,1024,[128,1],[1,1],"torch.float32",256]})");
+}
+
+TEST_CASE("BuildCanonicalIndexFromMetadata handles multiple storages and views", "[daemon][lip]") {
+  std::vector<LeaseSegMeta> segments = {
+      LeaseSegMeta{.device_id = 0, .handle_bytes = "handle-a", .base_offset = 0, .length = 1024, .dst_offset = 0},
+      LeaseSegMeta{.device_id = 0, .handle_bytes = "handle-b", .base_offset = 0, .length = 2048, .dst_offset = 4096},
+  };
+  std::vector<RegisterStorageMeta> storages = {
+      RegisterStorageMeta{.storage_id = "s0", .device_id = 0, .handle_bytes = "handle-a", .storage_length = 1024},
+      RegisterStorageMeta{.storage_id = "s1", .device_id = 0, .handle_bytes = "handle-b", .storage_length = 2048},
+  };
+
+  std::vector<RegisterTensorAliasMeta> aliases;
+  RegisterTensorAliasMeta a_full;
+  a_full.name = "a_full";
+  a_full.storage_id = "s0";
+  a_full.storage_offset = 0;
+  a_full.logical_length = 1024;
+  a_full.shape = {256};
+  a_full.stride = {1};
+  a_full.dtype = "torch.float32";
+  aliases.push_back(a_full);
+
+  RegisterTensorAliasMeta a_tail;
+  a_tail.name = "a_tail";
+  a_tail.storage_id = "s0";
+  a_tail.storage_offset = 256;
+  a_tail.logical_length = 512;
+  a_tail.shape = {128};
+  a_tail.stride = {1};
+  a_tail.dtype = "torch.float32";
+  aliases.push_back(a_tail);
+
+  RegisterTensorAliasMeta b_full;
+  b_full.name = "b_full";
+  b_full.storage_id = "s1";
+  b_full.storage_offset = 0;
+  b_full.logical_length = 2048;
+  b_full.shape = {512};
+  b_full.stride = {1};
+  b_full.dtype = "torch.float16";
+  aliases.push_back(b_full);
+
+  RegisterTensorAliasMeta b_view;
+  b_view.name = "b_view";
+  b_view.storage_id = "s1";
+  b_view.storage_offset = 512;
+  b_view.logical_length = 1024;
+  b_view.shape = {256};
+  b_view.stride = {1};
+  b_view.dtype = "torch.float16";
+  aliases.push_back(b_view);
+
+  auto canon_or = build_canonical_index_from_metadata(segments, storages, aliases, /*device_id=*/0);
+  REQUIRE(canon_or.ok());
+  REQUIRE(
+      *canon_or ==
+      R"({"a_full":[0,1024,[256],[1],"torch.float32",0],"a_tail":[0,1024,[128],[1],"torch.float32",256],"b_full":[4096,2048,[512],[1],"torch.float16",0],"b_view":[4096,2048,[256],[1],"torch.float16",512]})");
 }
 
 TEST_CASE("BuildCanonicalIndexFromMetadata detects mismatched storage", "[daemon][lip]") {

--- a/daemon/registration_manager.h
+++ b/daemon/registration_manager.h
@@ -75,10 +75,40 @@ class RegistrationManager {
       v.push_back(std::move(s));
   }
 
+  void append_storage_entries(const std::string& reg_id, std::vector<RegisterStorageMeta>&& storages) {
+    absl::MutexLock l(&mu_);
+    auto& bucket = reg_storages_[reg_id];
+    for (auto& s : storages)
+      bucket.push_back(std::move(s));
+  }
+
+  void append_tensor_aliases(const std::string& reg_id, std::vector<RegisterTensorAliasMeta>&& aliases) {
+    absl::MutexLock l(&mu_);
+    auto& bucket = reg_aliases_[reg_id];
+    for (auto& a : aliases)
+      bucket.push_back(std::move(a));
+  }
+
   std::vector<LeaseSegMeta> get_lease_segments(const std::string& reg_id) const {
     absl::MutexLock l(&mu_);
     auto it = reg_leases_.find(reg_id);
     if (it == reg_leases_.end())
+      return {};
+    return it->second;
+  }
+
+  std::vector<RegisterStorageMeta> get_storage_entries(const std::string& reg_id) const {
+    absl::MutexLock l(&mu_);
+    auto it = reg_storages_.find(reg_id);
+    if (it == reg_storages_.end())
+      return {};
+    return it->second;
+  }
+
+  std::vector<RegisterTensorAliasMeta> get_tensor_aliases(const std::string& reg_id) const {
+    absl::MutexLock l(&mu_);
+    auto it = reg_aliases_.find(reg_id);
+    if (it == reg_aliases_.end())
       return {};
     return it->second;
   }
@@ -98,6 +128,8 @@ class RegistrationManager {
     if (it->second.expiry.time_since_epoch().count() > 0 && now > it->second.expiry) {
       reg_meta_.erase(it);
       reg_leases_.erase(reg_id);
+      reg_storages_.erase(reg_id);
+      reg_aliases_.erase(reg_id);
       return true;
     }
     return false;
@@ -152,6 +184,8 @@ class RegistrationManager {
     absl::MutexLock l(&mu_);
     reg_meta_.erase(reg_id);
     reg_leases_.erase(reg_id);
+    reg_storages_.erase(reg_id);
+    reg_aliases_.erase(reg_id);
   }
 
   // Enumerate registration ids (for TTL sweeping and tests)
@@ -168,6 +202,8 @@ class RegistrationManager {
   mutable absl::Mutex mu_;
   absl::flat_hash_map<std::string, RegMeta> reg_meta_ ABSL_GUARDED_BY(mu_);
   absl::flat_hash_map<std::string, std::vector<LeaseSegMeta>> reg_leases_ ABSL_GUARDED_BY(mu_);
+  absl::flat_hash_map<std::string, std::vector<RegisterStorageMeta>> reg_storages_ ABSL_GUARDED_BY(mu_);
+  absl::flat_hash_map<std::string, std::vector<RegisterTensorAliasMeta>> reg_aliases_ ABSL_GUARDED_BY(mu_);
 };
 
 // Stream operator for RegPlan to enable readable logging

--- a/daemon/service/controllers/registration_controller.cc
+++ b/daemon/service/controllers/registration_controller.cc
@@ -164,8 +164,45 @@ grpc::Status RegistrationController::feed_stream(
         to_add.push_back(std::move(m));
       }
       d_.reg.append_lease_segments(reg_id, std::move(to_add));
+    } else if (!req.storage_entries().empty() || !req.tensor_aliases().empty()) {
+      // allow requests that only carry storage/alias metadata without segments
     } else {
       return {StatusCode::INVALID_ARGUMENT, "missing feed payload"};
+    }
+    if (!req.storage_entries().empty()) {
+      std::vector<RegisterStorageMeta> storages;
+      storages.reserve(req.storage_entries().size());
+      for (const auto& entry : req.storage_entries()) {
+        RegisterStorageMeta meta;
+        meta.storage_id = entry.storage_id();
+        meta.device_id = entry.device_id();
+        meta.handle_bytes = entry.cuda_ipc_handle();
+        meta.storage_length = entry.storage_length();
+        storages.push_back(std::move(meta));
+      }
+      if (!storages.empty())
+        d_.reg.append_storage_entries(reg_id, std::move(storages));
+    }
+    if (!req.tensor_aliases().empty()) {
+      std::vector<RegisterTensorAliasMeta> aliases;
+      aliases.reserve(req.tensor_aliases().size());
+      for (const auto& alias : req.tensor_aliases()) {
+        RegisterTensorAliasMeta meta;
+        meta.name = alias.name();
+        meta.storage_id = alias.storage_id();
+        meta.storage_offset = alias.storage_offset();
+        meta.logical_length = alias.logical_length();
+        meta.shape.reserve(alias.shape().size());
+        for (int64_t v : alias.shape())
+          meta.shape.push_back(v);
+        meta.stride.reserve(alias.stride().size());
+        for (int64_t v : alias.stride())
+          meta.stride.push_back(v);
+        meta.dtype = alias.dtype();
+        aliases.push_back(std::move(meta));
+      }
+      if (!aliases.empty())
+        d_.reg.append_tensor_aliases(reg_id, std::move(aliases));
     }
   }
   rctx.mark_success();
@@ -223,8 +260,45 @@ grpc::Status RegistrationController::feed_vector(const std::vector<v1::FeedRegis
         to_add.push_back(std::move(m));
       }
       d_.reg.append_lease_segments(reg_id, std::move(to_add));
+    } else if (!req.storage_entries().empty() || !req.tensor_aliases().empty()) {
+      // allow metadata-only payloads
     } else {
       return {StatusCode::INVALID_ARGUMENT, "missing feed payload"};
+    }
+    if (!req.storage_entries().empty()) {
+      std::vector<RegisterStorageMeta> storages;
+      storages.reserve(req.storage_entries().size());
+      for (const auto& entry : req.storage_entries()) {
+        RegisterStorageMeta meta;
+        meta.storage_id = entry.storage_id();
+        meta.device_id = entry.device_id();
+        meta.handle_bytes = entry.cuda_ipc_handle();
+        meta.storage_length = entry.storage_length();
+        storages.push_back(std::move(meta));
+      }
+      if (!storages.empty())
+        d_.reg.append_storage_entries(reg_id, std::move(storages));
+    }
+    if (!req.tensor_aliases().empty()) {
+      std::vector<RegisterTensorAliasMeta> aliases;
+      aliases.reserve(req.tensor_aliases().size());
+      for (const auto& alias : req.tensor_aliases()) {
+        RegisterTensorAliasMeta meta;
+        meta.name = alias.name();
+        meta.storage_id = alias.storage_id();
+        meta.storage_offset = alias.storage_offset();
+        meta.logical_length = alias.logical_length();
+        meta.shape.reserve(alias.shape().size());
+        for (int64_t v : alias.shape())
+          meta.shape.push_back(v);
+        meta.stride.reserve(alias.stride().size());
+        for (int64_t v : alias.stride())
+          meta.stride.push_back(v);
+        meta.dtype = alias.dtype();
+        aliases.push_back(std::move(meta));
+      }
+      if (!aliases.empty())
+        d_.reg.append_tensor_aliases(reg_id, std::move(aliases));
     }
   }
   return Status::OK;
@@ -298,6 +372,24 @@ grpc::Status RegistrationController::commit(
       return {StatusCode::FAILED_PRECONDITION, "no lease segments fed"};
     }
 
+    auto storage_entries = d_.reg.get_storage_entries(req.registration_id());
+    auto alias_vec = d_.reg.get_tensor_aliases(req.registration_id());
+    if (storage_entries.empty()) {
+      return {StatusCode::FAILED_PRECONDITION, "registration missing storage_entries payload"};
+    }
+    if (alias_vec.empty()) {
+      return {StatusCode::FAILED_PRECONDITION, "registration missing tensor_aliases payload"};
+    }
+    try {
+      static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+      static auto storage_counter = meter->CreateDoubleCounter("tc_register_storage_count");
+      static auto alias_counter = meter->CreateDoubleCounter("tc_register_tensor_count");
+      storage_counter->Add(static_cast<double>(storage_entries.size()));
+      alias_counter->Add(static_cast<double>(alias_vec.size()));
+    } catch (...) {
+      VLOG(1) << "metrics counter tc_register_storage_count/tc_register_tensor_count unavailable";
+    }
+
     auto out_or = d_.lip.commit_lease_in_place(
         req.registration_id(),
         meta.device_id,
@@ -307,7 +399,9 @@ grpc::Status RegistrationController::commit(
         meta.total_size,
         meta.index_data,
         meta.index_key_hex,
-        std::move(lease_vec));
+        std::move(lease_vec),
+        std::move(storage_entries),
+        std::move(alias_vec));
     if (!out_or.ok()) {
       if (absl::IsAlreadyExists(out_or.status())) {
         try {

--- a/daemon/types.h
+++ b/daemon/types.h
@@ -34,6 +34,23 @@ struct LeaseSegMeta {
   uint64_t dst_offset{0}; // destination offset in coalesced buffer
 };
 
+struct RegisterStorageMeta {
+  std::string storage_id;
+  int device_id{0};
+  std::string handle_bytes;
+  uint64_t storage_length{0};
+};
+
+struct RegisterTensorAliasMeta {
+  std::string name;
+  std::string storage_id;
+  uint64_t storage_offset{0};
+  uint64_t logical_length{0};
+  std::vector<int64_t> shape;
+  std::vector<int64_t> stride;
+  std::string dtype;
+};
+
 // LIP Registry entry (post-Commit leases)
 struct LipLeaseEntry {
   std::string registration_id; // original registration id for keepalive/revoke
@@ -46,6 +63,8 @@ struct LipLeaseEntry {
   uint64_t total_size{0};
   std::string index_data; // canonical JSON (for verification hashing if needed)
   std::vector<LeaseSegMeta> segments; // mapped via cuda IPC when used
+  std::vector<RegisterStorageMeta> storages; // deduplicated storage entries
+  std::vector<RegisterTensorAliasMeta> aliases; // logical tensor metadata
   std::string verification_json; // optional stored verification metadata (JSON)
 };
 

--- a/docs/architecture/p2p-transfer-strategies.md
+++ b/docs/architecture/p2p-transfer-strategies.md
@@ -195,6 +195,7 @@ cursor.execute("""
 - **P2P path (synchronous in engine)**: `ingest_from_p2p_internal()` performs the transfer synchronously (waits for load to complete). On GPU memory pressure it attempts eviction and retries once. It then returns a `ReplicaHandle` with `ready_future` already resolved.
 - **Disk path**: `ingest_from_disk_internal()` starts an async load and waits until the target memory location reaches `LOADED` before returning. The returned `ReplicaHandle` includes the loading future (already completed on success) and CUDA IPC handle for GPU targets.
 - **Registration**: On successful P2P or disk load, the orchestrator finalizes the transport with Global Store and registers the local replica via the StoreEngine helper.
+- **Lease-in-place payloads**: Registration feeds now include `storage_entries` and `tensor_aliases` so the daemon can rebuild the canonical tensor index without reopening CUDA IPC handles for every tensor. Metrics (`tc_register_storage_count`, `tc_register_tensor_count`) expose the number of unique storages and logical tensors processed per commit to validate deduplication.
 - **Failure handling**: If a transport is granted but P2P ingestion fails, the orchestrator still calls `complete_replica_transport()` to release capacity on the source, then attempts disk fallback when `hints.disk_path` is provided. If no `disk_path` is available, the error is propagated.
 
 

--- a/docs/designs/0003-unified-memory-registration-avbs-lip.md
+++ b/docs/designs/0003-unified-memory-registration-avbs-lip.md
@@ -15,6 +15,7 @@ Core elements:
 - Unified identity: `mi2:` IDs computed over canonical index and AVBS bytes (with PAD=0) that are invariant across plans.
 - One RPC family for Begin/Feed/KeepAlive/Commit/Abort/Revoke across all plans.
 - Clear plan behaviors: Coalesced VRAM, Lease (materialize‑on‑Commit), and Lease‑In‑Place (LIP, ephemeral, TTL‑bound).
+- Registration payloads mirror the disk persistence pipeline so shared storages deduplicate to a single CUDA IPC handle and alias metadata stays consistent with Canonical Index v2.
 
 ## Implementation status (current release)
 
@@ -49,6 +50,12 @@ Non‑Goals
   - COALESCED_VRAM: Daemon‑owned contiguous GPU memory (zero‑copy via CUDA IPC on the same machine).
   - VRAM_LEASED: Lease plan materialized to daemon VRAM at Commit (`in_place=false`).
   - VRAM_LEASE_IN_PLACE (LIP): Ephemeral, post‑Commit lease over producer VRAM; TTL‑bound, PID‑owned; same‑device consumption disallowed.
+
+### Shared Storage Unification
+
+Registration now treats shared PyTorch storages the same way as the disk persistence path. A single helper surfaces unique storage descriptors alongside tensor alias metadata, so both flows reuse the same canonical introspection of storage identity, placement, and logical tensor views. The registration RPC payload carries those structures directly, which allows the daemon to open each CUDA IPC handle exactly once while preserving the canonical index ordering already validated by `save_dict`.
+
+This alignment eliminates redundant handle traffic from registration, keeps RPC payloads compact, and makes the canonical index reconstruction identical across live registration and disk artifacts. It also provides a stable place to enforce guardrails (storage/tensor consistency checks, address hashing) before the daemon commits replicas.
 
 ## SDK API (Python)
 
@@ -90,6 +97,7 @@ Key fields and behaviors
 - Feed for Lease provides `lease_segments(dst_offset,len,...)` covering DATA ranges; PAD is implicit and zero‑filled by the daemon.
 - KeepAlive requires `owner_pid` matching Begin; extends registration or LIP lease.
 - Commit computes `mi2:` over AVBS with PAD=0 and registers the replica type.
+- Feed now includes deduplicated storage descriptors plus tensor alias metadata, mirroring the disk pipeline so the daemon can rebuild the canonical index without inferring alias groups from raw segments.
 
 ## Data Plane & Materialization
 
@@ -210,6 +218,7 @@ Observability
 - Counters/latency for Begin, Feed, Commit, Abort, KeepAlive, Revoke.
 - Staging metrics: staged bytes, pool occupancy, release queues.
 - Lease/LIP: export/unlock totals, verification failures, TTL expirations, PID auto‑revokes.
+- Registration vs. disk parity: metrics track the ratio of unique storages to logical tensors and expose IPC open counts so rollout can confirm deduplication is active.
 
 Security & policy
 - Same‑process CUDA IPC fallback is disabled.

--- a/docs/internals/canonical-index.md
+++ b/docs/internals/canonical-index.md
@@ -1,0 +1,126 @@
+---
+title: Canonical Index Deep Dive
+description: Structural layout identity for TensorCast artifacts across disk, memory, and transport flows
+areas: ["core", "daemon", "global_store", "sdk"]
+---
+
+# Canonical Index Deep Dive
+
+This note consolidates everything in-tree about the canonical index (Index v2) that TensorCast relies on to make artifact identity, storage deduplication, and transport reproducibility work. It ties together the existing design docs (`docs/designs/0003-unified-memory-registration-avbs-lip.md`, `docs/designs/0007-content-addressed-artifact-id.md`, and `docs/designs/0014-store-session-api-modernization.md`), the core implementation in `core/store/loader`, and the SDK/daemon call paths that consume it today.
+
+```mermaid
+flowchart LR
+  A[User tensors<br>(PyTorch storages)] --> B[Index v2 builder<br>(SDK or daemon)]
+  B --> C[Canonical index bytes]
+  C --> D[Index multihash<br>(structural fingerprint)]
+  C --> E[Segment plan<br>(DATA + PAD)]
+  D --> F[mi2 artifact id]
+  E --> G[Transport sources<br>(disk, coalesced VRAM, LIP)]
+  G --> H[Consumers<br>(daemon, clients, remote nodes)]
+```
+
+## Why We Use a Canonical Index
+
+- **Stable structural identity.** The canonical index linearizes tensor layout—offset, size, shape, stride, dtype, storage offset—for every tensor in the artifact. The `index_multihash` over these bytes feeds the mi2 `artifact_id` (`docs/designs/0007-content-addressed-artifact-id.md`), guaranteeing that identical layouts across disk, lease-in-place (LIP), and coalesced VRAM flows collapse onto one identifier. This lets Global Store deduplicate replicas by structure alone before even looking at payload bytes.
+- **Re-hydration without ambiguity.** At load time the Store Engine rebuilds segment plans (`core/store/loader/segment_plan_source.cc`) directly from canonical index JSON/CBOR. This allows deterministic reconstruction of the Artifact Virtual Byte Stream (AVBS) and enables PAD-zeroing so that cross-device copies, padding gaps, and staged disk reloads remain consistent.
+- **Source-agnostic transport.** Whether bytes originate from disk partitions, daemon-owned coalesced VRAM, or CUDA IPC handles exported by a producer, the canonical index gives every consumer the same byte ranges to hash, copy, or verify. Without it, each transport would have to encode ad-hoc metadata about views, padding, and dtype ordering, undermining the unification promised in `docs/designs/0003-unified-memory-registration-avbs-lip.md`.
+
+## Schema and Invariants
+
+Index v2 encodes each tensor entry as `[offset, size, shape, stride, dtype, storage_offset]`, with the following rules enforced by `core/store/loader/canonical_index.cc`:
+
+- **Sorted keys.** Tensor names appear in ascending order. Builders sort explicitly (`tensorcast/api/_indices.py:135-150`, `daemon/lip_metadata_utils.cc:92`).
+- **Alignment.** `offset` values are 8-byte aligned; builders round up coalesced layouts when deduplicating storage ranges (`tensorcast/api/_indices.py:109-132`).
+- **Size semantics.** `size` is the total logical bytes occupied by the full storage, not the slice size of an alias. Multiple tensors that share a storage therefore emit identical `offset`/`size` pairs; the differentiator for views is only `storage_offset`.
+- **Shape/stride normalization.** Shapes and strides are serialized as unsigned 64-bit lists. Dtypes are lowercased internally to maintain deterministic ordering (`torch_dtype_code` helper).
+- **Storage offsets.** `storage_offset` captures each alias's view into the parent storage. When present, it must not push `storage_offset + size` past the storage boundary; both Python (`tensorcast/api/store.py` validation) and daemon (`daemon/lip_metadata_utils.cc:67-78`) enforce the bound.
+
+Together these invariants make the canonical index a pure description of *layout* rather than physical allocation. Physical placement is captured elsewhere (segment plans and CUDA IPC handles) while the index remains transport-neutral.
+
+## Memory Model Relationships
+
+### PyTorch storages, aliases, and Register metadata
+
+- **Storages.** The SDK gathers unique storages from the state_dict, deduplicating by `data_ptr` per device. During registration each storage becomes a `RegisterStorageMeta` (`daemon/types.h:43-58`) containing a storage ID, device, CUDA IPC handle bytes, and the storage-length in bytes.
+- **Aliases.** Each tensor alias carries `shape`, `stride`, `dtype`, and `storage_offset` (`RegisterTensorAliasMeta`). The alias refers back to its storage, which guarantees that views into a larger tensor are captured correctly.
+- **Lease segments.** When copying or hashing, the daemon works with `LeaseSegMeta` entries describing contiguous CUDA IPC ranges (`daemon/types.h:32-41`). These segments are stitched into the AVBS according to canonical index offsets.
+
+### Coalesced VRAM vs. user storage
+
+- **Coalesced plan (`put`).** For coalesced registrations (`tensorcast/api/store.py:1726-1791`), the SDK allocates a daemon-owned contiguous VRAM buffer and computes per-tensor destinations via `calculate_tensor_device_offsets` (`tensorcast/api/_indices.py:19-56`). That yields a new storage layout that still respects canonical index ordering. The canonical index recorded for the artifact uses the coalesced destination offsets while preserving alias metadata, so any later materialization reconstructs exactly what the daemon allocated.
+- **Lease-In-Place (LIP).** For LIP flows, the producer's storages remain authoritative. The daemon rebuilds the canonical index from alias+storage metadata (`daemon/lip_metadata_utils.cc`) and associates each storage with one destination offset derived from the segments it exports. Consumers later open CUDA IPC handles to map those physical ranges.
+
+## Build Paths
+
+### Disk save (`tensorcast.save_dict`)
+
+`tensorcast/csrc/checkpoint_py.cc` materializes canonical index bytes when persisting to disk:
+
+1. Replays the canonical ordering and writes `tensor_index.(json|cbor)`.
+2. Computes `index_multihash` from the canonical index and `data_multihash` from the normalized byte stream (`compute_data_multihash_from_seekable_source`).
+3. Emits `artifact_descriptor.json` embedding both hashes and the total size.
+
+Because the canonical index encodes the logical layout, on-disk partitions can be reshuffled or zero-padded without breaking identity; only the canonical offsets matter.
+
+### SDK registration (`put` / `register_artifact`)
+
+During registration (`tensorcast/api/_register.py`):
+
+1. `BuildContext.from_artifact` inspects tensors to produce `tensor_meta_index` and `tensor_source_index`.
+2. `calculate_tensor_device_offsets` computes coalesced destination offsets, deduplicating identical `(src_offset, size)` tuples so that shared storages reuse the same destination range.
+3. `build_v2_index_bytes` (`tensorcast/api/_indices.py:129-151`) emits canonical index bytes using the destination offsets (coalesced or lease-in-place depending on plan) but retains each alias's `storage_offset`.
+4. The SDK ships the canonical index bytes (or at least the multihash) along with storage and alias descriptors to the daemon, ensuring both sides agree on layout before any GPU copy begins.
+
+### Daemon reconstruction (LIP)
+
+When the daemon commits a LIP registration (`daemon/lip_manager.cc:490-610`):
+
+1. The commit RPC provides segments (CUDA IPC handles), storages, and aliases.
+2. `build_canonical_index_from_metadata` (`daemon/lip_metadata_utils.cc`) rebuilds the canonical index so hashing is authoritative server-side.
+3. The daemon opens CUDA IPC mappings, constructs a `SeekableSource` that stitches segments according to canonical offsets, zero-fills PAD gaps, and hashes the resulting stream to compute `data_multihash`.
+4. The resulting `index_multihash` determines whether an artifact already exists (`ArtifactDeviceKey` lookup) and whether deduplication or lease extension is possible.
+
+Canonical offsets depend only on storage identity, not per-alias offsets. The daemon mirrors the SDK by emitting storage-level destination offsets and full storage lengths for every alias, so view tensors hash identically across disk, coalesced, and LIP flows.
+
+## Global Store, Artifact Identity, and Deduplication
+
+- **Index caching.** The Global Store persists canonical index blobs keyed by `index_multihash` (`tensorcast/global_store/repositories/artifact_index_repository.py`). Replicas reference the stored key rather than duplicating the bytes.
+- **mi2 artifact IDs.** Commit-time multihashes produce the `mi2:` ID returned to clients and used as the primary key for replicas (`docs/designs/0007-content-addressed-artifact-id.md`). As long as canonical index bytes match, artifacts from disk, coalesced VRAM, and LIP share the same ID.
+- **Doc sync with Global Store.** When clients call `materialize_replica` or `get`, the Store Engine pulls canonical index bytes via `get_canonical_index_by_id` (`core/store/store_engine.cc:1649-1684`) to reconstruct the expected layout before deciding whether local replicas satisfy the request.
+
+## Materialization, Transport, and CUDA Memory
+
+- **SegmentPlan + PAD.** From the canonical index JSON, Store Engine builds a `SegmentPlan` (`core/store/loader/segment_plan_source.cc:18-72`). The plan outlines alternating DATA and PAD pieces, ensuring consumers zero-fill gaps consistently.
+- **Coalesced VRAM consumption.** Consumers opening a coalesced replica map exactly the daemon-allocated buffer using CUDA IPC. Because the canonical index encodes the buffer’s logical layout, tensors restored via `restore_tensors` mirror the original storages regardless of intermediate transfers.
+- **LIP consumption.** For lease-in-place replicas, the daemon refuses same-device consumption but can copy over NVLink/PCIe into a coalesced buffer on another device. The canonical index ensures that copy respects view offsets and pad gaps, so the resulting coalesced buffer hashes identically to the producer’s layout.
+- **Cross-node P2P.** When Global Store coordinates remote fetches, the sending daemon reads its replica using canonical offsets (coalesced VRAM or disk) and streams DATA segments to the receiver. Because both sides share the canonical index, the receiver knows exactly how to populate its local buffer and can perform verification using the same offsets.
+
+## Cross-Process and Cross-Node Consistency
+
+- **CUDA IPC invariants.** `LeaseSegMeta` and `RegisterStorageMeta` tie canonical offsets to CUDA IPC handles. The daemon verifies that each alias fits within its storage bounds before accepting the registration (`daemon/lip_metadata_utils.cc:67-78`), preventing mismatched offsets from propagating.
+- **Process isolation.** Consumers never see producer-specific addresses. Canonical offsets are relative to the AVBS, while actual IPC mappings are per-process resources managed inside the daemon (`daemon/lip_manager.cc:520-610`).
+- **Cross-node transmissions.** The `SegmentPlan` is agnostic to transport; PAD segments become ranges of zeros, while DATA segments are serialized in the same order independent of source. This uniformity allows hashing and verification to be identical whether bytes came from disk partitions (`tensorcast/csrc/checkpoint_py.cc:316-403`), local GPU memory (`core/store/loader/segment_plan_source.cc:74-146`), or remote daemons.
+
+## Current Gaps and Risks
+
+- **Canonical offset drift.** Deduplication relies on every path emitting storage-level destination offsets and storage lengths for each alias. Keep conformance tests between SDK and daemon builders so future edits preserve the shared-storage invariant.
+- **Split authority.** Python builds canonical index bytes during registration, while the daemon rebuilds them from metadata. Divergence in either direction (field ordering, offset arithmetic, numeric width) silently corrupts deduplication. Long-term mitigation is to share a single builder implementation (e.g., extend `core/store/loader` with a helper that accepts storage + alias spans) and reuse it in both places.
+- **Padding assumptions.** Every consumer assumes PAD ranges are zero. If producers materialize artifacts with uninitialized memory and rely on PAD to be copied through, verification will fail. Documentation and guardrails should make this explicit.
+- **Device mismatch.** LIP commits currently rely on the caller to send accurate `device_id` for storages. If a storage is registered on the wrong device, CUDA IPC mapping can succeed but later P2P copies may degrade or fail. Enhancements could include hashing `(device_id, handle_bytes)` to detect device drift early.
+- **Global Store consistency.** The Global Store treats `index_multihash` as the canonical key. If we ever emit mismatched canonical index bytes for the same artifact (e.g., due to SDK vs. daemon drift), cached copies become poisoned. Automated validation comparing client-sent index bytes with the daemon-rebuilt version can mitigate this risk; current code only logs a warning (`daemon/lip_manager.cc:498-505`).
+
+## Recommended Practices
+
+1. **Guard storage-level offset invariants.** Keep regression tests and CI checks that compare daemon-built indices with SDK output so shared storages continue to yield identical offset/size pairs.
+2. **Centralize canonical index construction.** Expose a C++ helper in `core/store/loader` that accepts ordered storages, aliases, and destination offsets; bind it for Python so the SDK and daemon call the same implementation.
+3. **Extend test coverage.** Add end-to-end tests covering: shared storage views, zero-sized tensors, multi-device artifacts, and PAD-heavy layouts. Verify that disk save, coalesced registration, and LIP registration yield identical canonical index hashes.
+4. **Strengthen observability.** Surface metrics for canonical index cache hits/misses (`tensorcast/global_store/grpc_service.py:297-534`) and mismatches detected during daemon rebuild. Alert when deduplication fails unexpectedly.
+5. **Document PAD semantics for users.** Ensure SDK and user guides make it clear that PAD bytes are always treated as zeros and will not survive round trips unless explicitly part of storage data.
+
+## References
+
+- Canonical index builders: `core/store/loader/canonical_index.{h,cc}`, `tensorcast/api/_indices.py`, `daemon/lip_metadata_utils.cc`
+- Hashing & segment plans: `core/store/loader/segment_plan_source.cc`, `tensorcast/csrc/checkpoint_py.cc`
+- Registration flows: `tensorcast/api/_register.py`, `tensorcast/api/store.py`
+- Lease management: `daemon/lip_manager.cc`, `daemon/types.h`
+- Design background: `docs/designs/0003-unified-memory-registration-avbs-lip.md`, `docs/designs/0007-content-addressed-artifact-id.md`, `docs/designs/0014-store-session-api-modernization.md`

--- a/docs/internals/model-loading.md
+++ b/docs/internals/model-loading.md
@@ -105,6 +105,12 @@ sequenceDiagram
   - SDK already computes a coalesced layout and sets `dst_offset` per unique storage block.
   - Ordering no longer matters, but the SDK still sorts for stable traces.
 
+### Shared Storage Graph Helper
+
+- SDK registration flows call `tensorcast.api._tensor_graph.build_tensor_storage_graph()` before feeding lease segments.
+- The helper deduplicates `torch.Storage` objects and emits a `TensorStorageGraph` containing `StorageEntry` rows (unique storage id, device id, base pointer, storage length) plus `TensorAlias` metadata (tensor name, storage id, storage offset, logical byte length, shape, stride, dtype).
+- Clients transmit the deduplicated storage table via `storage_entries` and alias metadata via `tensor_aliases`. The daemon reconstructs canonical index JSON from these structures, producing byte-for-byte parity with disk persistence and opening each CUDA IPC handle only once per unique storage.
+
 Recommended: rely on `tensorcast.register(...)` (or `register_async`) with
 `RegisterArtifactOptions(lease_in_place=True)` and an explicit `ttl_ms`. The Store
 manages keepalives automatically and surfaces the committed descriptor through the

--- a/docs/internals/save_dict_flow.md
+++ b/docs/internals/save_dict_flow.md
@@ -111,7 +111,13 @@ All three tensors share the same storage but have different shapes/strides/stora
 
 ---
 
-## 7. Related Documentation
+## 7. Registration Payload Parity
+
+- Lease-in-place registration reuses the same deduplicated storage metadata produced by `build_tensor_storage_graph()`.
+- Clients transmit `storage_entries` (unique storage handle + device + length) and `tensor_aliases` (tensor name, storage id, offset, logical length, shape, stride, dtype) alongside the canonical index bytes.
+- The daemon rebuilds canonical index JSON using this metadata, guaranteeing byte-for-byte parity with the disk writer and ensuring each CUDA IPC handle is opened once per storage.
+
+## 8. Related Documentation
 
 * Checkpoint architecture details – `core/checkpoint/docs/architecture.md`
 * Verification integration – `core/checkpoint/docs/verification-integration.md`

--- a/proto/tensorcast/daemon/v1/store_daemon.proto
+++ b/proto/tensorcast/daemon/v1/store_daemon.proto
@@ -401,6 +401,10 @@ message FeedRegisterArtifactStreamRequest {
   oneof feed {
     LeaseSegments lease_segments = 11;
   }
+  // Optional deduplicated storage table and tensor alias metadata. Clients send
+  // these fields when using the unified registration flow; legacy clients omit them.
+  repeated StorageEntry storage_entries = 20;
+  repeated TensorAlias tensor_aliases = 21;
 }
 message FeedRegisterArtifactStreamResponse {}
 
@@ -415,6 +419,23 @@ message LeasedSegment {
   // Destination offset in the coalesced VRAM buffer (bytes).
   // This locates the DATA interval within the SegmentPlan; PAD is handled by the daemon.
   uint64 dst_offset = 5;
+}
+
+message StorageEntry {
+  string storage_id = 1;
+  int32 device_id = 2;
+  bytes cuda_ipc_handle = 3;
+  uint64 storage_length = 4;
+}
+
+message TensorAlias {
+  string name = 1;
+  string storage_id = 2;
+  uint64 storage_offset = 3;
+  uint64 logical_length = 4;
+  repeated int64 shape = 5;
+  repeated int64 stride = 6;
+  string dtype = 7;
 }
 
 // Keep alive for lease lifecycle

--- a/tensorcast/api/README.md
+++ b/tensorcast/api/README.md
@@ -1,0 +1,31 @@
+# TensorCast Python API
+
+The `tensorcast.api` package exposes the high-level registration and loading
+helpers that SDK integrations use during artifact lifecycle management.
+
+## Tensor Storage Graph Helper
+
+`build_tensor_storage_graph()` inspects a `dict[str, torch.Tensor]` and returns
+a `TensorStorageGraph` containing:
+
+- **storages** – one `StorageEntry` per unique `torch.Storage` (deduped by
+  device id, base pointer, and storage length).
+- **aliases** – per logical tensor metadata (shape, stride, dtype, storage
+  offset, logical byte length) keyed by tensor name.
+- **tensor_meta_index / tensor_source_index** – canonical metadata reused by
+  both disk persistence and lease-in-place registration.
+
+Invariants guaranteed by the helper:
+
+- All CUDA tensors in the input must reside on the same device; the helper
+  records the device id for each storage and raises on mismatches.
+- Storage identifiers are deterministic and stable for the lifetime of the
+  process, enabling clients to sort and reference storage groups.
+- The aliases map preserves every tensor key from the input dict; consumers
+  can rebuild canonical index JSON by combining alias metadata with the device
+  offsets supplied by layout planners.
+
+Clients must invoke this helper before feeding lease segments so they can send
+the deduplicated storage table alongside per-tensor aliases. The daemon uses
+these structures to rebuild canonical indices and avoid repeated CUDA IPC
+opens for shared storages.

--- a/tensorcast/api/_config.py
+++ b/tensorcast/api/_config.py
@@ -99,3 +99,18 @@ class GetArtifactOptions:
     pinned_allocation_timeout_ms: int = DEFAULT_PINNED_TIMEOUT_MS
     wait_for_completion: bool = True
     enable_verification: bool = True
+
+
+__all__ = [
+    "DEFAULT_ALIGN",
+    "DEFAULT_PINNED_TIMEOUT_MS",
+    "GetArtifactOptions",
+    "PlanType",
+    "RegisterArtifactOptions",
+    "clear_daemon_address",
+    "get_daemon_address",
+    "get_global_store_address",
+    "has_daemon_address",
+    "set_daemon_address",
+    "set_global_store_address",
+]

--- a/tensorcast/api/_io_disk.py
+++ b/tensorcast/api/_io_disk.py
@@ -11,6 +11,7 @@ from tensorcast._C import restore_tensors_from_disk, save_model_to_disk
 
 from ._device import resolve_device
 from ._indices import calculate_tensor_device_offsets, load_tensor_indices_from_dir
+from ._tensor_graph import build_tensor_storage_graph
 
 
 def save_dict(
@@ -30,17 +31,19 @@ def save_dict(
         A descriptor dict with artifact_id, index_multihash, data_multihash,
         schema_version, encoding, and total_size.
     """
-    tensor_names = sorted(state_dict.keys())
-    tensor_data_index: dict[str, tuple[int, int]] = {}
+    graph = build_tensor_storage_graph(state_dict)
+    tensor_names = sorted(graph.aliases.keys())
+    tensor_data_index: dict[str, tuple[int, int]] = {
+        name: graph.tensor_source_index[name] for name in tensor_names
+    }
     meta_state_dict: dict[str, tuple[list[int], list[int], str, int]] = {}
-    for name, param in state_dict.items():
-        storage = param.untyped_storage()
-        tensor_data_index[name] = (int(storage.data_ptr()), int(storage.size()))
+    for name in tensor_names:
+        alias = graph.aliases[name]
         meta_state_dict[name] = (
-            list(map(int, param.shape)),
-            list(map(int, param.stride())),
-            str(param.dtype),
-            int(param.storage_offset()),
+            list(alias.shape),
+            list(alias.stride),
+            alias.dtype,
+            int(alias.storage_offset),
         )
 
     config = streaming_config or {}

--- a/tensorcast/api/_register.py
+++ b/tensorcast/api/_register.py
@@ -23,6 +23,7 @@ from tensorcast._C import (
     restore_tensors,
 )
 from tensorcast.api._indices import calculate_tensor_device_offsets
+from tensorcast.api._tensor_graph import TensorStorageGraph, build_tensor_storage_graph
 
 if TYPE_CHECKING:  # for static type checkers only
     from tensorcast.daemon_ctl import DaemonCtl
@@ -51,6 +52,8 @@ from tensorcast.types import (
     Handshake,
     LeasePlan,
     LeaseSegment,
+    RegisterStorage,
+    RegisterTensorAlias,
 )
 
 # Internal alignment hint for layout computation.
@@ -335,11 +338,13 @@ class BuildContext:
         input_mode: str,
         tensor_meta_index: TensorMetaIndex,
         tensor_source_index: TensorDataIndex,
+        storage_graph: TensorStorageGraph,
     ) -> None:
         self.device_id = int(device_id)
         self.input_mode = input_mode  # "cpu" or "cuda"
         self.tensor_meta_index = tensor_meta_index
         self.tensor_source_index = tensor_source_index
+        self.storage_graph = storage_graph
 
     @staticmethod
     def from_artifact(
@@ -374,23 +379,21 @@ class BuildContext:
                     )
             input_mode = "cpu"
 
-        tensor_meta_index: TensorMetaIndex = {}
-        tensor_source_index: TensorDataIndex = {}
-        for name, t in artifact.items():
-            storage = t.untyped_storage()
-            tensor_source_index[name] = (int(storage.data_ptr()), int(storage.size()))
-            tensor_meta_index[name] = (
-                list(map(int, t.shape)),
-                list(map(int, t.stride())),
-                str(t.dtype),
-                int(t.storage_offset()),
-            )
+        storage_graph = build_tensor_storage_graph(artifact)
+        if input_mode == "cuda":
+            for entry in storage_graph.storages.values():
+                if entry.device_id != target_device_id:
+                    raise DeviceMismatch(
+                        f"Tensor storage device mismatch: expected cuda:{target_device_id}, "
+                        f"got {entry.device_id}"
+                    )
 
         return BuildContext(
             device_id=target_device_id,
             input_mode=input_mode,
-            tensor_meta_index=tensor_meta_index,
-            tensor_source_index=tensor_source_index,
+            tensor_meta_index=storage_graph.tensor_meta_index,
+            tensor_source_index=storage_graph.tensor_source_index,
+            storage_graph=storage_graph,
         )
 
 
@@ -554,26 +557,84 @@ class _LeaseUploader:
         def _export_cuda_ipc_handle(ptr: int) -> bytes:
             return get_cuda_memory_handle(ctx.device_id, int(ptr))
 
-        segments: list[LeaseSegment] = []
-        chunks = list(layout.unique_chunks)
-        chunks.sort(key=lambda x: int(x[2]))
-        for src_off, size_bytes, dst_off, _stream in chunks:
+        graph = ctx.storage_graph
+        offsets_for_device = layout.offsets.get(int(ctx.device_id), {})
+        if not offsets_for_device:
+            raise TensorCastError(
+                f"No layout offsets recorded for device {ctx.device_id} during lease registration"
+            )
+
+        storage_to_dst: dict[str, int] = {}
+        aliases_payload: list[RegisterTensorAlias] = []
+        for name in sorted(graph.aliases.keys()):
+            alias = graph.aliases[name]
             if cancel_event and cancel_event.is_set():
                 raise CancelledError
-            handle_bytes = _export_cuda_ipc_handle(int(src_off))
+            if name not in offsets_for_device:
+                raise TensorCastError(
+                    f"Missing layout offset for tensor '{name}' in lease plan"
+                )
+            dst_offset = int(offsets_for_device[name])
+            storage_to_dst.setdefault(alias.storage_id, dst_offset)
+            aliases_payload.append(
+                RegisterTensorAlias(
+                    name=alias.name,
+                    storage_id=alias.storage_id,
+                    storage_offset=int(alias.storage_offset),
+                    logical_length=int(alias.logical_length),
+                    shape=list(alias.shape),
+                    stride=list(alias.stride),
+                    dtype=alias.dtype,
+                )
+            )
+
+        segments: list[LeaseSegment] = []
+        storages_payload: list[RegisterStorage] = []
+        for storage_id in sorted(graph.storages.keys()):
+            if cancel_event and cancel_event.is_set():
+                raise CancelledError
+            entry = graph.storages[storage_id]
+            if entry.device_id != int(ctx.device_id):
+                raise DeviceMismatch(
+                    f"Storage '{storage_id}' device mismatch: expected cuda:{ctx.device_id}, got {entry.device_id}"
+                )
+            dst_offset = storage_to_dst[storage_id]
+            handle_bytes = _export_cuda_ipc_handle(int(entry.base_ptr))
+            length_bytes = int(entry.size_bytes)
             segments.append(
                 LeaseSegment(
                     device_id=int(ctx.device_id),
                     cuda_ipc_handle=handle_bytes,
                     base_addr=0,
-                    length=int(size_bytes),
-                    dst_offset=int(dst_off),
+                    length=length_bytes,
+                    dst_offset=int(dst_offset),
                 )
+            )
+            storages_payload.append(
+                RegisterStorage(
+                    storage_id=storage_id,
+                    device_id=int(ctx.device_id),
+                    cuda_ipc_handle=handle_bytes,
+                    storage_length=length_bytes,
+                )
+            )
+        if not storages_payload:
+            raise TensorCastError(
+                "No storage entries resolved during lease registration; artifact tensors must supply shared storage metadata"
+            )
+        if not aliases_payload:
+            raise TensorCastError(
+                "No tensor aliases resolved during lease registration; artifact tensors must supply alias metadata"
             )
         if cancel_event and cancel_event.is_set():
             raise CancelledError
         ctl = handle.client
-        ok = ctl.feed_register_artifact_lease_segments(handle.registration_id, segments)
+        ok = ctl.feed_register_artifact_lease_segments(
+            handle.registration_id,
+            segments,
+            storages=storages_payload,
+            tensor_aliases=aliases_payload,
+        )
         if not ok:
             raise FeedFailed("Lease segments feed failed")
         return artifact

--- a/tensorcast/api/_tensor_graph.py
+++ b/tensorcast/api/_tensor_graph.py
@@ -1,0 +1,104 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+import torch
+
+from tensorcast._C import collect_tensor_storage_graph
+from tensorcast.api._indices import TensorDataIndex, TensorMetaIndex
+
+
+@dataclass(frozen=True)
+class StorageEntry:
+    storage_id: str
+    device_id: int
+    base_ptr: int
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class TensorAlias:
+    name: str
+    storage_id: str
+    storage_offset: int
+    logical_length: int
+    shape: list[int]
+    stride: list[int]
+    dtype: str
+
+
+@dataclass(frozen=True)
+class TensorStorageGraph:
+    storages: Dict[str, StorageEntry]
+    aliases: Dict[str, TensorAlias]
+    tensor_meta_index: TensorMetaIndex
+    tensor_source_index: TensorDataIndex
+
+
+def build_tensor_storage_graph(
+    tensors: Mapping[str, torch.Tensor],
+) -> TensorStorageGraph:
+    tensor_dict = dict(tensors)
+    storages: Dict[str, StorageEntry] = {}
+    aliases: Dict[str, TensorAlias] = {}
+    tensor_meta_index: TensorMetaIndex = {}
+    tensor_source_index: TensorDataIndex = {}
+
+    native_graph = collect_tensor_storage_graph(tensor_dict)
+    native_storages = native_graph.get("storages", {})
+    native_aliases = native_graph.get("aliases", {})
+    native_meta = native_graph.get("tensor_meta_index", {})
+    native_sources = native_graph.get("tensor_source_index", {})
+
+    for storage_id, payload in native_storages.items():
+        device_id = int(payload["device_id"])
+        base_ptr = int(payload["base_ptr"])
+        size_bytes = int(payload["size_bytes"])
+        storages[storage_id] = StorageEntry(
+            storage_id=storage_id,
+            device_id=device_id,
+            base_ptr=base_ptr,
+            size_bytes=size_bytes,
+        )
+
+    for name, payload in native_aliases.items():
+        aliases[name] = TensorAlias(
+            name=name,
+            storage_id=str(payload["storage_id"]),
+            storage_offset=int(payload["storage_offset"]),
+            logical_length=int(payload["logical_length"]),
+            shape=[int(v) for v in payload["shape"]],
+            stride=[int(v) for v in payload["stride"]],
+            dtype=str(payload["dtype"]),
+        )
+
+    for name, tup in native_meta.items():
+        shape, stride, dtype, storage_offset = tup
+        tensor_meta_index[name] = (
+            [int(v) for v in shape],
+            [int(v) for v in stride],
+            str(dtype),
+            int(storage_offset),
+        )
+
+    for name, tup in native_sources.items():
+        base_ptr, size_bytes = tup
+        tensor_source_index[name] = (int(base_ptr), int(size_bytes))
+
+    return TensorStorageGraph(
+        storages=storages,
+        aliases=aliases,
+        tensor_meta_index=tensor_meta_index,
+        tensor_source_index=tensor_source_index,
+    )
+
+
+__all__ = [
+    "StorageEntry",
+    "TensorAlias",
+    "TensorStorageGraph",
+    "build_tensor_storage_graph",
+]

--- a/tensorcast/csrc/checkpoint_py.cc
+++ b/tensorcast/csrc/checkpoint_py.cc
@@ -25,6 +25,9 @@
 #include <vector>
 
 #include <nlohmann/json.hpp>
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "core/common/artifact_verification.h"
 #include "core/store/loader/canonical_index.h"
 #include "core/store/loader/file_partition_source.h"
@@ -542,6 +545,100 @@ static py::dict inspect_or_generate_descriptor_wrapper(const std::string& path) 
   return result;
 }
 
+namespace {
+
+struct StorageAccumulator {
+  int device_id;
+  uint64_t base_ptr;
+  uint64_t size_bytes;
+};
+
+std::string make_storage_id(int device_id, uint64_t base_ptr, uint64_t size_bytes) {
+  return absl::StrFormat("%d:%016x:%016x", device_id, base_ptr, size_bytes);
+}
+
+} // namespace
+
+static py::dict collect_tensor_storage_graph(const py::dict& tensors) {
+  absl::flat_hash_map<std::string, StorageAccumulator> storage_map;
+  py::dict aliases;
+  py::dict tensor_meta_index;
+  py::dict tensor_source_index;
+
+  for (auto item : tensors) {
+    const std::string name = py::cast<std::string>(item.first);
+    py::handle tensor_obj = item.second;
+    at::Tensor tensor = tensor_obj.cast<at::Tensor>();
+    if (!tensor.defined()) {
+      PY_THROW_WITH_LOG(PyExc_ValueError, absl::StrCat("Tensor for '", name, "' is not defined"));
+    }
+
+    int device_id = -1;
+    if (tensor.is_cuda()) {
+      device_id = tensor.get_device();
+    } else if (!tensor.device().is_cpu()) {
+      PY_THROW_WITH_LOG(
+          PyExc_ValueError, absl::StrCat("Unsupported device for tensor '", name, "': ", tensor.device().str()));
+    }
+
+    const uint64_t storage_offset = static_cast<uint64_t>(tensor.storage_offset());
+    auto storage = tensor.storage();
+    auto* storage_impl = storage.unsafeGetStorageImpl();
+    if (storage_impl == nullptr) {
+      PY_THROW_WITH_LOG(PyExc_RuntimeError, absl::StrCat("Missing storage for tensor '", name, "'"));
+    }
+    const uint64_t base_ptr = reinterpret_cast<uint64_t>(storage_impl->data_ptr().get());
+    const uint64_t storage_size_bytes = static_cast<uint64_t>(storage_impl->nbytes());
+    const uint64_t logical_length = static_cast<uint64_t>(tensor.nbytes());
+    const std::string storage_id = make_storage_id(device_id, base_ptr, storage_size_bytes);
+
+    storage_map.try_emplace(
+        storage_id, StorageAccumulator{.device_id = device_id, .base_ptr = base_ptr, .size_bytes = storage_size_bytes});
+
+    std::vector<int64_t> shape_vec(tensor.sizes().begin(), tensor.sizes().end());
+    std::vector<int64_t> stride_vec(tensor.strides().begin(), tensor.strides().end());
+    py::list shape_py;
+    py::list stride_py;
+    for (auto v : shape_vec) {
+      shape_py.append(static_cast<int64_t>(v));
+    }
+    for (auto v : stride_vec) {
+      stride_py.append(static_cast<int64_t>(v));
+    }
+    std::string dtype_str = py::str(tensor_obj.attr("dtype")).cast<std::string>();
+
+    py::dict alias_entry;
+    alias_entry["name"] = name;
+    alias_entry["storage_id"] = storage_id;
+    alias_entry["storage_offset"] = storage_offset;
+    alias_entry["logical_length"] = logical_length;
+    alias_entry["shape"] = shape_py;
+    alias_entry["stride"] = stride_py;
+    alias_entry["dtype"] = dtype_str;
+    aliases[name.c_str()] = alias_entry;
+
+    tensor_meta_index[name.c_str()] = py::make_tuple(shape_py, stride_py, dtype_str, storage_offset);
+    tensor_source_index[name.c_str()] = py::make_tuple(static_cast<uint64_t>(base_ptr), storage_size_bytes);
+  }
+
+  py::dict storages;
+  for (const auto& [storage_id, entry] : storage_map) {
+    py::dict storage_entry;
+    storage_entry["storage_id"] = storage_id;
+    storage_entry["device_id"] = entry.device_id;
+    storage_entry["base_ptr"] = py::int_(entry.base_ptr);
+    storage_entry["size_bytes"] = py::int_(entry.size_bytes);
+    storages[storage_id.c_str()] = storage_entry;
+  }
+
+  py::dict result;
+  result["storages"] = storages;
+  result["aliases"] = aliases;
+  result["tensor_meta_index"] = tensor_meta_index;
+  result["tensor_source_index"] = tensor_source_index;
+  return result;
+}
+
 // ------------------------------------------------------------------
 // Expose canonical index builder for safetensors directories
 // ------------------------------------------------------------------
@@ -656,7 +753,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("memory_size"),
           py::arg("expected_verification"),
           py::arg("verification_level"),
-          "Verify artifact data integrity from GPU memory");
+          "Verify artifact data integrity from GPU memory")
+      .def(
+          "collect_tensor_storage_graph",
+          &collect_tensor_storage_graph,
+          py::arg("tensors"),
+          "Collect deduplicated storage metadata and tensor alias information");
 
   m.def(
       "inspect_or_generate_descriptor",

--- a/tensorcast/daemon_ctl.py
+++ b/tensorcast/daemon_ctl.py
@@ -31,6 +31,8 @@ from tensorcast.types import (
     LeaseHandshake,
     LeaseSegment,
     Plan,
+    RegisterStorage,
+    RegisterTensorAlias,
     ServerConfig,
 )
 
@@ -830,7 +832,12 @@ class DaemonCtl:
     # ------------------------------------------------------------------
 
     def feed_register_artifact_lease_segments(
-        self, registration_id: str, segments: list[LeaseSegment]
+        self,
+        registration_id: str,
+        segments: list[LeaseSegment],
+        *,
+        storages: list["RegisterStorage"] | None = None,
+        tensor_aliases: list["RegisterTensorAlias"] | None = None,
     ) -> bool:
         # Stream lease segments via FeedRegisterArtifactStream
         def _iter():
@@ -844,6 +851,23 @@ class DaemonCtl:
                 seg.base_addr = int(s.base_addr)
                 seg.length = int(s.length)
                 seg.dst_offset = int(s.dst_offset)
+            if storages:
+                for storage in storages:
+                    entry = req.storage_entries.add()
+                    entry.storage_id = storage.storage_id
+                    entry.device_id = int(storage.device_id)
+                    entry.cuda_ipc_handle = storage.cuda_ipc_handle
+                    entry.storage_length = int(storage.storage_length)
+            if tensor_aliases:
+                for alias in tensor_aliases:
+                    dst = req.tensor_aliases.add()
+                    dst.name = alias.name
+                    dst.storage_id = alias.storage_id
+                    dst.storage_offset = int(alias.storage_offset)
+                    dst.logical_length = int(alias.logical_length)
+                    dst.shape.extend(int(v) for v in alias.shape)
+                    dst.stride.extend(int(v) for v in alias.stride)
+                    dst.dtype = alias.dtype
             yield req
 
         try:

--- a/tensorcast/types.py
+++ b/tensorcast/types.py
@@ -159,6 +159,31 @@ class LeaseSegment(BaseModel):
     dst_offset: int
 
 
+class RegisterStorage(BaseModel):
+    """Deduplicated storage descriptor used during registration feeds."""
+
+    model_config = ConfigDict(frozen=True)
+
+    storage_id: str
+    device_id: int
+    cuda_ipc_handle: bytes
+    storage_length: int
+
+
+class RegisterTensorAlias(BaseModel):
+    """Logical tensor metadata referencing a deduplicated storage."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    storage_id: str
+    storage_offset: int
+    logical_length: int
+    shape: list[int]
+    stride: list[int]
+    dtype: str
+
+
 __all__ = [
     "ServerConfig",
     "CoalescedHandshake",
@@ -172,4 +197,6 @@ __all__ = [
     "LeasePlan",
     "Plan",
     "LeaseSegment",
+    "RegisterStorage",
+    "RegisterTensorAlias",
 ]

--- a/tests/python/daemon/test_cpp_daemon_lifecycle.py
+++ b/tests/python/daemon/test_cpp_daemon_lifecycle.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2025, TensorCast Team.
 
-# Copyright (c) 2025, TensorCast Team.
-
 """
 Integration test for the C++ StoreDaemon lifecycle with Global Store.
 

--- a/tests/python/test_tensor_storage_graph.py
+++ b/tests/python/test_tensor_storage_graph.py
@@ -1,0 +1,151 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+import re
+from typing import Iterable
+
+import torch
+import pytest
+
+from tensorcast.api._tensor_graph import build_tensor_storage_graph
+
+
+def _assert_group_shares_storage(graph, names: Iterable[str]) -> str:
+    group_ids = {graph.aliases[name].storage_id for name in names}
+    assert len(group_ids) == 1, f"Expected {names} to share storage, got ids={group_ids}"
+    return next(iter(group_ids))
+
+
+def test_build_tensor_storage_graph_complex_layout():
+    # Shared CPU tensors with various views/slices/transposes
+    cpu_base = torch.arange(0, 64, dtype=torch.float32).reshape(8, 8)
+    cpu_view_perm = cpu_base.t()
+    cpu_slice = cpu_base[:, 2:6]
+    cpu_narrow = cpu_base.reshape(4, 16)[1]
+
+    # Independent CPU tensors with different dtypes
+    cpu_independent = torch.ones(10, dtype=torch.float32) * 3.14
+    cpu_int = torch.arange(0, 32, dtype=torch.int16)
+    cpu_int_view = cpu_int.view(4, 8)
+
+    tensors: dict[str, torch.Tensor] = {
+        "cpu_base": cpu_base,
+        "cpu_view_perm": cpu_view_perm,
+        "cpu_slice": cpu_slice,
+        "cpu_narrow": cpu_narrow,
+        "cpu_independent": cpu_independent,
+        "cpu_int": cpu_int,
+        "cpu_int_view": cpu_int_view,
+    }
+
+    # Optional GPU tensors if CUDA available
+    if torch.cuda.is_available():
+        device = torch.device("cuda", torch.cuda.current_device())
+        gpu_base = torch.linspace(0, 1, steps=48, device=device, dtype=torch.float16)
+        gpu_view = gpu_base.view(12, 4)
+        gpu_slice = gpu_base[8:32]
+        tensors.update(
+            {
+                "gpu_base": gpu_base,
+                "gpu_view": gpu_view,
+                "gpu_slice": gpu_slice,
+            }
+        )
+
+    graph = build_tensor_storage_graph(tensors)
+
+    assert set(graph.aliases.keys()) == set(tensors.keys())
+
+    # Validate CPU shared storage group
+    cpu_shared_id = _assert_group_shares_storage(
+        graph, ["cpu_base", "cpu_view_perm", "cpu_slice", "cpu_narrow"]
+    )
+    cpu_storage_entry = graph.storages[cpu_shared_id]
+    assert cpu_storage_entry.device_id == -1
+    assert cpu_storage_entry.size_bytes == cpu_base.untyped_storage().nbytes()
+    assert re.match(r"^-?[\d]+:[0-9a-f]{16}:[0-9a-f]{16}$", cpu_shared_id)
+
+    # Validate independent CPU tensors do not share storage
+    independent_ids = {
+        graph.aliases["cpu_independent"].storage_id,
+        graph.aliases["cpu_int"].storage_id,
+    }
+    assert cpu_shared_id not in independent_ids
+    assert len(independent_ids) == 2
+    assert (
+        graph.storages[graph.aliases["cpu_independent"].storage_id].size_bytes
+        == cpu_independent.untyped_storage().nbytes()
+    )
+
+    # Validate integer tensor view shares storage with base
+    int_shared_id = _assert_group_shares_storage(graph, ["cpu_int", "cpu_int_view"])
+    assert int_shared_id != cpu_shared_id
+    assert graph.storages[int_shared_id].size_bytes == cpu_int.untyped_storage().nbytes()
+
+    # Validate tensor_meta_index mirrors tensor attributes
+    for name, tensor in tensors.items():
+        shape, stride, dtype, storage_offset = graph.tensor_meta_index[name]
+        assert shape == list(tensor.shape)
+        assert stride == list(tensor.stride())
+        assert dtype == str(tensor.dtype)
+        assert storage_offset == tensor.storage_offset()
+
+    # Validate tensor_source_index points to the correct storage base pointer
+    for group in [["cpu_base", "cpu_view_perm", "cpu_slice", "cpu_narrow"], ["cpu_int", "cpu_int_view"]]:
+        sources = {graph.tensor_source_index[name] for name in group}
+        assert len(sources) == 1
+
+    assert graph.tensor_source_index["cpu_independent"] != graph.tensor_source_index["cpu_base"]
+
+    if torch.cuda.is_available():
+        gpu_group_id = _assert_group_shares_storage(
+            graph, ["gpu_base", "gpu_view", "gpu_slice"]
+        )
+        gpu_entry = graph.storages[gpu_group_id]
+        assert gpu_entry.device_id == torch.cuda.current_device()
+        assert gpu_entry.size_bytes == tensors["gpu_base"].untyped_storage().nbytes()
+        gpu_sources = {graph.tensor_source_index[name] for name in ["gpu_base", "gpu_view", "gpu_slice"]}
+        assert len(gpu_sources) == 1
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_tensor_storage_graph_cuda_only_groups():
+    device = torch.device("cuda", torch.cuda.current_device())
+    base = torch.randn(256, dtype=torch.float16, device=device)
+    view = base.view(64, 4)
+    slice_a = base[16:128]
+    slice_b = base[32:192:2]
+    reshape_view = base.reshape(32, 8)
+    independent = torch.ones(32, dtype=torch.float16, device=device)
+
+    tensors = {
+        "base": base,
+        "view": view,
+        "slice_a": slice_a,
+        "slice_b": slice_b,
+        "reshape_view": reshape_view,
+        "independent": independent,
+    }
+    graph = build_tensor_storage_graph(tensors)
+
+    shared_id = _assert_group_shares_storage(
+        graph, ["base", "view", "slice_a", "slice_b", "reshape_view"]
+    )
+    storage_entry = graph.storages[shared_id]
+    assert storage_entry.device_id == torch.cuda.current_device()
+    assert storage_entry.size_bytes == base.untyped_storage().nbytes()
+
+    independent_id = graph.aliases["independent"].storage_id
+    assert independent_id != shared_id
+    assert (
+        graph.storages[independent_id].size_bytes == independent.untyped_storage().nbytes()
+    )
+
+    shared_offsets = {graph.tensor_source_index[name] for name in tensors if name != "independent"}
+    assert len(shared_offsets) == 1
+
+    for name, tensor in tensors.items():
+        shape, stride, dtype, storage_offset = graph.tensor_meta_index[name]
+        assert shape == list(tensor.shape)
+        assert stride == list(tensor.stride())
+        assert dtype == str(tensor.dtype)
+        assert storage_offset == tensor.storage_offset()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extends LIP registration to carry deduplicated storage and tensor alias metadata, rebuilding/validating the canonical index in the daemon and updating SDK, proto, and tests accordingly.
> 
> - **Daemon (C++)**:
>   - **LIP flow**: `LipManager::commit_lease_in_place` now accepts `storages` and `aliases`, rebuilds canonical index (`lip_metadata_utils.{h,cc}`), validates segment/storage consistency, stores metadata on leases, and emits metrics; `copy_to_new_coalesced` extended to take `storages`.
>   - **Controllers/Registry**: `RegistrationController` feeds `storage_entries`/`tensor_aliases`; `RegistrationManager` tracks them; `LipBridge` forwards storages to copy path.
>   - **Build/Tests**: Add `lip_metadata_utils` lib and `lip_metadata_utils_test`.
> - **Proto**:
>   - Add `StorageEntry` and `TensorAlias` messages; extend `FeedRegisterArtifactStreamRequest` with `storage_entries` and `tensor_aliases`.
> - **SDK (Python)**:
>   - Add `tensorcast.api._tensor_graph` and native `collect_tensor_storage_graph`; `register` LIP feeds `LeaseSegment`s plus `RegisterStorage`/`RegisterTensorAlias`.
>   - Update `save_dict` to use storage graph; extend `types` and `daemon_ctl` to carry new fields.
>   - Add tests for storage graph.
> - **Misc**:
>   - CUDA IPC logging tweak in `cuda_real.cc`.
>   - Docs: add canonical index deep dive and update LIP/registration docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 798bcfd3580b360db7538154d829efb92cf546ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->