### PR TITLE
feat(store): implement variant view registration and ingestion support

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -29,5 +29,6 @@ cc_binary(
         "//core/store/loader:file_partition_source",
         "//core/store/loader:safetensors_util",
         "//core/store/loader:source_hash",
+        "//core/store/loader:view_planner",
     ],
 )

--- a/core/store/BUILD
+++ b/core/store/BUILD
@@ -236,6 +236,7 @@ sc_cc_library(
         "//core/store/loader:p2p_loader",
         "//core/store/loader:segment_plan_source",
         "//core/store/loader:source_hash",
+        "//core/store/loader:view_ingest_executor",
         "//core/store/loader:view_plan_source",
         "//core/store/loader:view_planner",
         "//core/store/replica",

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -124,6 +124,11 @@ graph TB
     - CPU (artifact-level convenience): `get_chunk_states_cpu_uma(artifact_id)`
       - Selection rule when multiple replicas exist: prefer a CPU instance if present; otherwise choose the GPU instance with the smallest device ordinal.
 
+- View registration (v1.5):
+  - `begin_register_artifact` accepts optional `ViewRegistration` payloads and requests a `BidirectionalViewPlan` from `core/store/loader::ViewPlanner`.
+  - `ingest_view_registration_chunk` streams view bytes (SERVER placement) into canonical memory using `ViewIngestExecutor`; `commit_registered_artifact` publishes canonical + variant hashes and canonical coverage.
+  - See [Variant View Registration Telemetry](../../docs/architecture/p2p-transfer-strategies.md#variant-view-registration-telemetry) for the end-to-end flow across daemon and Global Store.
+
 - Remote access and registration helpers:
   - `enable_remote_replica_access/disable_remote_replica_access`
   - `register_replica_with_global_store(ReplicaKey, artifact_id_override)`

--- a/core/store/components/global_store_client.cc
+++ b/core/store/components/global_store_client.cc
@@ -14,6 +14,8 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "core/common/otel/grpc_propagation.h"
 #include "core/communicator/misc/utils.h"
 #include "opentelemetry/trace/provider.h"
@@ -359,6 +361,59 @@ absl::Status GlobalStoreClient::record_variant_residency(
   // Until that lands, treat this as a best-effort noop so core plumbing can wire
   // the call sites without coupling to server availability.
   return absl::UnimplementedError("Global Store variant residency RPC not yet implemented");
+}
+
+absl::Status GlobalStoreClient::update_artifact_view_state(const VariantViewUpdate& update) {
+  if (!is_connected()) {
+    return absl::FailedPreconditionError("GlobalStoreClient not connected");
+  }
+  if (update.artifact_id.empty()) {
+    return absl::InvalidArgumentError("update_artifact_view_state requires artifact_id");
+  }
+  if (update.view_id.empty()) {
+    return absl::InvalidArgumentError("update_artifact_view_state requires view_id");
+  }
+
+  global_store::UpdateArtifactViewStateRequest request;
+  request.set_artifact_id(update.artifact_id);
+  auto* variant = request.mutable_variant();
+  variant->set_view_id(update.view_id);
+  variant->set_view_spec_json(update.view_spec_json);
+  variant->set_view_size(update.view_size_bytes);
+  if (update.view_data_hash.has_value()) {
+    variant->set_view_data_hash(*update.view_data_hash);
+  }
+  if (update.canonical_size_bytes > 0 || update.canonical_bytes_covered > 0) {
+    auto* coverage = variant->mutable_canonical_coverage();
+    coverage->set_total_bytes(update.canonical_size_bytes);
+    coverage->set_covered_bytes(update.canonical_bytes_covered);
+  }
+  if (update.mark_verified) {
+    const absl::Time now = absl::Now();
+    auto* ts = variant->mutable_verified_at();
+    const int64_t seconds = absl::ToUnixSeconds(now);
+    const int64_t nanos = absl::ToInt64Nanoseconds(now - absl::UnixEpoch() - absl::Seconds(seconds));
+    ts->set_seconds(seconds);
+    ts->set_nanos(static_cast<int32_t>(nanos));
+  }
+  for (const auto& leaf : update.leaf_writes) {
+    *request.add_leaf_writes() = leaf;
+  }
+
+  global_store::UpdateArtifactViewStateResponse response;
+  auto status = execute_rpc_with_retry(
+      request,
+      &response,
+      [this](auto* ctx, const auto& req, auto* resp) { return stub_->UpdateArtifactViewState(ctx, req, resp); },
+      "UpdateArtifactViewState");
+  if (!status.ok()) {
+    return status;
+  }
+  if (response.status() != global_store::STATUS_OK) {
+    return absl::InternalError(
+        absl::StrFormat("UpdateArtifactViewState failed: status=%s", status_to_cstr(response.status())));
+  }
+  return absl::OkStatus();
 }
 
 absl::StatusOr<std::string> GlobalStoreClient::register_memory_replica(

--- a/core/store/components/global_store_client.h
+++ b/core/store/components/global_store_client.h
@@ -78,6 +78,18 @@ struct KeyMapping {
   std::string disk_path;
 };
 
+struct VariantViewUpdate {
+  std::string artifact_id;
+  std::string view_id;
+  std::string view_spec_json;
+  uint64_t view_size_bytes{0};
+  std::optional<std::string> view_data_hash;
+  bool mark_verified{false};
+  uint64_t canonical_size_bytes{0};
+  uint64_t canonical_bytes_covered{0};
+  std::vector<global_store::v1::LeafWrite> leaf_writes;
+};
+
 class IGlobalStoreClient {
  public:
   virtual ~IGlobalStoreClient() = default;
@@ -200,6 +212,8 @@ class IGlobalStoreClient {
       std::string node_address,
       uint32_t grpc_port,
       uint32_t p2p_port) = 0;
+
+  virtual absl::Status update_artifact_view_state(const VariantViewUpdate& update) = 0;
 };
 
 class GlobalStoreClient : public IGlobalStoreClient {
@@ -330,6 +344,8 @@ class GlobalStoreClient : public IGlobalStoreClient {
 
   void update_local_endpoint(std::string node_id, std::string node_address, uint32_t grpc_port, uint32_t p2p_port)
       override;
+
+  absl::Status update_artifact_view_state(const VariantViewUpdate& update) override;
 
  private:
   // Helper for RPC retries

--- a/core/store/loader/BUILD
+++ b/core/store/loader/BUILD
@@ -225,6 +225,20 @@ sc_cc_library(
     ],
 )
 
+sc_cc_library(
+    name = "view_ingest_executor",
+    srcs = ["view_ingest_executor.cc"],
+    hdrs = ["view_ingest_executor.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":view_planner",
+        "//core/common:cuda_api_lib",
+        "//core/common:memory_location_lib",
+        "@abseil-cpp//absl/strings",
+        "@libtorch//:torch",
+    ],
+)
+
 # Sink implementations
 sc_cc_library(
     name = "gpu_memory_sink",
@@ -505,6 +519,21 @@ cc_test(
         ":view_transform_executor",
         "//core/common:memory_location_lib",
         "//core/testing:catch_main",
+        "@catch2//:catch2_main",
+        "@nlohmann_json//:json",
+    ],
+)
+
+cc_test(
+    name = "view_ingest_executor_test",
+    srcs = ["view_ingest_executor_test.cc"],
+    deps = [
+        ":view_ingest_executor",
+        ":view_planner",
+        "//core/common:cuda_api_lib",
+        "//core/common:memory_location_lib",
+        "//core/testing:catch_main",
+        "@abseil-cpp//absl/types:span",
         "@catch2//:catch2_main",
         "@nlohmann_json//:json",
     ],

--- a/core/store/loader/view_ingest_executor.cc
+++ b/core/store/loader/view_ingest_executor.cc
@@ -1,0 +1,302 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/store/loader/view_ingest_executor.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <string_view>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "core/common/cuda_api.h"
+#include "torch/torch.h"
+
+namespace tensorcast::store::loader {
+namespace {
+
+absl::StatusOr<at::ScalarType> to_scalar_type(std::string_view dtype) {
+  if (dtype == "torch.float16") {
+    return at::kHalf;
+  }
+  if (dtype == "torch.bfloat16") {
+    return at::kBFloat16;
+  }
+  if (dtype == "torch.float32" || dtype == "torch.float") {
+    return at::kFloat;
+  }
+  if (dtype == "torch.float64" || dtype == "torch.double") {
+    return at::kDouble;
+  }
+  if (dtype == "torch.int8") {
+    return at::kChar;
+  }
+  if (dtype == "torch.uint8") {
+    return at::kByte;
+  }
+  if (dtype == "torch.int16") {
+    return at::kShort;
+  }
+  if (dtype == "torch.int32") {
+    return at::kInt;
+  }
+  if (dtype == "torch.int64" || dtype == "torch.long") {
+    return at::kLong;
+  }
+  if (dtype == "torch.bool") {
+    return at::kBool;
+  }
+  return absl::InvalidArgumentError(absl::StrCat("Unsupported dtype for view ingestion: ", dtype));
+}
+
+torch::TensorOptions create_tensor_options_for_location(
+    at::ScalarType scalar_type,
+    common::memory::MemoryLocation location,
+    int device_id) {
+#ifdef USE_FAKE_CUDA
+  (void)device_id;
+  if (location == common::memory::MemoryLocation::GPU) {
+    return torch::TensorOptions().device(torch::kCPU).dtype(scalar_type);
+  }
+#endif
+  if (location == common::memory::MemoryLocation::GPU) {
+    return torch::TensorOptions().device(torch::kCUDA, device_id).dtype(scalar_type);
+  }
+  return torch::TensorOptions().device(torch::kCPU).dtype(scalar_type);
+}
+
+absl::Status execute_inverse_transform(
+    const TransformPlan& plan,
+    common::memory::MemoryLocation location,
+    void* base_ptr,
+    int device_id) {
+  if (plan.empty() || !plan.requires_materialization) {
+    return absl::OkStatus();
+  }
+  if (base_ptr == nullptr) {
+    return absl::InvalidArgumentError("execute_inverse_transform requires non-null base pointer");
+  }
+  const bool is_gpu = (location == common::memory::MemoryLocation::GPU);
+#ifndef USE_FAKE_CUDA
+  if (is_gpu && device_id < 0) {
+    return absl::InvalidArgumentError("execute_inverse_transform (GPU) requires a valid CUDA device id");
+  }
+#else
+  (void)device_id;
+  (void)is_gpu;
+#endif
+
+  torch::NoGradGuard no_grad;
+  auto* byte_base = static_cast<std::uint8_t*>(base_ptr);
+
+  for (const TensorTransformPlan& tensor_plan : plan.tensors) {
+    if (tensor_plan.permutation.empty()) {
+      continue;
+    }
+    auto scalar_or = to_scalar_type(tensor_plan.dtype);
+    if (!scalar_or.ok()) {
+      return scalar_or.status();
+    }
+    const at::ScalarType scalar_type = *scalar_or;
+    torch::TensorOptions options = create_tensor_options_for_location(scalar_type, location, device_id);
+
+    std::uint8_t* tensor_base = byte_base + tensor_plan.dst_offset;
+    std::uint8_t* canonical_ptr = tensor_base + tensor_plan.storage_offset_elements * tensor_plan.element_size_bytes;
+
+    auto view_tensor = torch::from_blob(
+        canonical_ptr,
+        torch::IntArrayRef(tensor_plan.view_shape),
+        torch::IntArrayRef(tensor_plan.view_stride),
+        [](void*) {},
+        options);
+
+    auto permutation_ref = torch::IntArrayRef(tensor_plan.permutation);
+    torch::Tensor permuted = view_tensor.permute(permutation_ref);
+    torch::Tensor contiguous = permuted.contiguous();
+
+    auto destination_tensor = torch::from_blob(
+        canonical_ptr,
+        torch::IntArrayRef(tensor_plan.canonical_shape),
+        torch::IntArrayRef(tensor_plan.canonical_stride),
+        [](void*) {},
+        options);
+
+    destination_tensor.copy_(contiguous);
+  }
+
+  return absl::OkStatus();
+}
+
+} // namespace
+
+ViewIngestExecutor::ViewIngestExecutor(ViewWritePlan write_plan, TransformPlan inverse_transform)
+    : inverse_transform_(std::move(inverse_transform)) {
+  chunks_.reserve(write_plan.chunks.size());
+  for (auto& chunk : write_plan.chunks) {
+    total_view_bytes_ += chunk.length;
+    ChunkState state;
+    state.chunk = std::move(chunk);
+    state.written = 0;
+    chunks_.push_back(std::move(state));
+  }
+  if (chunks_.empty()) {
+    current_chunk_idx_ = 0;
+  }
+}
+
+absl::Status ViewIngestExecutor::copy_into_canonical(
+    ChunkState& chunk,
+    uint64_t chunk_offset_bytes,
+    absl::Span<const std::byte> data,
+    common::memory::MemoryLocation location,
+    void* canonical_base_ptr,
+    int device_id) {
+  if (data.empty()) {
+    return absl::OkStatus();
+  }
+
+  const uint64_t canonical_offset = chunk.chunk.canonical_offset + chunk_offset_bytes;
+  auto* dst = static_cast<std::byte*>(canonical_base_ptr) + static_cast<std::ptrdiff_t>(canonical_offset);
+
+  switch (location) {
+    case common::memory::MemoryLocation::CPU:
+      std::memcpy(dst, data.data(), data.size());
+      return absl::OkStatus();
+    case common::memory::MemoryLocation::GPU: {
+      auto copy_status = cuda::memcpy(dst, data.data(), data.size(), cudaMemcpyHostToDevice);
+      return copy_status;
+    }
+    default:
+      return absl::InvalidArgumentError(
+          absl::StrCat(
+              "unsupported memory location for view ingestion: ", common::memory::location_to_string(location)));
+  }
+}
+
+absl::Status ViewIngestExecutor::ingest_chunk(
+    uint64_t view_offset,
+    absl::Span<const std::byte> data,
+    common::memory::MemoryLocation location,
+    void* canonical_base_ptr,
+    int device_id) {
+  if (finalized_) {
+    return absl::FailedPreconditionError("view ingestion already finalized");
+  }
+  if (canonical_base_ptr == nullptr) {
+    return absl::InvalidArgumentError("canonical_base_ptr must not be null");
+  }
+  if (data.empty()) {
+    return absl::OkStatus();
+  }
+  if (location == common::memory::MemoryLocation::GPU) {
+#ifndef USE_FAKE_CUDA
+    if (device_id < 0) {
+      return absl::InvalidArgumentError("device_id must be >= 0 for GPU ingestion");
+    }
+#endif
+    auto set_status = cuda::set_device(device_id);
+    if (!set_status.ok()) {
+      return set_status;
+    }
+  }
+
+  const size_t total = data.size();
+  if (current_chunk_idx_ >= chunks_.size()) {
+    return absl::InvalidArgumentError("ingested bytes exceed planned view size");
+  }
+
+  size_t idx = current_chunk_idx_;
+  size_t processed = 0;
+
+  while (processed < total) {
+    if (idx >= chunks_.size()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("view chunk exceeds planned ranges: offset=", view_offset, " length=", total));
+    }
+    ChunkState& chunk = chunks_[idx];
+    const uint64_t expected_view_offset = chunk.chunk.view_offset + chunk.written;
+    const uint64_t absolute_offset = view_offset + processed;
+    if (absolute_offset < expected_view_offset) {
+      return absl::InvalidArgumentError(
+          absl::StrCat(
+              "view chunk overlaps already ingested data: offset=",
+              absolute_offset,
+              " expected=",
+              expected_view_offset));
+    }
+    if (absolute_offset > expected_view_offset) {
+      return absl::InvalidArgumentError(
+          absl::StrCat(
+              "view chunk violates contiguity requirement: offset=",
+              absolute_offset,
+              " expected=",
+              expected_view_offset));
+    }
+
+    const uint64_t chunk_remaining = chunk.chunk.length - chunk.written;
+    const uint64_t data_remaining = static_cast<uint64_t>(total - processed);
+    const uint64_t step = std::min(chunk_remaining, data_remaining);
+    if (step > std::numeric_limits<size_t>::max()) {
+      return absl::OutOfRangeError("view chunk size exceeds platform limits");
+    }
+    const size_t to_copy = static_cast<size_t>(step);
+    absl::Span<const std::byte> slice = data.subspan(processed, to_copy);
+
+    auto copy_status = copy_into_canonical(chunk, chunk.written, slice, location, canonical_base_ptr, device_id);
+    if (!copy_status.ok()) {
+      return copy_status;
+    }
+
+    chunk.written += step;
+    processed += to_copy;
+    ingested_bytes_ += step;
+    if (ingested_bytes_ > total_view_bytes_) {
+      return absl::InvalidArgumentError("ingested bytes exceed planned view size");
+    }
+
+    if (chunk.written == chunk.chunk.length) {
+      ++idx;
+    }
+  }
+
+  current_chunk_idx_ = idx;
+  return absl::OkStatus();
+}
+
+absl::Status ViewIngestExecutor::finalize(
+    common::memory::MemoryLocation location,
+    void* canonical_base_ptr,
+    int device_id) {
+  if (finalized_) {
+    return absl::FailedPreconditionError("view ingestion already finalized");
+  }
+  if (!is_complete()) {
+    return absl::FailedPreconditionError("view bytes incomplete; cannot finalize");
+  }
+  if (canonical_base_ptr == nullptr) {
+    return absl::InvalidArgumentError("canonical_base_ptr must not be null");
+  }
+  if (location == common::memory::MemoryLocation::GPU) {
+#ifndef USE_FAKE_CUDA
+    if (device_id < 0) {
+      return absl::InvalidArgumentError("device_id must be >= 0 for GPU ingestion");
+    }
+#endif
+    auto set_status = cuda::set_device(device_id);
+    if (!set_status.ok()) {
+      return set_status;
+    }
+  }
+
+  auto transform_status = execute_inverse_transform(inverse_transform_, location, canonical_base_ptr, device_id);
+  if (!transform_status.ok()) {
+    return transform_status;
+  }
+
+  finalized_ = true;
+  return absl::OkStatus();
+}
+
+} // namespace tensorcast::store::loader

--- a/core/store/loader/view_ingest_executor.h
+++ b/core/store/loader/view_ingest_executor.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "core/common/memory/memory_location.h"
+#include "core/store/loader/view_planner.h"
+
+namespace tensorcast::store::loader {
+
+/**
+ * ViewIngestExecutor incrementally copies view-formatted bytes into canonical
+ * replica memory and applies inverse transforms to recover canonical layout.
+ *
+ * Registration streaming feeds call ingest_chunk() with server-received view
+ * payloads. finalize() must be called once all expected bytes have been
+ * ingested to run any pending inverse transforms (e.g., transpose).
+ */
+class ViewIngestExecutor {
+ public:
+  ViewIngestExecutor(ViewWritePlan write_plan, TransformPlan inverse_transform);
+
+  [[nodiscard]] uint64_t expected_view_bytes() const {
+    return total_view_bytes_;
+  }
+
+  [[nodiscard]] uint64_t ingested_bytes() const {
+    return ingested_bytes_;
+  }
+
+  [[nodiscard]] bool is_complete() const {
+    return ingested_bytes_ == total_view_bytes_;
+  }
+
+  absl::Status ingest_chunk(
+      uint64_t view_offset,
+      absl::Span<const std::byte> data,
+      common::memory::MemoryLocation location,
+      void* canonical_base_ptr,
+      int device_id);
+
+  absl::Status finalize(common::memory::MemoryLocation location, void* canonical_base_ptr, int device_id);
+
+ private:
+  struct ChunkState {
+    ViewWritePlan::Chunk chunk;
+    uint64_t written{0};
+  };
+
+  absl::Status copy_into_canonical(
+      ChunkState& chunk,
+      uint64_t chunk_offset_bytes,
+      absl::Span<const std::byte> data,
+      common::memory::MemoryLocation location,
+      void* canonical_base_ptr,
+      int device_id);
+
+  std::vector<ChunkState> chunks_;
+  TransformPlan inverse_transform_;
+  uint64_t total_view_bytes_{0};
+  uint64_t ingested_bytes_{0};
+  size_t current_chunk_idx_{0};
+  bool finalized_{false};
+};
+
+} // namespace tensorcast::store::loader

--- a/core/store/loader/view_ingest_executor_test.cc
+++ b/core/store/loader/view_ingest_executor_test.cc
@@ -1,0 +1,267 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/store/loader/view_ingest_executor.h"
+
+#include <cstring>
+#include <vector>
+
+#include "absl/types/span.h"
+#include "catch2/catch_test_macros.hpp"
+#include "core/common/cuda_api.h"
+#include "core/store/loader/view_planner.h"
+#include "nlohmann/json.hpp"
+
+using tensorcast::common::memory::MemoryLocation;
+using tensorcast::store::loader::BidirectionalViewPlan;
+using tensorcast::store::loader::NarrowOp;
+using tensorcast::store::loader::TensorViewOps;
+using tensorcast::store::loader::TransposeOp;
+using tensorcast::store::loader::ViewOp;
+using tensorcast::store::loader::ViewPlanner;
+using tensorcast::store::loader::ViewSpec;
+using tensorcast::store::loader::ViewWritePlan;
+
+namespace cuda = tensorcast::cuda;
+
+namespace {
+
+nlohmann::json tensor_entry(
+    uint64_t offset,
+    uint64_t size,
+    const std::vector<int64_t>& shape,
+    const std::vector<int64_t>& stride,
+    const std::string& dtype,
+    uint64_t storage_offset) {
+  nlohmann::json arr = nlohmann::json::array();
+  arr.push_back(offset);
+  arr.push_back(size);
+  nlohmann::json j_shape = nlohmann::json::array();
+  for (auto v : shape) {
+    j_shape.push_back(v);
+  }
+  nlohmann::json j_stride = nlohmann::json::array();
+  for (auto v : stride) {
+    j_stride.push_back(v);
+  }
+  arr.push_back(j_shape);
+  arr.push_back(j_stride);
+  arr.push_back(dtype);
+  arr.push_back(storage_offset);
+  return arr;
+}
+
+absl::Span<const std::byte> as_byte_span(const std::vector<uint8_t>& data) {
+  return absl::Span<const std::byte>(reinterpret_cast<const std::byte*>(data.data()), data.size());
+}
+
+std::vector<uint8_t> to_bytes(const std::vector<float>& values) {
+  std::vector<uint8_t> out(values.size() * sizeof(float));
+  std::memcpy(out.data(), values.data(), out.size());
+  return out;
+}
+
+std::vector<uint8_t> transpose_2x3_to_3x2(const std::vector<float>& canonical) {
+  std::vector<float> transposed(6);
+  transposed[0] = canonical[0];
+  transposed[1] = canonical[3];
+  transposed[2] = canonical[1];
+  transposed[3] = canonical[4];
+  transposed[4] = canonical[2];
+  transposed[5] = canonical[5];
+  return to_bytes(transposed);
+}
+
+BidirectionalViewPlan compute_plan(const std::string& canonical_index_json, const ViewSpec& spec) {
+  auto plan_or = ViewPlanner::compute_bidirectional_view_plan(canonical_index_json, spec);
+  REQUIRE(plan_or.ok());
+  return std::move(*plan_or);
+}
+
+} // namespace
+
+TEST_CASE("ViewIngestExecutor ingests identity view on CPU", "[view_ingest_executor]") {
+  nlohmann::json index = nlohmann::json::object();
+  index["weights"] = tensor_entry(
+      /*offset=*/0,
+      /*size=*/32,
+      /*shape=*/{8},
+      /*stride=*/{1},
+      /*dtype=*/"torch.float32",
+      /*storage_offset=*/0);
+  const std::string canonical = index.dump();
+
+  ViewSpec spec; // identity
+  BidirectionalViewPlan bidir = compute_plan(canonical, spec);
+
+  std::vector<uint8_t> canonical_buffer(32, 0);
+  std::vector<uint8_t> view_buffer(32);
+  for (size_t i = 0; i < view_buffer.size(); ++i) {
+    view_buffer[i] = static_cast<uint8_t>(i + 1);
+  }
+
+  tensorcast::store::loader::ViewIngestExecutor executor(std::move(bidir.write), std::move(bidir.inverse_transform));
+
+  REQUIRE(executor.expected_view_bytes() == view_buffer.size());
+  auto ingest_status = executor.ingest_chunk(
+      /*view_offset=*/0,
+      as_byte_span(view_buffer),
+      MemoryLocation::CPU,
+      canonical_buffer.data(),
+      /*device_id=*/0);
+  REQUIRE(ingest_status.ok());
+  CHECK(executor.is_complete());
+
+  auto finalize_status = executor.finalize(MemoryLocation::CPU, canonical_buffer.data(), 0);
+  REQUIRE(finalize_status.ok());
+
+  CHECK(canonical_buffer == view_buffer);
+}
+
+TEST_CASE("ViewIngestExecutor handles narrow view in multiple chunks", "[view_ingest_executor]") {
+  nlohmann::json index = nlohmann::json::object();
+  index["activation"] = tensor_entry(
+      /*offset=*/0,
+      /*size=*/32,
+      /*shape=*/{2, 4},
+      /*stride=*/{4, 1},
+      /*dtype=*/"torch.float32",
+      /*storage_offset=*/0);
+  const std::string canonical = index.dump();
+
+  ViewSpec spec;
+  TensorViewOps ops;
+  ops.ops.push_back(ViewOp::Narrow(NarrowOp{.dim = 1, .start = 1, .length = 2}));
+  spec.tensors.emplace("activation", ops);
+
+  BidirectionalViewPlan bidir = compute_plan(canonical, spec);
+  REQUIRE_FALSE(bidir.write.chunks.empty());
+
+  std::vector<uint8_t> canonical_buffer(32, 0);
+  std::vector<uint8_t> view_buffer(16);
+  for (size_t i = 0; i < view_buffer.size(); ++i) {
+    view_buffer[i] = static_cast<uint8_t>(100 + i);
+  }
+
+  tensorcast::store::loader::ViewIngestExecutor executor(std::move(bidir.write), std::move(bidir.inverse_transform));
+
+  // First half of the view payload.
+  auto first_half =
+      absl::Span<const std::byte>(reinterpret_cast<const std::byte*>(view_buffer.data()), view_buffer.size() / 2);
+  auto ingest_status = executor.ingest_chunk(
+      /*view_offset=*/0,
+      first_half,
+      MemoryLocation::CPU,
+      canonical_buffer.data(),
+      /*device_id=*/0);
+  REQUIRE(ingest_status.ok());
+  CHECK_FALSE(executor.is_complete());
+
+  // Second half of the payload.
+  auto second_half = absl::Span<const std::byte>(
+      reinterpret_cast<const std::byte*>(view_buffer.data() + view_buffer.size() / 2), view_buffer.size() / 2);
+  ingest_status = executor.ingest_chunk(
+      /*view_offset=*/static_cast<uint64_t>(view_buffer.size() / 2),
+      second_half,
+      MemoryLocation::CPU,
+      canonical_buffer.data(),
+      /*device_id=*/0);
+  REQUIRE(ingest_status.ok());
+  CHECK(executor.is_complete());
+
+  auto finalize_status = executor.finalize(MemoryLocation::CPU, canonical_buffer.data(), 0);
+  REQUIRE(finalize_status.ok());
+
+  // Expected: slices copied into canonical offsets 4..11 and 20..27.
+  std::vector<uint8_t> expected(32, 0);
+  std::memcpy(expected.data() + 4, view_buffer.data(), 8);
+  std::memcpy(expected.data() + 20, view_buffer.data() + 8, 8);
+  CHECK(canonical_buffer == expected);
+}
+
+TEST_CASE("ViewIngestExecutor applies inverse transpose", "[view_ingest_executor]") {
+  nlohmann::json index = nlohmann::json::object();
+  index["tensor"] = tensor_entry(
+      /*offset=*/0,
+      /*size=*/24,
+      /*shape=*/{2, 3},
+      /*stride=*/{3, 1},
+      /*dtype=*/"torch.float32",
+      /*storage_offset=*/0);
+  const std::string canonical = index.dump();
+
+  ViewSpec spec;
+  TensorViewOps ops;
+  ops.ops.push_back(ViewOp::Transpose(TransposeOp{.dim0 = 0, .dim1 = 1}));
+  spec.tensors.emplace("tensor", ops);
+
+  BidirectionalViewPlan bidir = compute_plan(canonical, spec);
+
+  std::vector<float> canonical_values = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f};
+  std::vector<uint8_t> canonical_buffer = to_bytes(std::vector<float>(canonical_values.size(), 0.f));
+  std::vector<uint8_t> view_buffer = transpose_2x3_to_3x2(canonical_values);
+
+  tensorcast::store::loader::ViewIngestExecutor executor(std::move(bidir.write), std::move(bidir.inverse_transform));
+
+  auto ingest_status = executor.ingest_chunk(
+      /*view_offset=*/0,
+      as_byte_span(view_buffer),
+      MemoryLocation::CPU,
+      canonical_buffer.data(),
+      /*device_id=*/0);
+  REQUIRE(ingest_status.ok());
+  CHECK(executor.is_complete());
+
+  auto finalize_status = executor.finalize(MemoryLocation::CPU, canonical_buffer.data(), 0);
+  REQUIRE(finalize_status.ok());
+
+  std::vector<uint8_t> expected = to_bytes(canonical_values);
+  CHECK(canonical_buffer == expected);
+}
+
+TEST_CASE("ViewIngestExecutor ingests into GPU memory (fake backend)", "[view_ingest_executor][gpu]") {
+  nlohmann::json index = nlohmann::json::object();
+  index["weights"] = tensor_entry(
+      /*offset=*/0,
+      /*size=*/16,
+      /*shape=*/{4},
+      /*stride=*/{1},
+      /*dtype=*/"torch.float32",
+      /*storage_offset=*/0);
+  const std::string canonical = index.dump();
+
+  ViewSpec spec;
+  BidirectionalViewPlan bidir = compute_plan(canonical, spec);
+
+  std::vector<uint8_t> view_buffer(16);
+  for (size_t i = 0; i < view_buffer.size(); ++i) {
+    view_buffer[i] = static_cast<uint8_t>(200 + i);
+  }
+
+  void* device_ptr = nullptr;
+  REQUIRE(cuda::set_device(0).ok());
+  auto alloc_status = cuda::malloc(&device_ptr, view_buffer.size());
+  REQUIRE(alloc_status.ok());
+
+  tensorcast::store::loader::ViewIngestExecutor executor(std::move(bidir.write), std::move(bidir.inverse_transform));
+
+  auto ingest_status = executor.ingest_chunk(
+      /*view_offset=*/0,
+      as_byte_span(view_buffer),
+      MemoryLocation::GPU,
+      device_ptr,
+      /*device_id=*/0);
+  REQUIRE(ingest_status.ok());
+  CHECK(executor.is_complete());
+
+  auto finalize_status = executor.finalize(MemoryLocation::GPU, device_ptr, 0);
+  REQUIRE(finalize_status.ok());
+
+  std::vector<uint8_t> host_buffer(view_buffer.size(), 0);
+  auto copy_status = cuda::memcpy(host_buffer.data(), device_ptr, host_buffer.size(), cudaMemcpyDeviceToHost);
+  REQUIRE(copy_status.ok());
+
+  CHECK(host_buffer == view_buffer);
+
+  auto free_status = cuda::free(device_ptr);
+  REQUIRE(free_status.ok());
+}

--- a/core/store/loader/view_planner.cc
+++ b/core/store/loader/view_planner.cc
@@ -203,15 +203,89 @@ void finalize_selection_plan(SelectionPlan* plan) {
   plan->is_segment_aligned = plan->is_contiguous && segment_aligned;
 }
 
-} // namespace
+ViewWritePlan build_view_write_plan(const SelectionPlan& selection) {
+  ViewWritePlan write_plan;
+  write_plan.chunks.reserve(selection.ranges.size());
+  for (const auto& range : selection.ranges) {
+    if (range.kind != SelectionPlan::Range::Kind::kData) {
+      continue;
+    }
+    ViewWritePlan::Chunk chunk;
+    chunk.canonical_offset = range.src_offset;
+    chunk.view_offset = range.dst_offset;
+    chunk.length = range.length;
+    chunk.segment_aligned =
+        is_multiple_of(range.src_offset, kAlignmentBytes) && is_multiple_of(range.length, kAlignmentBytes);
+    write_plan.chunks.push_back(std::move(chunk));
+  }
+  return write_plan;
+}
 
-absl::StatusOr<ViewPlan> ViewPlanner::compute_view_plan(std::string_view canonical_index_json, const ViewSpec& spec) {
+absl::StatusOr<std::vector<int64_t>> compute_inverse_permutation(
+    const std::vector<int64_t>& permutation,
+    std::string_view tensor_name) {
+  const size_t n = permutation.size();
+  std::vector<int64_t> inverse(n, 0);
+  std::vector<bool> seen(n, false);
+  for (size_t idx = 0; idx < n; ++idx) {
+    const int64_t value = permutation[idx];
+    if (value < 0 || static_cast<size_t>(value) >= n) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("transpose permutation entry out of range for tensor ", tensor_name));
+    }
+    if (seen[static_cast<size_t>(value)]) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("transpose permutation repeats dimension for tensor ", tensor_name));
+    }
+    seen[static_cast<size_t>(value)] = true;
+    inverse[static_cast<size_t>(value)] = static_cast<int64_t>(idx);
+  }
+  return inverse;
+}
+
+absl::StatusOr<TransformPlan> build_inverse_transform(
+    const TransformPlan& forward,
+    const std::unordered_map<std::string, uint64_t>& canonical_offsets) {
+  TransformPlan inverse;
+  inverse.requires_materialization = forward.requires_materialization;
+  if (forward.tensors.empty()) {
+    return inverse;
+  }
+  inverse.tensors.reserve(forward.tensors.size());
+  for (const TensorTransformPlan& tensor_plan : forward.tensors) {
+    auto it = canonical_offsets.find(tensor_plan.tensor_name);
+    if (it == canonical_offsets.end()) {
+      return absl::InvalidArgumentError(absl::StrCat("missing canonical offset for tensor ", tensor_plan.tensor_name));
+    }
+    auto inverse_perm_or = compute_inverse_permutation(tensor_plan.permutation, tensor_plan.tensor_name);
+    if (!inverse_perm_or.ok()) {
+      return inverse_perm_or.status();
+    }
+    TensorTransformPlan inverse_plan;
+    inverse_plan.tensor_name = tensor_plan.tensor_name;
+    inverse_plan.dst_offset = it->second;
+    inverse_plan.canonical_offset = it->second;
+    inverse_plan.storage_offset_elements = tensor_plan.storage_offset_elements;
+    inverse_plan.canonical_shape = tensor_plan.canonical_shape;
+    inverse_plan.canonical_stride = tensor_plan.canonical_stride;
+    inverse_plan.view_shape = tensor_plan.view_shape;
+    inverse_plan.view_stride = tensor_plan.view_stride;
+    inverse_plan.permutation = std::move(*inverse_perm_or);
+    inverse_plan.dtype = tensor_plan.dtype;
+    inverse_plan.element_size_bytes = tensor_plan.element_size_bytes;
+    inverse.tensors.push_back(std::move(inverse_plan));
+  }
+  return inverse;
+}
+
+absl::StatusOr<BidirectionalViewPlan> compute_bidirectional_internal(
+    std::string_view canonical_index_json,
+    const ViewSpec& spec) {
   std::map<std::string, CanonicalEntry> canonical_entries;
   if (auto st = parse_canonical_index(canonical_index_json, &canonical_entries); !st.ok()) {
     return st;
   }
 
-  // Validate spec tensors exist and ops supported.
   for (const auto& [tensor_name, ops] : spec.tensors) {
     if (!canonical_entries.contains(tensor_name)) {
       return absl::InvalidArgumentError(absl::StrCat("ViewSpec references unknown tensor: ", tensor_name));
@@ -233,6 +307,11 @@ absl::StatusOr<ViewPlan> ViewPlanner::compute_view_plan(std::string_view canonic
   std::unordered_map<std::string, uint64_t> offsets;
   std::unordered_map<std::string, uint64_t> sizes;
   std::unordered_map<std::string, CanonicalTensorMeta> metas;
+  std::unordered_map<std::string, uint64_t> canonical_offsets;
+  offsets.reserve(canonical_entries.size());
+  sizes.reserve(canonical_entries.size());
+  metas.reserve(canonical_entries.size());
+  canonical_offsets.reserve(canonical_entries.size());
 
   for (const auto& [name, entry] : canonical_entries) {
     const uint64_t aligned_start = (view_cursor + (kAlignmentBytes - 1)) / kAlignmentBytes * kAlignmentBytes;
@@ -242,6 +321,7 @@ absl::StatusOr<ViewPlan> ViewPlanner::compute_view_plan(std::string_view canonic
     }
 
     ordered_names.push_back(name);
+    canonical_offsets[name] = entry.offset;
     const auto spec_it = spec.tensors.find(name);
     const TensorViewOps* ops = (spec_it == spec.tensors.end() ? nullptr : &spec_it->second);
 
@@ -384,18 +464,19 @@ absl::StatusOr<ViewPlan> ViewPlanner::compute_view_plan(std::string_view canonic
           selection_plan.ranges.push_back(make_data_range(entry.offset, view_cursor, entry.size_bytes));
           view_cursor += entry.size_bytes;
 
-          TensorTransformPlan spec;
-          spec.tensor_name = name;
-          spec.dst_offset = tensor_dst_offset;
-          spec.storage_offset_elements = entry.storage_offset;
-          spec.canonical_shape = entry.shape;
-          spec.canonical_stride = entry.stride.empty() ? compute_compact_stride(entry.shape) : entry.stride;
-          spec.view_shape = view_shape;
-          spec.view_stride = view_stride;
-          spec.permutation.assign(permutation.begin(), permutation.end());
-          spec.dtype = entry.dtype;
-          spec.element_size_bytes = element_size;
-          transform_plan.tensors.push_back(std::move(spec));
+          TensorTransformPlan tensor_transform;
+          tensor_transform.tensor_name = name;
+          tensor_transform.dst_offset = tensor_dst_offset;
+          tensor_transform.canonical_offset = entry.offset;
+          tensor_transform.storage_offset_elements = entry.storage_offset;
+          tensor_transform.canonical_shape = entry.shape;
+          tensor_transform.canonical_stride = entry.stride.empty() ? compute_compact_stride(entry.shape) : entry.stride;
+          tensor_transform.view_shape = view_shape;
+          tensor_transform.view_stride = view_stride;
+          tensor_transform.permutation.assign(permutation.begin(), permutation.end());
+          tensor_transform.dtype = entry.dtype;
+          tensor_transform.element_size_bytes = element_size;
+          transform_plan.tensors.push_back(std::move(tensor_transform));
           any_requires_materialization = true;
         }
       } else {
@@ -417,27 +498,54 @@ absl::StatusOr<ViewPlan> ViewPlanner::compute_view_plan(std::string_view canonic
   selection_plan.requires_materialization = any_requires_materialization;
   transform_plan.requires_materialization = any_requires_materialization;
 
-  ViewPlan plan;
-  plan.is_identity = !has_transform;
-  plan.view_size_bytes = view_cursor;
-  plan.selection = std::move(selection_plan);
-  plan.transform = std::move(transform_plan);
+  ViewPlan forward_plan;
+  forward_plan.is_identity = !has_transform;
+  forward_plan.view_size_bytes = view_cursor;
+  forward_plan.selection = std::move(selection_plan);
+  forward_plan.transform = std::move(transform_plan);
 
-  if (!has_transform) {
+  if (forward_plan.is_identity) {
     auto rebuilt_or = rebuild_stable_canonical_index(std::string(canonical_index_json), 0);
     if (!rebuilt_or.ok()) {
       return rebuilt_or.status();
     }
-    plan.view_index_json = *rebuilt_or;
-    return plan;
+    forward_plan.view_index_json = *rebuilt_or;
+  } else {
+    absl::StatusOr<std::string> view_index_json_or = build_canonical_index_json(ordered_names, offsets, sizes, metas);
+    if (!view_index_json_or.ok()) {
+      return view_index_json_or.status();
+    }
+    forward_plan.view_index_json = *view_index_json_or;
   }
 
-  absl::StatusOr<std::string> view_index_json_or = build_canonical_index_json(ordered_names, offsets, sizes, metas);
-  if (!view_index_json_or.ok()) {
-    return view_index_json_or.status();
+  ViewWritePlan write_plan = build_view_write_plan(forward_plan.selection);
+  auto inverse_transform_or = build_inverse_transform(forward_plan.transform, canonical_offsets);
+  if (!inverse_transform_or.ok()) {
+    return inverse_transform_or.status();
   }
-  plan.view_index_json = *view_index_json_or;
-  return plan;
+
+  BidirectionalViewPlan bidirectional;
+  bidirectional.forward = std::move(forward_plan);
+  bidirectional.write = std::move(write_plan);
+  bidirectional.inverse_transform = std::move(*inverse_transform_or);
+  return bidirectional;
+}
+
+} // namespace
+
+absl::StatusOr<ViewPlan> ViewPlanner::compute_view_plan(std::string_view canonical_index_json, const ViewSpec& spec) {
+  auto bidirectional_or = compute_bidirectional_internal(canonical_index_json, spec);
+  if (!bidirectional_or.ok()) {
+    return bidirectional_or.status();
+  }
+  BidirectionalViewPlan bidirectional = std::move(*bidirectional_or);
+  return std::move(bidirectional.forward);
+}
+
+absl::StatusOr<BidirectionalViewPlan> ViewPlanner::compute_bidirectional_view_plan(
+    std::string_view canonical_index_json,
+    const ViewSpec& spec) {
+  return compute_bidirectional_internal(canonical_index_json, spec);
 }
 
 } // namespace tensorcast::store::loader

--- a/core/store/loader/view_planner.h
+++ b/core/store/loader/view_planner.h
@@ -73,6 +73,7 @@ struct SelectionPlan {
 struct TensorTransformPlan {
   std::string tensor_name;
   uint64_t dst_offset{0};
+  uint64_t canonical_offset{0};
   uint64_t storage_offset_elements{0};
   std::vector<int64_t> canonical_shape;
   std::vector<int64_t> canonical_stride;
@@ -100,9 +101,34 @@ struct ViewPlan {
   TransformPlan transform;
 };
 
+struct ViewWritePlan {
+  struct Chunk {
+    uint64_t canonical_offset{0};
+    uint64_t view_offset{0};
+    uint64_t length{0};
+    bool segment_aligned{false};
+  };
+
+  std::vector<Chunk> chunks;
+
+  [[nodiscard]] bool empty() const {
+    return chunks.empty();
+  }
+};
+
+struct BidirectionalViewPlan {
+  ViewPlan forward;
+  ViewWritePlan write;
+  TransformPlan inverse_transform;
+};
+
 class ViewPlanner {
  public:
   [[nodiscard]] static absl::StatusOr<ViewPlan> compute_view_plan(
+      std::string_view canonical_index_json,
+      const ViewSpec& spec);
+
+  [[nodiscard]] static absl::StatusOr<BidirectionalViewPlan> compute_bidirectional_view_plan(
       std::string_view canonical_index_json,
       const ViewSpec& spec);
 };

--- a/core/store/registration_memory_replica_test.cc
+++ b/core/store/registration_memory_replica_test.cc
@@ -2,17 +2,24 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <chrono>
+#include <cstddef>
 #include <filesystem>
 #include <optional>
 #include <string>
 #include <thread>
 
 #include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "core/store/components/global_store_client.h"
+#include "core/store/loader/view_planner.h"
 #include "core/store/replica/memory_state.h"
 #include "core/store/store_engine.h"
 #include "core/store/store_engine_options.h"
 #include "core/testing/common.h"
+#include "nlohmann/json.hpp"
+#include "tensorcast/global_store/v1/global_store.pb.h"
 
 namespace fs = std::filesystem;
 using tensorcast::DeviceType;
@@ -31,6 +38,7 @@ static StoreEngine make_store(
   opts.storage_path = storage_root.string();
   opts.memory_pool_size = pool_size_bytes;
   opts.tx_slice_bytes = chunk_size_bytes;
+  opts.artifact_chunk_bytes = chunk_size_bytes;
   opts.num_thread = io_threads;
   opts.pinned_memory_timeout = std::chrono::milliseconds(0);
   return StoreEngine(opts);
@@ -39,6 +47,167 @@ static StoreEngine make_store(
 static DeviceKey make_gpu_key(int ordinal) {
   return DeviceKey{DeviceType::GPU, ordinal, /*uuid=*/""};
 }
+
+class RecordingViewGlobalStoreClient final : public tensorcast::store::components::IGlobalStoreClient {
+ public:
+  bool connected{true};
+  std::vector<tensorcast::store::components::VariantViewUpdate> view_updates;
+
+  absl::Status initialize() override {
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::string> register_worker(
+      std::string_view,
+      std::string_view,
+      uint32_t,
+      uint32_t,
+      uint64_t,
+      uint64_t,
+      bool,
+      std::string_view) override {
+    return absl::UnimplementedError("register_worker not supported in test stub");
+  }
+
+  absl::Status send_heartbeat(std::string_view, uint64_t, bool) override {
+    return absl::UnimplementedError("send_heartbeat not supported in test stub");
+  }
+
+  absl::StatusOr<tensorcast::global_store::v1::WorkerHeartbeatResponse> send_heartbeat_enhanced(
+      std::string_view,
+      uint64_t,
+      bool,
+      uint64_t,
+      std::string_view,
+      const std::vector<std::string>&,
+      int64_t,
+      tensorcast::global_store::v1::ConnectionStatus) override {
+    return absl::UnimplementedError("send_heartbeat_enhanced not supported in test stub");
+  }
+
+  absl::Status unregister_worker(std::string_view, bool) override {
+    return absl::UnimplementedError("unregister_worker not supported in test stub");
+  }
+
+  absl::StatusOr<std::string> register_replica(
+      std::string_view,
+      std::string_view,
+      const tensorcast::store::DeviceKey&,
+      tensorcast::common::memory::MemoryLocation,
+      uint64_t,
+      uint32_t) override {
+    return std::string("replica-0");
+  }
+
+  absl::Status record_variant_residency(std::string_view, std::string_view, uint64_t, std::optional<std::string_view>)
+      override {
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::string> register_memory_replica(
+      std::string_view,
+      std::string_view,
+      const tensorcast::store::DeviceKey&,
+      uint64_t,
+      std::string_view,
+      const std::vector<std::string>&,
+      const std::vector<uint64_t>&,
+      const std::optional<std::string>&,
+      std::string_view,
+      std::string_view,
+      uint32_t,
+      const std::optional<std::string>&) override {
+    return std::string("memory-replica-0");
+  }
+
+  absl::Status unregister_replica(std::string_view, std::string_view) override {
+    return absl::UnimplementedError("unregister_replica not supported in test stub");
+  }
+
+  absl::Status update_artifact_view_state(const tensorcast::store::components::VariantViewUpdate& update) override {
+    view_updates.push_back(update);
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<tensorcast::store::components::TransportSession> request_replica_transport(
+      std::string_view,
+      std::string_view,
+      std::string_view,
+      uint32_t,
+      const tensorcast::store::DeviceKey&,
+      uint32_t) override {
+    return absl::UnimplementedError("request_replica_transport not supported in test stub");
+  }
+
+  absl::StatusOr<tensorcast::store::components::TransportSession> request_view_transport(
+      std::string_view,
+      std::string_view,
+      std::string_view,
+      std::string_view,
+      uint32_t,
+      const tensorcast::store::DeviceKey&,
+      uint32_t) override {
+    return absl::UnimplementedError("request_view_transport not supported in test stub");
+  }
+
+  absl::Status complete_replica_transport(std::string_view) override {
+    return absl::UnimplementedError("complete_replica_transport not supported in test stub");
+  }
+
+  absl::StatusOr<std::vector<tensorcast::store::components::RemoteReplicaInfo>> get_artifact_replicas(
+      std::string_view) override {
+    return absl::UnimplementedError("get_artifact_replicas not supported in test stub");
+  }
+
+  absl::StatusOr<std::vector<tensorcast::store::components::ChunkLocationInfo>> query_chunk_locations(
+      std::string_view,
+      const std::vector<uint32_t>&) override {
+    return absl::UnimplementedError("query_chunk_locations not supported in test stub");
+  }
+
+  absl::StatusOr<std::pair<uint64_t, std::string>> synchronize_worker_state(
+      const tensorcast::global_store::v1::WorkerLocalState&,
+      bool,
+      std::vector<tensorcast::global_store::v1::StateChange>*) override {
+    return absl::UnimplementedError("synchronize_worker_state not supported in test stub");
+  }
+
+  absl::StatusOr<std::pair<uint64_t, std::string>> request_full_state_sync(
+      std::string_view,
+      uint64_t,
+      std::vector<tensorcast::common::v1::ReplicaInfo>*) override {
+    return absl::UnimplementedError("request_full_state_sync not supported in test stub");
+  }
+
+  bool is_connected() const override {
+    return connected;
+  }
+
+  absl::Status batch_update_chunk_states(
+      std::string_view,
+      std::string_view,
+      const std::vector<tensorcast::store::components::ChunkStateUpdate>&) override {
+    return absl::UnimplementedError("batch_update_chunk_states not supported in test stub");
+  }
+
+  absl::StatusOr<tensorcast::store::components::KeyMapping> resolve_key_mapping(std::string_view) override {
+    return absl::UnimplementedError("resolve_key_mapping not supported in test stub");
+  }
+
+  absl::Status upsert_key_mapping(std::string_view, std::string_view, std::string_view, absl::Duration) override {
+    return absl::UnimplementedError("upsert_key_mapping not supported in test stub");
+  }
+
+  absl::Status revoke_key_mapping(std::string_view) override {
+    return absl::UnimplementedError("revoke_key_mapping not supported in test stub");
+  }
+
+  void update_local_endpoint(std::string, std::string, uint32_t, uint32_t) override {}
+
+  absl::StatusOr<std::string> get_artifact_index_by_id(std::string_view) override {
+    return absl::UnimplementedError("get_artifact_index_by_id not supported in test stub");
+  }
+};
 
 TEST_CASE("Memory Artifact registration: begin/commit lifecycle", "[store_engine][memory-registration]") {
   if (!tensorcast::testing::is_cuda_available()) {
@@ -77,7 +246,9 @@ TEST_CASE("Memory Artifact registration: begin/commit lifecycle", "[store_engine
 
   // Commit should finalize and keep memory owned by the daemon (store)
   auto commit_or = store.commit_registered_artifact(begin.registration_id);
-  REQUIRE(commit_or.ok());
+  if (!commit_or.ok()) {
+    FAIL("commit failed: " + commit_or.status().ToString());
+  }
   auto commit = commit_or.value();
   REQUIRE(commit.registration_id == begin.registration_id);
   // RFC-0007: Commit returns content-addressed artifact_id (mi2:<index_mh>:<data_mh>)
@@ -194,6 +365,116 @@ TEST_CASE("Memory Artifact registration: TTL expiry prevents commit", "[store_en
   auto state = store.get_replica_state(key, DeviceType::GPU);
   const bool ttl_state_ok = (state == MemoryState::UNINITIALIZED) || (state == MemoryState::UNALLOCATED);
   REQUIRE(ttl_state_ok);
+
+  REQUIRE(store.clear_mem() == 0);
+  std::error_code ec;
+  fs::remove_all(temp_root, ec);
+}
+
+TEST_CASE(
+    "Memory Artifact view registration publishes leaf digests",
+    "[store_engine][memory-registration][view][global-store]") {
+  if (!tensorcast::testing::is_cuda_available()) {
+    WARN("CUDA not available – skipping memory view registration test.");
+    return;
+  }
+
+  const std::string artifact_id = "mem_reg_view";
+  constexpr size_t kElements = 1024;
+  const uint64_t canonical_size = static_cast<uint64_t>(kElements * sizeof(float));
+
+  fs::path temp_root = fs::temp_directory_path() / "store_engine_mem_view_test";
+  fs::create_directories(temp_root);
+
+  StoreEngine store = make_store(
+      temp_root,
+      /*pool_size_bytes=*/32ULL * 1024 * 1024,
+      /*chunk_size_bytes=*/canonical_size);
+  auto gs_stub = std::make_shared<RecordingViewGlobalStoreClient>();
+  store.set_global_store_client_for_testing(gs_stub);
+
+  nlohmann::json index_entry = nlohmann::json::array();
+  index_entry.push_back(0);
+  index_entry.push_back(canonical_size);
+  index_entry.push_back(nlohmann::json::array({static_cast<int64_t>(kElements)}));
+  index_entry.push_back(nlohmann::json::array({1}));
+  index_entry.push_back("torch.float32");
+  index_entry.push_back(0);
+
+  nlohmann::json index_json = nlohmann::json::object();
+  index_json["weights"] = index_entry;
+  const std::string index_data = index_json.dump();
+
+  StoreEngine::ArtifactRegistration reg;
+  reg.artifact_id = artifact_id;
+  reg.tensor_index_key = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+  reg.tensor_index_data = index_data;
+  reg.encoding = "json";
+  reg.schema_version = "v3";
+  reg.device_id = 0;
+  reg.total_size_bytes = canonical_size;
+  reg.enable_p2p = false;
+
+  StoreEngine::ViewRegistration view_reg;
+  view_reg.view_id = "view-full";
+  tensorcast::store::loader::ViewSpec spec;
+  tensorcast::store::loader::TensorViewOps ops;
+  ops.ops.push_back(
+      tensorcast::store::loader::ViewOp::Narrow(
+          tensorcast::store::loader::NarrowOp{.dim = 0, .start = 0, .length = kElements}));
+  spec.tensors.emplace("weights", ops);
+  view_reg.spec = spec;
+  view_reg.placement = StoreEngine::ViewPlacement::kServer;
+  view_reg.canonical_size_bytes = canonical_size;
+  view_reg.allow_partial = false;
+  reg.view = view_reg;
+
+  auto begin_or = store.begin_register_artifact(reg);
+  REQUIRE(begin_or.ok());
+  const auto begin = begin_or.value();
+  REQUIRE(begin.size_bytes == canonical_size);
+
+  std::array<float, kElements> view_payload{};
+  for (size_t i = 0; i < kElements; ++i) {
+    view_payload[i] = static_cast<float>(i + 1);
+  }
+  auto ingest_status = store.ingest_view_registration_chunk(
+      begin.registration_id,
+      /*view_offset=*/0,
+      absl::Span<const std::byte>(reinterpret_cast<const std::byte*>(view_payload.data()), canonical_size));
+  REQUIRE(ingest_status.ok());
+
+  auto commit_or = store.commit_registered_artifact(begin.registration_id);
+  if (!commit_or.ok()) {
+    FAIL("view commit failed: " + commit_or.status().ToString());
+  }
+  const auto commit = commit_or.value();
+  REQUIRE(commit.view_id.has_value());
+  CHECK(commit.view_id.value() == "view-full");
+  CHECK(commit.view_data_multihash.has_value());
+
+  REQUIRE(gs_stub->view_updates.size() == 1);
+  const auto& update = gs_stub->view_updates.front();
+  CHECK(update.view_id == "view-full");
+  CHECK(update.view_data_hash.has_value());
+  CHECK(update.canonical_size_bytes == canonical_size);
+  CHECK(update.canonical_bytes_covered == canonical_size);
+  size_t variant_count = 0;
+  size_t canonical_count = 0;
+  for (const auto& leaf : update.leaf_writes) {
+    if (leaf.space_kind() == tensorcast::global_store::v1::BYTE_SPACE_KIND_VARIANT) {
+      ++variant_count;
+      CHECK(leaf.space_id() == "view-full");
+      CHECK(leaf.leaf_idx() == 0);
+      CHECK(leaf.digest().size() == 32);
+    } else if (leaf.space_kind() == tensorcast::global_store::v1::BYTE_SPACE_KIND_CANONICAL) {
+      ++canonical_count;
+      CHECK(leaf.leaf_idx() == 0);
+      CHECK(leaf.digest().size() == 32);
+    }
+  }
+  CHECK(variant_count == 1);
+  CHECK(canonical_count == 1);
 
   REQUIRE(store.clear_mem() == 0);
   std::error_code ec;

--- a/core/store/store_engine.cc
+++ b/core/store/store_engine.cc
@@ -4,6 +4,7 @@
 
 #include <unistd.h>
 
+#include <algorithm>
 #include <cctype>
 #include <chrono>
 #include <cstring>
@@ -26,6 +27,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "absl/types/span.h"
 #include "core/common/artifact_hash.h"
 #include "core/common/artifact_verification.h"
 #include "core/common/cuda_api.h"
@@ -39,6 +41,7 @@
 #include <nlohmann/json.hpp>
 #include "core/store/loader/canonical_index.h"
 #include "core/store/loader/safetensors_util.h"
+#include "core/store/loader/view_ingest_executor.h"
 #include "core/store/loader/view_plan_source.h"
 #include "core/store/loader/view_planner.h"
 // Unified hashing over SeekableSource for CPU/GPU/P2P
@@ -51,6 +54,7 @@
 #include "opentelemetry/trace/provider.h"
 #include "opentelemetry/trace/scope.h"
 #include "opentelemetry/trace/span.h"
+#include "tensorcast/global_store/v1/global_store.pb.h"
 
 namespace tensorcast::store {
 
@@ -139,6 +143,220 @@ std::optional<std::string> ComputeViewDataHash(
     return std::nullopt;
   }
   return *hash_or;
+}
+
+struct TreeHashWithLeaves {
+  std::string multihash;
+  std::vector<std::vector<uint8_t>> leaf_digests;
+};
+
+absl::StatusOr<TreeHashWithLeaves> compute_tree_hash_and_leaves(
+    loader::SeekableSource& source,
+    uint64_t total_size,
+    size_t leaf_chunk_bytes) {
+  if (total_size == 0) {
+    return absl::InvalidArgumentError("total_size must be > 0");
+  }
+  if (leaf_chunk_bytes == 0) {
+    return absl::InvalidArgumentError("leaf_chunk_bytes must be > 0");
+  }
+  std::vector<std::vector<uint8_t>> leaves;
+  leaves.reserve(static_cast<size_t>((total_size + leaf_chunk_bytes - 1) / leaf_chunk_bytes));
+  std::vector<uint8_t> buffer(leaf_chunk_bytes);
+  uint64_t processed = 0;
+  while (processed < total_size) {
+    const size_t to_read = static_cast<size_t>(std::min<uint64_t>(leaf_chunk_bytes, total_size - processed));
+    auto read_or = source.read_at(processed, buffer.data(), to_read);
+    if (!read_or.ok()) {
+      return read_or.status();
+    }
+    const size_t got = read_or.value();
+    if (got == 0) {
+      return absl::DataLossError("short read while computing tree hash");
+    }
+    leaves.push_back(common::sha256_digest_bytes(absl::Span<const uint8_t>(buffer.data(), got)));
+    processed += got;
+  }
+  TreeHashWithLeaves out;
+  out.multihash = common::multibase_multihash_sha256(common::compute_tree_hash_root_sha256(leaves));
+  out.leaf_digests = std::move(leaves);
+  return out;
+}
+
+uint64_t align_up(uint64_t value, uint64_t align) {
+  if (align == 0) {
+    return value;
+  }
+  const uint64_t remainder = value % align;
+  return remainder == 0 ? value : value + (align - remainder);
+}
+
+uint64_t align_down(uint64_t value, uint64_t align) {
+  if (align == 0) {
+    return value;
+  }
+  return value - (value % align);
+}
+
+std::vector<uint64_t> compute_fully_covered_canonical_leaf_indices(
+    absl::Span<const StoreEngine::CanonicalRange> ranges,
+    uint64_t chunk_bytes) {
+  if (chunk_bytes == 0) {
+    return {};
+  }
+  absl::flat_hash_set<uint64_t> indices;
+  for (const auto& range : ranges) {
+    if (range.length == 0) {
+      continue;
+    }
+    const uint64_t range_start = range.offset;
+    const uint64_t range_end = range.offset + range.length;
+    const uint64_t first_full = align_up(range_start, chunk_bytes);
+    const uint64_t last_full = align_down(range_end, chunk_bytes);
+    if (first_full >= last_full) {
+      continue;
+    }
+    for (uint64_t pos = first_full; pos < last_full; pos += chunk_bytes) {
+      indices.insert(pos / chunk_bytes);
+    }
+  }
+  std::vector<uint64_t> sorted(indices.begin(), indices.end());
+  std::sort(sorted.begin(), sorted.end());
+  return sorted;
+}
+
+absl::StatusOr<std::vector<std::vector<uint8_t>>> compute_canonical_leaf_digests(
+    const replica::Replica& replica,
+    bool use_cpu_memory,
+    void* gpu_ptr_hint,
+    int device_id,
+    uint64_t total_size_bytes,
+    absl::Span<const uint64_t> leaf_indices,
+    size_t chunk_bytes) {
+  std::vector<std::vector<uint8_t>> digests;
+  if (leaf_indices.empty()) {
+    return digests;
+  }
+  if (use_cpu_memory) {
+    const auto cpu_ptrs = replica.get_memory_manager().get_pointer(MemoryLocation::CPU);
+    if (cpu_ptrs.empty() || cpu_ptrs[0] == nullptr) {
+      return absl::FailedPreconditionError("CPU pointer unavailable for canonical leaf digests");
+    }
+    const auto* base = static_cast<const uint8_t*>(cpu_ptrs[0]);
+    digests.reserve(leaf_indices.size());
+    for (uint64_t idx : leaf_indices) {
+      const uint64_t offset = idx * chunk_bytes;
+      if (offset + chunk_bytes > total_size_bytes) {
+        continue;
+      }
+      digests.push_back(common::sha256_digest_bytes(absl::Span<const uint8_t>(base + offset, chunk_bytes)));
+    }
+    return digests;
+  }
+  void* gpu_ptr = gpu_ptr_hint;
+  if (gpu_ptr == nullptr) {
+    const auto gpu_ptrs = replica.get_memory_manager().get_pointer(MemoryLocation::GPU);
+    if (!gpu_ptrs.empty()) {
+      gpu_ptr = gpu_ptrs[0];
+    }
+  }
+  if (gpu_ptr == nullptr) {
+    return absl::FailedPreconditionError("GPU pointer unavailable for canonical leaf digests");
+  }
+  std::vector<uint8_t> buffer(chunk_bytes);
+  digests.reserve(leaf_indices.size());
+  for (uint64_t idx : leaf_indices) {
+    const uint64_t offset = idx * chunk_bytes;
+    if (offset + chunk_bytes > total_size_bytes) {
+      continue;
+    }
+    if (auto st = tensorcast::cuda::set_device(device_id); !st.ok()) {
+      return st;
+    }
+    auto copy_status = tensorcast::cuda::memcpy(
+        buffer.data(), static_cast<uint8_t*>(gpu_ptr) + offset, chunk_bytes, cudaMemcpyDeviceToHost);
+    if (!copy_status.ok()) {
+      return copy_status;
+    }
+    if (auto sync_status = tensorcast::cuda::device_synchronize(); !sync_status.ok()) {
+      return sync_status;
+    }
+    digests.push_back(common::sha256_digest_bytes(absl::Span<const uint8_t>(buffer.data(), chunk_bytes)));
+  }
+  return digests;
+}
+
+uint64_t sum_view_write_bytes(const loader::ViewWritePlan& write_plan) {
+  uint64_t total = 0;
+  for (const auto& chunk : write_plan.chunks) {
+    total += chunk.length;
+  }
+  return total;
+}
+
+std::vector<StoreEngine::CanonicalRange> canonical_ranges_from_write_plan(const loader::ViewWritePlan& write_plan) {
+  std::vector<StoreEngine::CanonicalRange> ranges;
+  ranges.reserve(write_plan.chunks.size());
+  for (const auto& chunk : write_plan.chunks) {
+    StoreEngine::CanonicalRange range;
+    range.offset = chunk.canonical_offset;
+    range.length = chunk.length;
+    ranges.push_back(range);
+  }
+  std::sort(
+      ranges.begin(), ranges.end(), [](const StoreEngine::CanonicalRange& a, const StoreEngine::CanonicalRange& b) {
+        return a.offset < b.offset;
+      });
+  std::vector<StoreEngine::CanonicalRange> merged;
+  merged.reserve(ranges.size());
+  for (const auto& range : ranges) {
+    if (range.length == 0) {
+      continue;
+    }
+    if (merged.empty()) {
+      merged.push_back(range);
+      continue;
+    }
+    auto& last = merged.back();
+    const uint64_t last_end = last.offset + last.length;
+    if (range.offset <= last_end) {
+      const uint64_t new_end = std::max(last_end, range.offset + range.length);
+      last.length = new_end - last.offset;
+    } else {
+      merged.push_back(range);
+    }
+  }
+  return merged;
+}
+
+std::string build_view_spec_json(const loader::ViewSpec& spec) {
+  nlohmann::json tensors = nlohmann::json::object();
+  for (const auto& [tensor_name, ops] : spec.tensors) {
+    nlohmann::json tensor_json;
+    nlohmann::json ops_array = nlohmann::json::array();
+    for (const auto& op : ops.ops) {
+      nlohmann::json op_json;
+      switch (op.kind) {
+        case loader::ViewOp::Kind::kNarrow:
+          op_json["type"] = "narrow";
+          op_json["dim"] = op.narrow.dim;
+          op_json["start"] = op.narrow.start;
+          op_json["length"] = op.narrow.length;
+          break;
+        case loader::ViewOp::Kind::kTranspose:
+          op_json["type"] = "transpose";
+          op_json["dim0"] = op.transpose.dim0;
+          op_json["dim1"] = op.transpose.dim1;
+          break;
+      }
+      ops_array.push_back(std::move(op_json));
+    }
+    tensor_json["ops"] = std::move(ops_array);
+    tensors[tensor_name] = std::move(tensor_json);
+  }
+  nlohmann::json root;
+  root["tensors"] = std::move(tensors);
+  return root.dump();
 }
 
 } // namespace
@@ -2197,6 +2415,55 @@ absl::StatusOr<StoreEngine::RegistrationBeginResult> StoreEngine::begin_register
   if (reg.tensor_index_key.empty() && !reg.tensor_index_data.has_value()) {
     return absl::InvalidArgumentError("tensor index key or data must be provided");
   }
+  const uint64_t canonical_size = (reg.view.has_value() && reg.view->canonical_size_bytes != 0)
+      ? reg.view->canonical_size_bytes
+      : reg.total_size_bytes;
+
+  std::optional<loader::BidirectionalViewPlan> view_plan;
+  uint64_t expected_view_bytes = 0;
+  std::vector<CanonicalRange> canonical_ranges;
+  if (reg.view.has_value()) {
+    const auto& view_opts = *reg.view;
+    if (!reg.tensor_index_data.has_value() || reg.tensor_index_data->empty()) {
+      return absl::InvalidArgumentError("view registration requires inline canonical index data");
+    }
+    if (view_opts.placement == ViewPlacement::kUnspecified) {
+      return absl::InvalidArgumentError("view registration requires explicit placement");
+    }
+    if (view_opts.canonical_size_bytes != 0 && view_opts.canonical_size_bytes != reg.total_size_bytes) {
+      return absl::InvalidArgumentError("view.canonical_size_bytes must match total_size_bytes");
+    }
+    auto plan_or = loader::ViewPlanner::compute_bidirectional_view_plan(*reg.tensor_index_data, view_opts.spec);
+    if (!plan_or.ok()) {
+      return plan_or.status();
+    }
+    view_plan = std::move(*plan_or);
+    expected_view_bytes = sum_view_write_bytes(view_plan->write);
+    canonical_ranges = canonical_ranges_from_write_plan(view_plan->write);
+    uint64_t covered_bytes = 0;
+    for (const auto& range : canonical_ranges) {
+      covered_bytes += range.length;
+    }
+    if (!view_opts.allow_partial && covered_bytes != canonical_size) {
+      return absl::InvalidArgumentError(
+          "view registration does not fully cover canonical bytes; set allow_partial=true to permit partial coverage");
+    }
+    if (covered_bytes > canonical_size) {
+      return absl::InvalidArgumentError("view registration exceeds canonical byte space");
+    }
+    if (view_opts.placement == ViewPlacement::kServer && view_plan->inverse_transform.requires_materialization) {
+      auto info_or = device_manager_->get_gpu_info(reg.device_id);
+      if (!info_or.ok()) {
+        return absl::FailedPreconditionError(
+            absl::StrCat(
+                "SERVER placement for view registration requires GPU transpose support on device ",
+                reg.device_id,
+                "; retry with placement=CLIENT (",
+                info_or.status().message(),
+                ")"));
+      }
+    }
+  }
 
   // Prepare a memory-only Replica bound to target GPU to own the allocation.
   // Use InlineBufferSource with the known total size so Replica::create() can
@@ -2285,27 +2552,40 @@ absl::StatusOr<StoreEngine::RegistrationBeginResult> StoreEngine::begin_register
   std::uniform_int_distribution<uint64_t> dis;
   auto reg_id = absl::StrCat("reg_", absl::ToUnixNanos(absl::Now()), "_", getpid(), "_", dis(gen));
 
-  PendingRegistrationEntry entry;
-  entry.registration_id = reg_id;
-  entry.artifact_id = reg.artifact_id;
-  entry.device_id = reg.device_id;
-  entry.size_bytes = reg.total_size_bytes;
-  entry.tensor_index_key = reg.tensor_index_key;
-  entry.tensor_index_data = reg.tensor_index_data;
-  entry.schema_version = reg.schema_version;
-  entry.encoding = reg.encoding;
-  entry.enable_p2p = reg.enable_p2p;
+  auto entry = std::make_shared<PendingRegistrationEntry>();
+  entry->registration_id = reg_id;
+  entry->artifact_id = reg.artifact_id;
+  entry->device_id = reg.device_id;
+  entry->size_bytes = reg.total_size_bytes;
+  entry->tensor_index_key = reg.tensor_index_key;
+  entry->tensor_index_data = reg.tensor_index_data;
+  entry->schema_version = reg.schema_version;
+  entry->encoding = reg.encoding;
+  entry->enable_p2p = reg.enable_p2p;
   if (reg.ttl_ms > 0) {
-    entry.expiry_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(reg.ttl_ms);
+    entry->expiry_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(reg.ttl_ms);
   }
-  entry.replica = replica;
-  entry.gpu_ptr = base_ptr;
-  entry.ipc_handle = *ipc_or;
-  entry.plan = PendingRegistrationEntry::Plan::COALESCED;
+  entry->replica = replica;
+  entry->gpu_ptr = base_ptr;
+  entry->ipc_handle = *ipc_or;
+  entry->plan = PendingRegistrationEntry::Plan::COALESCED;
+  if (view_plan.has_value()) {
+    entry->view_state = std::make_unique<PendingRegistrationEntry::ViewState>();
+    entry->view_state->options = *reg.view;
+    entry->view_state->options.canonical_size_bytes = canonical_size;
+    entry->view_state->options.canonical_ranges = canonical_ranges;
+    entry->view_state->plan = *view_plan;
+    entry->view_state->expected_view_bytes = expected_view_bytes;
+    entry->view_state->ingested_bytes = 0;
+    if (entry->view_state->options.placement == ViewPlacement::kServer) {
+      entry->view_state->executor = std::make_unique<loader::ViewIngestExecutor>(
+          entry->view_state->plan.write, entry->view_state->plan.inverse_transform);
+    }
+  }
 
   {
     std::lock_guard<std::mutex> lock(pending_mutex_);
-    pending_regs_.emplace(reg_id, std::move(entry));
+    pending_regs_.emplace(reg_id, entry);
   }
 
   RegistrationBeginResult out;
@@ -2320,7 +2600,7 @@ absl::StatusOr<StoreEngine::RegistrationBeginResult> StoreEngine::begin_register
 
 absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_registered_artifact(
     std::string_view registration_id) {
-  PendingRegistrationEntry entry;
+  std::shared_ptr<PendingRegistrationEntry> entry;
   std::shared_ptr<Replica> expired_replica;
   {
     std::lock_guard<std::mutex> lock(pending_mutex_);
@@ -2328,15 +2608,12 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
     if (it == pending_regs_.end()) {
       return absl::NotFoundError("registration_id not found");
     }
-    // TTL enforcement: if expired, cleanup and fail fast.
-    // Keep the lock held to prevent race conditions during TTL check and removal
-    if (it->second.expiry_time.time_since_epoch().count() > 0 &&
-        std::chrono::steady_clock::now() > it->second.expiry_time) {
-      expired_replica = it->second.replica;
+    if (it->second->expiry_time.time_since_epoch().count() > 0 &&
+        std::chrono::steady_clock::now() > it->second->expiry_time) {
+      expired_replica = it->second->replica;
       pending_regs_.erase(it);
-      // Release outside the lock to avoid holding mutex during potentially slow operation
     } else {
-      entry = it->second; // make a copy; we may erase after successful commit
+      entry = it->second;
     }
   }
 
@@ -2351,57 +2628,88 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
     return absl::DeadlineExceededError("registration expired (TTL)");
   }
 
+  if (!entry) {
+    return absl::InternalError("pending registration entry missing after TTL check");
+  }
+
+  if (entry->view_state && entry->view_state->options.placement == ViewPlacement::kServer) {
+    auto& view_state = *entry->view_state;
+    if (!view_state.executor) {
+      return absl::FailedPreconditionError("view executor missing for server placement registration");
+    }
+    if (!view_state.executor->is_complete()) {
+      return absl::FailedPreconditionError(
+          absl::StrCat(
+              "view bytes incomplete; expected ",
+              view_state.expected_view_bytes,
+              " received ",
+              view_state.executor->ingested_bytes()));
+    }
+    auto finalize_status = view_state.executor->finalize(MemoryLocation::GPU, entry->gpu_ptr, entry->device_id);
+    if (!finalize_status.ok()) {
+      return finalize_status;
+    }
+    view_state.finalized = true;
+  }
+
   // Compute content-addressed artifact_id per RFC-0007: "mi2:<index_multihash>:<data_multihash>"
   // 1) index_multihash from canonical index bytes when provided, otherwise from key (sha256 hex)
   absl::StatusOr<std::string> index_mh_or =
-      common::compute_index_multihash(entry.tensor_index_data, entry.tensor_index_key);
+      common::compute_index_multihash(entry->tensor_index_data, entry->tensor_index_key);
   if (!index_mh_or.ok()) {
     return index_mh_or.status();
   }
 
-  if (!entry.schema_version.empty() && entry.schema_version != "v3") {
+  if (!entry->schema_version.empty() && entry->schema_version != "v3") {
     return absl::FailedPreconditionError(
-        absl::StrCat("Pending registration schema_version must be 'v3'; found '", entry.schema_version, "'"));
+        absl::StrCat("Pending registration schema_version must be 'v3'; found '", entry->schema_version, "'"));
   }
+
+  std::vector<loader::SegmentPiece> segment_plan;
+  bool segment_plan_ready = false;
 
   // 2) data_multihash via SegmentPlan linearization (PAD=0).
   absl::StatusOr<std::string> data_mh_or;
-  if (entry.plan == PendingRegistrationEntry::Plan::CPU) {
+  if (entry->plan == PendingRegistrationEntry::Plan::CPU) {
     // Hash directly from VS CPU memory (zero-initialized PAD regions).
-    auto region_or = va_space_->region_info(entry.artifact_id);
+    auto region_or = va_space_->region_info(entry->artifact_id);
     if (!region_or.ok()) {
       return region_or.status();
     }
     auto mh_or = loader::compute_data_multihash_from_cpu_memory(
-        gsl::not_null<const void*>{region_or->cpu_base}, entry.size_bytes);
-    if (!mh_or.ok())
+        gsl::not_null<const void*>{region_or->cpu_base}, entry->size_bytes);
+    if (!mh_or.ok()) {
       return mh_or.status();
+    }
     data_mh_or = *mh_or;
   } else {
-    void* gpu_ptr = nullptr;
-    {
-      const auto ptrs = entry.replica->get_memory_manager().get_pointer(MemoryLocation::GPU);
+    void* gpu_ptr = entry->gpu_ptr;
+    if (gpu_ptr == nullptr) {
+      const auto ptrs = entry->replica->get_memory_manager().get_pointer(MemoryLocation::GPU);
       gpu_ptr = (!ptrs.empty() ? ptrs[0] : nullptr);
     }
-    if (entry.tensor_index_data.has_value() && !entry.tensor_index_data->empty() && entry.encoding == "json") {
+    if (!gpu_ptr) {
+      return absl::FailedPreconditionError("GPU pointer is null; cannot hash GPU data");
+    }
+    if (entry->tensor_index_data.has_value() && !entry->tensor_index_data->empty() && entry->encoding == "json") {
       auto plan_or = loader::build_segment_plan_from_canonical_index_json(
-          *entry.tensor_index_data, entry.size_bytes, /*align_bytes=*/8);
-      if (plan_or.ok()) {
-        if (!gpu_ptr) {
-          return absl::FailedPreconditionError("GPU pointer is null; cannot hash GPU plan");
-        }
-        auto mh_or = loader::compute_data_multihash_from_gpu_plan(
-            gsl::not_null<void*>{gpu_ptr}, entry.device_id, absl::MakeSpan(*plan_or), entry.size_bytes);
-        if (!mh_or.ok())
-          return mh_or.status();
-        data_mh_or = *mh_or;
-      } else {
+          *entry->tensor_index_data, entry->size_bytes, /*align_bytes=*/8);
+      if (!plan_or.ok()) {
         return plan_or.status();
       }
-    } else {
-      auto mh_or = common::compute_data_multihash_from_gpu(gpu_ptr, entry.size_bytes, entry.device_id);
-      if (!mh_or.ok())
+      segment_plan = std::move(*plan_or);
+      segment_plan_ready = true;
+      auto mh_or = loader::compute_data_multihash_from_gpu_plan(
+          gsl::not_null<void*>{gpu_ptr}, entry->device_id, absl::MakeSpan(segment_plan), entry->size_bytes);
+      if (!mh_or.ok()) {
         return mh_or.status();
+      }
+      data_mh_or = *mh_or;
+    } else {
+      auto mh_or = common::compute_data_multihash_from_gpu(gpu_ptr, entry->size_bytes, entry->device_id);
+      if (!mh_or.ok()) {
+        return mh_or.status();
+      }
       data_mh_or = *mh_or;
     }
   }
@@ -2409,10 +2717,7 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
     return data_mh_or.status();
   }
 
-  const std::string artifact_id_mi2 = absl::StrCat("mi2:", *index_mh_or, ":", *data_mh_or);
-
-  // Replace entry.artifact_id with the content-addressed ID for registration and return
-  entry.artifact_id = artifact_id_mi2;
+  entry->artifact_id = absl::StrCat("mi2:", *index_mh_or, ":", *data_mh_or);
 
   // Idempotent success: if the same content-addressed artifact already has a
   // replica on the target device, reclaim this allocation and return OK with
@@ -2420,40 +2725,47 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
   // created and no Global Store upsert is attempted.
   {
     DeviceKey dev_key{
-        .type = (entry.plan == PendingRegistrationEntry::Plan::CPU ? DeviceType::CPU : DeviceType::GPU),
-        .ordinal = (entry.plan == PendingRegistrationEntry::Plan::CPU ? -1 : entry.device_id),
+        .type = (entry->plan == PendingRegistrationEntry::Plan::CPU ? DeviceType::CPU : DeviceType::GPU),
+        .ordinal = (entry->plan == PendingRegistrationEntry::Plan::CPU ? -1 : entry->device_id),
         .uuid = ""};
-    loading::ReplicaKey check_key{.artifact_id = entry.artifact_id, .device = dev_key, .replica = 0};
+    loading::ReplicaKey check_key{.artifact_id = entry->artifact_id, .device = dev_key, .replica = 0};
     auto existing_or = replica_registry_->find(check_key);
     if (existing_or.ok()) {
-      // Cleanup: erase pending entry and best-effort release the allocation we made
       {
         std::lock_guard<std::mutex> lock(pending_mutex_);
         pending_regs_.erase(std::string(registration_id));
       }
-      if (entry.plan == PendingRegistrationEntry::Plan::CPU) {
-        // VS path allocated CPU memory
-        absl::Status _st = entry.replica->release_memory(MemoryLocation::CPU);
+      if (entry->plan == PendingRegistrationEntry::Plan::CPU) {
+        absl::Status _st = entry->replica->release_memory(MemoryLocation::CPU);
         if (!_st.ok()) {
           VLOG(1) << "release_memory(CPU) failed during idempotent success cleanup: " << _st;
         }
       } else {
-        // Coalesced/Lease-materialized path allocated GPU memory
-        absl::Status _st = entry.replica->release_memory(MemoryLocation::GPU);
+        absl::Status _st = entry->replica->release_memory(MemoryLocation::GPU);
         if (!_st.ok()) {
           VLOG(1) << "release_memory(GPU) failed during idempotent success cleanup: " << _st;
         }
       }
       RegistrationCommitResult result;
       result.registration_id = std::string(registration_id);
-      result.artifact_id = entry.artifact_id;
-      result.device_id = entry.device_id;
-      result.size_bytes = entry.size_bytes;
+      result.artifact_id = entry->artifact_id;
+      result.device_id = entry->device_id;
+      result.size_bytes = entry->size_bytes;
       result.existed = true;
       result.index_multihash = *index_mh_or;
       result.data_multihash = *data_mh_or;
-      result.schema_version = entry.schema_version;
-      result.encoding = entry.encoding;
+      result.schema_version = entry->schema_version;
+      result.encoding = entry->encoding;
+      if (entry->view_state) {
+        if (!entry->view_state->options.view_id.empty()) {
+          result.view_id = entry->view_state->options.view_id;
+        }
+        result.canonical_ranges = entry->view_state->options.canonical_ranges;
+        result.allow_partial = entry->view_state->options.allow_partial;
+        if (!entry->view_state->plan.forward.view_index_json.empty()) {
+          result.view_index_json = entry->view_state->plan.forward.view_index_json;
+        }
+      }
       return result;
     }
   }
@@ -2463,26 +2775,24 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
   // original logical artifact_id used during Begin/Commit).
   {
     DeviceKey dev_key{
-        .type = (entry.plan == PendingRegistrationEntry::Plan::CPU ? DeviceType::CPU : DeviceType::GPU),
-        .ordinal = (entry.plan == PendingRegistrationEntry::Plan::CPU ? -1 : entry.device_id),
+        .type = (entry->plan == PendingRegistrationEntry::Plan::CPU ? DeviceType::CPU : DeviceType::GPU),
+        .ordinal = (entry->plan == PendingRegistrationEntry::Plan::CPU ? -1 : entry->device_id),
         .uuid = ""};
-    ReplicaKey mi2_key{.artifact_id = entry.artifact_id, .device = dev_key, .replica = 0};
-    {
-      absl::Status emplace_status =
-          replica_registry_->emplace(mi2_key, gsl::not_null<std::shared_ptr<replica::Replica>>{entry.replica});
-      if (absl::IsAlreadyExists(emplace_status)) {
-        VLOG(1) << "mi2 mapping already present for artifact_id=" << entry.artifact_id;
-      } else if (!emplace_status.ok()) {
-        return emplace_status;
-      }
+    ReplicaKey mi2_key{.artifact_id = entry->artifact_id, .device = dev_key, .replica = 0};
+    absl::Status emplace_status =
+        replica_registry_->emplace(mi2_key, gsl::not_null<std::shared_ptr<replica::Replica>>{entry->replica});
+    if (absl::IsAlreadyExists(emplace_status)) {
+      VLOG(1) << "mi2 mapping already present for artifact_id=" << entry->artifact_id;
+    } else if (!emplace_status.ok()) {
+      return emplace_status;
     }
   }
 
   // Export remote memory keys if communication is enabled (GPU location).
   std::vector<std::string> remote_keys;
   std::vector<uint64_t> buffer_sizes;
-  if (entry.plan != PendingRegistrationEntry::Plan::CPU && entry.enable_p2p && comm_manager_->is_enabled()) {
-    auto reg_info_or = entry.replica->enable_remote_memory_access(MemoryLocation::GPU, comm_manager_->get_engine());
+  if (entry->plan != PendingRegistrationEntry::Plan::CPU && entry->enable_p2p && comm_manager_->is_enabled()) {
+    auto reg_info_or = entry->replica->enable_remote_memory_access(MemoryLocation::GPU, comm_manager_->get_engine());
     if (!reg_info_or.ok()) {
       return reg_info_or.status();
     }
@@ -2496,18 +2806,17 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
   // Register with Global Store (memory replica). Provide tensor_index_key and optional UPSERT data.
   if (global_store_client_ && global_store_client_->is_connected()) {
     DeviceKey device{
-        .type = (entry.plan == PendingRegistrationEntry::Plan::CPU ? DeviceType::CPU : DeviceType::GPU),
-        .ordinal = (entry.plan == PendingRegistrationEntry::Plan::CPU ? -1 : entry.device_id),
+        .type = (entry->plan == PendingRegistrationEntry::Plan::CPU ? DeviceType::CPU : DeviceType::GPU),
+        .ordinal = (entry->plan == PendingRegistrationEntry::Plan::CPU ? -1 : entry->device_id),
         .uuid = ""};
     const std::string wid = worker_id_.empty() ? std::string("local") : worker_id_;
-    // Generate lightweight verification info (KEY_POINTS) for receiver-side validation
     std::optional<std::string> verification_json;
     if (!remote_keys.empty()) {
-      std::vector<void*> data_ptrs = entry.replica->get_memory_manager().get_pointer(MemoryLocation::GPU);
+      std::vector<void*> data_ptrs = entry->replica->get_memory_manager().get_pointer(MemoryLocation::GPU);
       if (!data_ptrs.empty() && data_ptrs[0] != nullptr) {
-        std::vector<size_t> data_sizes{static_cast<size_t>(entry.size_bytes)};
+        std::vector<size_t> data_sizes{static_cast<size_t>(entry->size_bytes)};
         auto info_or = common::ArtifactVerifier::generate_verification_info(
-            data_ptrs, data_sizes, entry.device_id, common::VerificationLevel::KEY_POINTS);
+            data_ptrs, data_sizes, entry->device_id, common::VerificationLevel::KEY_POINTS);
         if (info_or.ok()) {
           verification_json = info_or->to_json();
         }
@@ -2515,16 +2824,16 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
     }
 
     auto reg_or = global_store_client_->register_memory_replica(
-        entry.artifact_id,
+        entry->artifact_id,
         /*worker_id=*/wid,
         device,
-        entry.size_bytes,
-        entry.tensor_index_key,
+        entry->size_bytes,
+        entry->tensor_index_key,
         remote_keys,
         buffer_sizes,
-        entry.tensor_index_data,
-        entry.encoding,
-        entry.schema_version,
+        entry->tensor_index_data,
+        entry->encoding,
+        entry->schema_version,
         /*max_concurrency=*/1,
         verification_json);
     if (!reg_or.ok()) {
@@ -2532,23 +2841,206 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
     }
   }
 
-  // Finalize: remove from pending list on success.
+  // Compute view data hash and collect leaf digests once canonical data commit succeeds.
+  std::optional<std::string> view_data_hash;
+  std::optional<std::string> view_spec_json;
+  std::vector<global_store::v1::LeafWrite> leaf_writes;
+  std::vector<uint64_t> canonical_leaf_indices;
+  std::optional<size_t> leaf_chunk_bytes;
+  if (entry->view_state) {
+    if (!segment_plan_ready && entry->tensor_index_data.has_value() && !entry->tensor_index_data->empty() &&
+        entry->encoding == "json") {
+      auto plan_or = loader::build_segment_plan_from_canonical_index_json(
+          *entry->tensor_index_data, entry->size_bytes, /*align_bytes=*/8);
+      if (plan_or.ok()) {
+        segment_plan = std::move(*plan_or);
+        segment_plan_ready = true;
+      } else {
+        LOG(WARNING) << "Failed to rebuild segment plan for view hash: " << plan_or.status();
+      }
+    }
+    view_spec_json = build_view_spec_json(entry->view_state->options.spec);
+    leaf_chunk_bytes =
+        options_.artifact_chunk_bytes == 0 ? static_cast<size_t>(4ULL * 1024 * 1024) : options_.artifact_chunk_bytes;
+
+    if (segment_plan_ready && entry->view_state->plan.forward.selection.total_bytes > 0 &&
+        leaf_chunk_bytes.has_value()) {
+      void* gpu_ptr = entry->gpu_ptr;
+      if (gpu_ptr == nullptr) {
+        const auto ptrs = entry->replica->get_memory_manager().get_pointer(MemoryLocation::GPU);
+        gpu_ptr = (!ptrs.empty() ? ptrs[0] : nullptr);
+      }
+      if (gpu_ptr != nullptr) {
+        loader::LinearizedGpuPlanSource canonical_source(
+            gsl::not_null<void*>{gpu_ptr}, entry->device_id, absl::MakeSpan(segment_plan), entry->size_bytes);
+        loader::ViewPlanSource view_source(
+            gsl::not_null<loader::SeekableSource*>{&canonical_source}, entry->view_state->plan.forward.selection);
+        auto view_hash_or = compute_tree_hash_and_leaves(
+            view_source, entry->view_state->plan.forward.selection.total_bytes, *leaf_chunk_bytes);
+        if (view_hash_or.ok()) {
+          view_data_hash = view_hash_or->multihash;
+          const auto& digests = view_hash_or->leaf_digests;
+          leaf_writes.reserve(leaf_writes.size() + digests.size());
+          for (size_t idx = 0; idx < digests.size(); ++idx) {
+            global_store::v1::LeafWrite leaf;
+            leaf.set_space_kind(tensorcast::global_store::v1::BYTE_SPACE_KIND_VARIANT);
+            leaf.set_space_id(entry->view_state->options.view_id);
+            leaf.set_leaf_idx(static_cast<uint64_t>(idx));
+            const auto& digest = digests[idx];
+            leaf.set_digest(digest.data(), static_cast<int>(digest.size()));
+            leaf_writes.push_back(std::move(leaf));
+          }
+        } else {
+          LOG(WARNING) << "ComputeTreeHashAndLeaves (view) failed: " << view_hash_or.status();
+        }
+      }
+    }
+    canonical_leaf_indices = compute_fully_covered_canonical_leaf_indices(
+        entry->view_state->options.canonical_ranges, leaf_chunk_bytes.value_or(0));
+  }
+
+  if (entry->view_state && leaf_chunk_bytes.has_value() && !canonical_leaf_indices.empty()) {
+    auto canonical_digest_or = compute_canonical_leaf_digests(
+        *entry->replica,
+        entry->plan == PendingRegistrationEntry::Plan::CPU,
+        entry->gpu_ptr,
+        entry->device_id,
+        entry->size_bytes,
+        canonical_leaf_indices,
+        *leaf_chunk_bytes);
+    if (!canonical_digest_or.ok()) {
+      LOG(WARNING) << "Failed to compute canonical leaf digests for view registration: "
+                   << canonical_digest_or.status();
+    } else if (canonical_digest_or->size() != canonical_leaf_indices.size()) {
+      LOG(WARNING) << "Canonical leaf digest count mismatch: expected " << canonical_leaf_indices.size() << " got "
+                   << canonical_digest_or->size();
+    } else {
+      leaf_writes.reserve(leaf_writes.size() + canonical_leaf_indices.size());
+      for (size_t i = 0; i < canonical_leaf_indices.size(); ++i) {
+        global_store::v1::LeafWrite leaf;
+        leaf.set_space_kind(tensorcast::global_store::v1::BYTE_SPACE_KIND_CANONICAL);
+        leaf.set_space_id(*index_mh_or);
+        leaf.set_leaf_idx(canonical_leaf_indices[i]);
+        const auto& digest = (*canonical_digest_or)[i];
+        leaf.set_digest(digest.data(), static_cast<int>(digest.size()));
+        leaf_writes.push_back(std::move(leaf));
+      }
+    }
+  }
+
   {
     std::lock_guard<std::mutex> lock(pending_mutex_);
     pending_regs_.erase(std::string(registration_id));
   }
+
   RegistrationCommitResult result;
   result.registration_id = std::string(registration_id);
-  result.artifact_id = entry.artifact_id;
-  result.device_id = entry.device_id;
-  result.size_bytes = entry.size_bytes;
+  result.artifact_id = entry->artifact_id;
+  result.device_id = entry->device_id;
+  result.size_bytes = entry->size_bytes;
   result.existed = false;
-  // RFC-0007: Fill descriptor fields for upstream layers
   result.index_multihash = *index_mh_or;
   result.data_multihash = *data_mh_or;
-  result.schema_version = entry.schema_version;
-  result.encoding = entry.encoding;
+  result.schema_version = entry->schema_version;
+  result.encoding = entry->encoding;
+  uint64_t covered_bytes = 0;
+  if (entry->view_state) {
+    if (!entry->view_state->options.view_id.empty()) {
+      result.view_id = entry->view_state->options.view_id;
+    }
+    if (view_data_hash.has_value()) {
+      result.view_data_multihash = view_data_hash;
+    }
+    if (!entry->view_state->plan.forward.view_index_json.empty()) {
+      result.view_index_json = entry->view_state->plan.forward.view_index_json;
+    }
+    result.canonical_ranges = entry->view_state->options.canonical_ranges;
+    result.allow_partial = entry->view_state->options.allow_partial;
+    covered_bytes = 0;
+    for (const auto& range : result.canonical_ranges) {
+      covered_bytes += range.length;
+    }
+  }
+
+  if (entry->view_state && global_store_client_ && global_store_client_->is_connected() &&
+      !entry->view_state->options.view_id.empty()) {
+    components::VariantViewUpdate update;
+    update.artifact_id = entry->artifact_id;
+    update.view_id = entry->view_state->options.view_id;
+    update.view_spec_json = view_spec_json.value_or(build_view_spec_json(entry->view_state->options.spec));
+    update.view_size_bytes = entry->view_state->plan.forward.view_size_bytes;
+    update.view_data_hash = view_data_hash;
+    update.mark_verified = true;
+    update.canonical_size_bytes = entry->size_bytes;
+    update.canonical_bytes_covered = covered_bytes;
+    update.leaf_writes = std::move(leaf_writes);
+    absl::Status update_status = global_store_client_->update_artifact_view_state(update);
+    if (!update_status.ok()) {
+      LOG(WARNING) << "UpdateArtifactViewState failed for artifact " << entry->artifact_id
+                   << " view_id=" << entry->view_state->options.view_id << ": " << update_status;
+    }
+  }
   return result;
+}
+
+absl::Status StoreEngine::ingest_view_registration_chunk(
+    std::string_view registration_id,
+    uint64_t view_offset,
+    absl::Span<const std::byte> data) {
+  if (data.empty()) {
+    return absl::OkStatus();
+  }
+  std::shared_ptr<PendingRegistrationEntry> entry;
+  {
+    std::lock_guard<std::mutex> lock(pending_mutex_);
+    auto it = pending_regs_.find(std::string(registration_id));
+    if (it == pending_regs_.end()) {
+      return absl::NotFoundError("registration_id not found");
+    }
+    entry = it->second;
+  }
+  if (!entry || !entry->view_state) {
+    return absl::FailedPreconditionError("registration is not view-enabled");
+  }
+  auto& view_state = *entry->view_state;
+  if (view_state.options.placement != ViewPlacement::kServer) {
+    return absl::FailedPreconditionError("view chunk ingestion is only valid for SERVER placement");
+  }
+  if (!view_state.executor) {
+    return absl::FailedPreconditionError("view executor missing for SERVER placement ingestion");
+  }
+  void* canonical_base = entry->gpu_ptr;
+  if (canonical_base == nullptr) {
+    const auto ptrs = entry->replica->get_memory_manager().get_pointer(MemoryLocation::GPU);
+    canonical_base = (!ptrs.empty() ? ptrs[0] : nullptr);
+    if (canonical_base == nullptr) {
+      return absl::FailedPreconditionError("GPU pointer unavailable for view ingestion");
+    }
+    entry->gpu_ptr = canonical_base;
+  }
+  auto status =
+      view_state.executor->ingest_chunk(view_offset, data, MemoryLocation::GPU, canonical_base, entry->device_id);
+  if (!status.ok()) {
+    return status;
+  }
+  view_state.ingested_bytes = view_state.executor->ingested_bytes();
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint64_t> StoreEngine::get_view_registration_ingested_bytes(std::string_view registration_id) {
+  std::lock_guard<std::mutex> lock(pending_mutex_);
+  auto it = pending_regs_.find(std::string(registration_id));
+  if (it == pending_regs_.end()) {
+    return absl::NotFoundError("registration_id not found");
+  }
+  const std::shared_ptr<PendingRegistrationEntry>& entry = it->second;
+  if (!entry || !entry->view_state) {
+    return absl::FailedPreconditionError("registration has no view state");
+  }
+  if (entry->view_state->executor) {
+    return entry->view_state->executor->ingested_bytes();
+  }
+  return entry->view_state->expected_view_bytes;
 }
 
 absl::Status StoreEngine::keep_alive_registered_artifact(std::string_view registration_id, uint32_t ttl_ms) {
@@ -2560,7 +3052,7 @@ absl::Status StoreEngine::keep_alive_registered_artifact(std::string_view regist
   if (it == pending_regs_.end()) {
     return absl::NotFoundError("registration_id not found");
   }
-  it->second.expiry_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(ttl_ms);
+  it->second->expiry_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(ttl_ms);
   return absl::OkStatus();
 }
 
@@ -2594,7 +3086,7 @@ absl::Status StoreEngine::abort_registered_artifact(std::string_view registratio
     if (it == pending_regs_.end()) {
       return absl::NotFoundError("registration_id not found");
     }
-    replica = it->second.replica;
+    replica = it->second->replica;
     pending_regs_.erase(it);
   }
   if (replica) {

--- a/core/store/store_engine.h
+++ b/core/store/store_engine.h
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
+#include "absl/types/span.h"
 #include "core/common/memory/pinned_buffer_pool.h"
 #include "core/common/memory/virtual_address_space.h"
 #include "core/store/components/communication_manager.h"
@@ -36,6 +37,9 @@ class MaterializeOrchestrator;
 namespace loader {
 struct ViewPlan;
 struct ViewSpec;
+struct ViewWritePlan;
+struct BidirectionalViewPlan;
+class ViewIngestExecutor;
 class SeekableSource;
 } // namespace loader
 
@@ -104,6 +108,22 @@ class StoreEngine {
       const loader::ViewPlan& plan,
       size_t leaf_chunk_bytes = 4ULL * 1024 * 1024);
 
+  enum class ViewPlacement : uint8_t { kUnspecified = 0, kServer = 1, kClient = 2 };
+
+  struct CanonicalRange {
+    uint64_t offset{0};
+    uint64_t length{0};
+  };
+
+  struct ViewRegistration {
+    std::string view_id;
+    loader::ViewSpec spec;
+    ViewPlacement placement{ViewPlacement::kUnspecified};
+    uint64_t canonical_size_bytes{0};
+    std::vector<CanonicalRange> canonical_ranges;
+    bool allow_partial{false};
+  };
+
   // ------------------------------------------------------------------------
   // Memory Artifact Registration (coalesced) – Phase A (RFC-0006)
   // ------------------------------------------------------------------------
@@ -118,6 +138,7 @@ class StoreEngine {
     uint64_t total_size_bytes{0}; // Total coalesced byte size (8B-aligned)
     bool enable_p2p{true}; // Whether to enable remote access
     uint32_t ttl_ms{0}; // Optional TTL for Begin→Commit (0 = no TTL)
+    std::optional<ViewRegistration> view;
   };
 
   struct RegistrationBeginResult {
@@ -154,9 +175,21 @@ class StoreEngine {
     std::string data_multihash; // multibase(base32)-encoded multihash of tree-hash root
     std::string schema_version; // e.g. "v3"
     std::string encoding; // e.g. "json" or "cbor"
+    std::optional<std::string> view_id;
+    std::optional<std::string> view_data_multihash;
+    std::optional<std::string> view_index_json;
+    std::vector<CanonicalRange> canonical_ranges;
+    bool allow_partial{false};
   };
 
   absl::StatusOr<RegistrationCommitResult> commit_registered_artifact(std::string_view registration_id);
+
+  absl::Status ingest_view_registration_chunk(
+      std::string_view registration_id,
+      uint64_t view_offset,
+      absl::Span<const std::byte> data);
+
+  absl::StatusOr<uint64_t> get_view_registration_ingested_bytes(std::string_view registration_id);
 
   /**
    * @brief Abort a pending registration and release allocated memory.
@@ -372,10 +405,21 @@ class StoreEngine {
     cudaIpcMemHandle_t ipc_handle{}; // CUDA IPC handle bytes
     std::chrono::steady_clock::time_point expiry_time; // For TTL cleanup
     enum class Plan : uint8_t { COALESCED = 0, CPU = 1 } plan{Plan::COALESCED};
+
+    struct ViewState {
+      ViewRegistration options;
+      loader::BidirectionalViewPlan plan;
+      std::unique_ptr<loader::ViewIngestExecutor> executor;
+      uint64_t expected_view_bytes{0};
+      uint64_t ingested_bytes{0};
+      bool finalized{false};
+    };
+
+    std::unique_ptr<ViewState> view_state;
   };
 
   std::mutex pending_mutex_;
-  std::unordered_map<std::string, PendingRegistrationEntry> pending_regs_;
+  std::unordered_map<std::string, std::shared_ptr<PendingRegistrationEntry>> pending_regs_;
 
   // Worker identity (for Global Store registrations)
   std::string worker_id_;

--- a/core/store/store_engine_test.cc
+++ b/core/store/store_engine_test.cc
@@ -169,6 +169,7 @@ class RecordingGlobalStoreClient final : public tensorcast::store::components::I
   std::vector<std::string> replica_requests;
   std::vector<std::string> registered_replicas;
   std::vector<std::tuple<std::string, std::string, uint64_t>> recorded_variants;
+  std::vector<tensorcast::store::components::VariantViewUpdate> view_updates;
 
   absl::Status initialize() override {
     return absl::OkStatus();
@@ -244,6 +245,12 @@ class RecordingGlobalStoreClient final : public tensorcast::store::components::I
 
   absl::Status unregister_replica(std::string_view, std::string_view) override {
     return absl::UnimplementedError("unregister_replica not supported in test stub");
+  }
+
+  absl::Status update_artifact_view_state(const tensorcast::store::components::VariantViewUpdate& update) override {
+    view_requests.emplace_back(update.view_id);
+    view_updates.push_back(update);
+    return absl::OkStatus();
   }
 
   absl::StatusOr<tensorcast::store::components::TransportSession> request_replica_transport(

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -19,6 +19,7 @@ The Store Daemon is the data-plane service process that exposes a stable gRPC AP
 - Ephemeral state management with TTL: sessions (`replica_uuid` → key + readiness), PID references, transport locks, verification tracking.
 - Event-driven background scheduling with a unified `SessionLifecycleTask` (sessions TTL, PID liveness, registration join TTL), plus Lock TTL and Verification tasks. The lifecycle manager exposes a schedule hook so the scheduler can be rescheduled immediately when the earliest deadline changes, minimizing expiry drift.
 - Observability wrappers that attach unified metrics and tracing to each RPC.
+- Handles view registration uploads (slice/transpose) without feature flags: `RegistrationController` streams view chunks to the StoreEngine and publishes variant telemetry through Global Store (see [Variant View Registration Telemetry](../docs/architecture/p2p-transfer-strategies.md#variant-view-registration-telemetry)).
 - Enforces non-loopback advertisement when registering with Global Store; startup fails if no routable IP can be determined and `--advertise_host` is unset.
 - Immediate reclaim: when the last UseLease retires and no PlacementPins remain for a daemon-owned GPU replica, the lifecycle finalizer unloads the replica immediately (best-effort).
 - Eviction consults lifecycle counters (use_count, placement_pins); request-level cache hints removed.

--- a/daemon/grpc_service_impl_registration_test.cc
+++ b/daemon/grpc_service_impl_registration_test.cc
@@ -2,6 +2,7 @@
 
 #include "daemon/grpc_service_impl.h"
 
+#include <unistd.h>
 #include <filesystem>
 #include <string>
 
@@ -47,7 +48,7 @@ TEST_CASE("CommitRegisteredArtifact populates descriptor", "[daemon][registratio
   breq.set_owner_pid(getpid());
   auto* idx = breq.mutable_tensor_index_data();
   idx->set_data("{}");
-  idx->set_schema_version("v2");
+  idx->set_schema_version("v3");
   idx->set_encoding("json");
 
   grpc::ServerContext ctx;
@@ -75,4 +76,38 @@ TEST_CASE("CommitRegisteredArtifact populates descriptor", "[daemon][registratio
   REQUIRE(!desc.index_multihash().empty());
   REQUIRE(!desc.data_multihash().empty());
   REQUIRE(desc.total_size() == 1 * 1024 * 1024);
+}
+
+TEST_CASE(
+    "BeginRegisterArtifact enforces server transpose fallback when GPU unavailable",
+    "[daemon][registration][view]") {
+  auto engine = std::make_shared<tensorcast::store::StoreEngine>(make_opts());
+  StoreDaemonServiceImpl service(engine);
+
+  tensorcast::daemon::v1::BeginRegisterArtifactRequest breq;
+  breq.set_device_id(99); // invalid device id to trigger fallback guard
+  breq.set_total_size(16);
+  breq.set_owner_pid(getpid());
+  auto* idx = breq.mutable_tensor_index_data();
+  idx->set_data(R"({"weights":[0,16,[2,2],[2,1],"torch.float32",0]})");
+  idx->set_schema_version("v3");
+  idx->set_encoding("json");
+
+  auto* view = breq.mutable_view();
+  view->set_view_id("view-transpose");
+  view->set_canonical_size_bytes(16);
+  view->set_allow_partial(false);
+  view->set_placement(tensorcast::daemon::v1::TRANSFORM_PLACEMENT_SERVER);
+  auto& tensors = *view->mutable_spec()->mutable_tensors();
+  tensorcast::daemon::v1::TensorViewOps ops;
+  auto* transpose = ops.add_ops()->mutable_transpose();
+  transpose->set_dim0(0);
+  transpose->set_dim1(1);
+  tensors["weights"] = ops;
+
+  grpc::ServerContext ctx;
+  tensorcast::daemon::v1::BeginRegisterArtifactResponse bresp;
+  auto status = service.BeginRegisterArtifact(&ctx, &breq, &bresp);
+  REQUIRE(status.error_code() == grpc::StatusCode::FAILED_PRECONDITION);
+  REQUIRE(status.error_message().find("placement=CLIENT") != std::string::npos);
 }

--- a/daemon/registration_manager.h
+++ b/daemon/registration_manager.h
@@ -34,6 +34,13 @@ class RegistrationManager {
     bool lease_in_place{false};
     std::string index_key_hex;
     std::string index_data;
+    bool view_registration{false};
+    store::StoreEngine::ViewPlacement view_placement{store::StoreEngine::ViewPlacement::kUnspecified};
+    std::string view_id;
+    bool view_allow_partial{false};
+    uint64_t view_ingested_bytes{0};
+    std::vector<store::StoreEngine::CanonicalRange> view_canonical_ranges;
+    std::optional<std::string> view_data_multihash;
     // Join semantics: set when Commit detects an existing replica and the
     // controller joined a lightweight reference for this registration.
     bool joined_existing{false};
@@ -87,6 +94,14 @@ class RegistrationManager {
     auto& bucket = reg_aliases_[reg_id];
     for (auto& a : aliases)
       bucket.push_back(std::move(a));
+  }
+
+  void update_view_ingested_bytes(const std::string& reg_id, uint64_t bytes) {
+    absl::MutexLock l(&mu_);
+    auto it = reg_meta_.find(reg_id);
+    if (it != reg_meta_.end()) {
+      it->second.view_ingested_bytes = bytes;
+    }
   }
 
   std::vector<LeaseSegMeta> get_lease_segments(const std::string& reg_id) const {

--- a/daemon/server_main.cc
+++ b/daemon/server_main.cc
@@ -29,7 +29,6 @@
 ABSL_FLAG(std::string, config, "", "Path to unified daemon config (YAML/JSON)");
 ABSL_FLAG(std::string, config_text, "", "Inline daemon config as YAML/JSON text (mutually exclusive with --config)");
 ABSL_FLAG(bool, use_cursor_pagination, false, "Enable opaque cursor pagination for GetLoadedReplicasV2");
-
 using namespace tensorcast;
 
 int main(int argc, char** argv) {

--- a/daemon/service/controllers/registration_controller.cc
+++ b/daemon/service/controllers/registration_controller.cc
@@ -4,12 +4,16 @@
 
 #include "daemon/service/controllers/registration_controller.h"
 
+#include <cstddef>
 #include <string>
 
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "core/store/loader/view_planner.h"
 #include "daemon/status_utils.h"
 #include "opentelemetry/metrics/provider.h"
 
@@ -18,6 +22,69 @@ namespace tensorcast::daemon {
 using ::grpc::Status;
 using ::grpc::StatusCode;
 using status_utils::to_grpc_status;
+
+namespace {
+
+absl::StatusOr<store::loader::ViewSpec> BuildViewSpecFromProto(const v1::ViewSpec& spec_proto) {
+  store::loader::ViewSpec spec;
+  for (const auto& [tensor_name, ops_proto] : spec_proto.tensors()) {
+    store::loader::TensorViewOps tensor_ops;
+    for (const auto& op_proto : ops_proto.ops()) {
+      if (op_proto.has_narrow()) {
+        const auto& narrow = op_proto.narrow();
+        store::loader::NarrowOp narrow_op;
+        narrow_op.dim = static_cast<int32_t>(narrow.dim());
+        narrow_op.start = narrow.start();
+        narrow_op.length = narrow.length();
+        tensor_ops.ops.push_back(store::loader::ViewOp::Narrow(narrow_op));
+      } else if (op_proto.has_transpose()) {
+        const auto& transpose = op_proto.transpose();
+        store::loader::TransposeOp transpose_op;
+        transpose_op.dim0 = static_cast<int32_t>(transpose.dim0());
+        transpose_op.dim1 = static_cast<int32_t>(transpose.dim1());
+        tensor_ops.ops.push_back(store::loader::ViewOp::Transpose(transpose_op));
+      } else {
+        return absl::InvalidArgumentError("unsupported view operation in ViewSpec");
+      }
+    }
+    spec.tensors.emplace(tensor_name, std::move(tensor_ops));
+  }
+  return spec;
+}
+
+store::StoreEngine::ViewPlacement ToPlacement(v1::TransformPlacement placement) {
+  switch (placement) {
+    case v1::TRANSFORM_PLACEMENT_SERVER:
+      return store::StoreEngine::ViewPlacement::kServer;
+    case v1::TRANSFORM_PLACEMENT_CLIENT:
+      return store::StoreEngine::ViewPlacement::kClient;
+    case v1::TRANSFORM_PLACEMENT_UNSPECIFIED:
+    default:
+      return store::StoreEngine::ViewPlacement::kUnspecified;
+  }
+}
+
+void record_view_bytes_metric(double bytes) {
+  try {
+    static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+    static auto counter = meter->CreateDoubleCounter("tc_register_view_bytes_total");
+    counter->Add(bytes);
+  } catch (...) {
+    VLOG(1) << "metrics counter tc_register_view_bytes_total unavailable";
+  }
+}
+
+void record_view_partial_metric() {
+  try {
+    static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+    static auto counter = meter->CreateDoubleCounter("tc_register_view_partials_total");
+    counter->Add(1.0);
+  } catch (...) {
+    VLOG(1) << "metrics counter tc_register_view_partials_total unavailable";
+  }
+}
+
+} // namespace
 
 grpc::Status RegistrationController::begin(
     RpcContext& rctx,
@@ -55,6 +122,28 @@ grpc::Status RegistrationController::begin(
     meta.index_key_hex = req.tensor_index_key();
   else if (req.has_tensor_index_data())
     meta.index_data = std::string(req.tensor_index_data().data().begin(), req.tensor_index_data().data().end());
+
+  if (req.has_view()) {
+    auto placement = ToPlacement(req.view().placement());
+    if (placement == store::StoreEngine::ViewPlacement::kUnspecified) {
+      return {StatusCode::INVALID_ARGUMENT, "view placement must be specified"};
+    }
+    auto spec_or = BuildViewSpecFromProto(req.view().spec());
+    if (!spec_or.ok()) {
+      return to_grpc_status(spec_or.status());
+    }
+    store::StoreEngine::ViewRegistration view_reg;
+    view_reg.view_id = req.view().view_id();
+    view_reg.spec = std::move(*spec_or);
+    view_reg.placement = placement;
+    view_reg.canonical_size_bytes = req.view().canonical_size_bytes();
+    view_reg.allow_partial = req.view().allow_partial();
+    reg.view = view_reg;
+    meta.view_registration = true;
+    meta.view_placement = placement;
+    meta.view_id = view_reg.view_id;
+    meta.view_allow_partial = view_reg.allow_partial;
+  }
 
   if (plan == RegistrationManager::RegPlan::COALESCED) {
     if (req.has_tensor_index_key())
@@ -164,6 +253,18 @@ grpc::Status RegistrationController::feed_stream(
         to_add.push_back(std::move(m));
       }
       d_.reg.append_lease_segments(reg_id, std::move(to_add));
+    } else if (req.has_view_chunk()) {
+      const std::string& payload = req.view_chunk().data();
+      absl::Span<const std::byte> bytes(reinterpret_cast<const std::byte*>(payload.data()), payload.size());
+      auto ingest_status = d_.engine.ingest_view_registration_chunk(reg_id, req.view_chunk().view_offset(), bytes);
+      if (!ingest_status.ok()) {
+        return to_grpc_status(ingest_status);
+      }
+      record_view_bytes_metric(static_cast<double>(payload.size()));
+      auto ingested_or = d_.engine.get_view_registration_ingested_bytes(reg_id);
+      if (ingested_or.ok()) {
+        d_.reg.update_view_ingested_bytes(reg_id, *ingested_or);
+      }
     } else if (!req.storage_entries().empty() || !req.tensor_aliases().empty()) {
       // allow requests that only carry storage/alias metadata without segments
     } else {
@@ -260,6 +361,18 @@ grpc::Status RegistrationController::feed_vector(const std::vector<v1::FeedRegis
         to_add.push_back(std::move(m));
       }
       d_.reg.append_lease_segments(reg_id, std::move(to_add));
+    } else if (req.has_view_chunk()) {
+      const std::string& payload = req.view_chunk().data();
+      absl::Span<const std::byte> bytes(reinterpret_cast<const std::byte*>(payload.data()), payload.size());
+      auto ingest_status = d_.engine.ingest_view_registration_chunk(reg_id, req.view_chunk().view_offset(), bytes);
+      if (!ingest_status.ok()) {
+        return to_grpc_status(ingest_status);
+      }
+      record_view_bytes_metric(static_cast<double>(payload.size()));
+      auto ingested_or = d_.engine.get_view_registration_ingested_bytes(reg_id);
+      if (ingested_or.ok()) {
+        d_.reg.update_view_ingested_bytes(reg_id, *ingested_or);
+      }
     } else if (!req.storage_entries().empty() || !req.tensor_aliases().empty()) {
       // allow metadata-only payloads
     } else {
@@ -467,6 +580,41 @@ grpc::Status RegistrationController::commit(
     desc->set_encoding(out.encoding);
     desc->set_total_size(out.size_bytes);
     resp.set_existed(out.existed);
+    if (out.view_id.has_value()) {
+      resp.set_view_id(*out.view_id);
+    }
+    if (out.view_index_json.has_value()) {
+      resp.set_view_index_json(*out.view_index_json);
+    }
+    if (out.view_data_multihash.has_value()) {
+      resp.set_view_data_hash(*out.view_data_multihash);
+    }
+    for (const auto& range : out.canonical_ranges) {
+      auto* r = resp.add_canonical_ranges();
+      r->set_offset(range.offset);
+      r->set_length(range.length);
+    }
+    resp.set_allow_partial(out.allow_partial);
+    if (out.view_id.has_value()) {
+      meta.view_registration = true;
+      meta.view_id = *out.view_id;
+      meta.view_canonical_ranges = out.canonical_ranges;
+      meta.view_data_multihash = out.view_data_multihash;
+      uint64_t covered_bytes = 0;
+      for (const auto& range : out.canonical_ranges) {
+        covered_bytes += range.length;
+      }
+      if (!out.existed && covered_bytes < out.size_bytes) {
+        record_view_partial_metric();
+        LOG(INFO) << "View registration partial coverage: artifact_id=" << out.artifact_id
+                  << " view_id=" << *out.view_id << " covered_bytes=" << covered_bytes
+                  << " canonical_bytes=" << out.size_bytes << " ingested_view_bytes=" << meta.view_ingested_bytes;
+      } else {
+        VLOG(1) << "View registration coverage: artifact_id=" << out.artifact_id << " view_id=" << *out.view_id
+                << " covered_bytes=" << covered_bytes << " canonical_bytes=" << out.size_bytes
+                << " ingested_view_bytes=" << meta.view_ingested_bytes;
+      }
+    }
     if (out.existed) {
       // Join reference to existing GPU replica for coalesced plan duplicates
       store::loading::ReplicaKey key{

--- a/docs/designs/0018-artifact-view-registration.md
+++ b/docs/designs/0018-artifact-view-registration.md
@@ -1,0 +1,230 @@
+---
+slug: 0018-artifact-view-registration
+title: Draft — Variant View Registration (v1.5)
+areas: ["core","daemon","global_store","sdk"]
+related_code:
+  - core/store/**
+  - daemon/**
+  - tensorcast/api/**
+  - tensorcast/global_store/**
+status: drafting
+---
+
+# Summary
+
+We already ship view-aware retrieval: the daemon, core engine, and SDK can narrow or transpose canonical artifacts without materialising the full tensor set, using `ViewPlanner`, `ViewPlanSource`, and the variant metadata plumbed through Global Store (`variants`, `leaves`, `UpdateArtifactViewState`). Registration, however, still requires clients to upload canonical byte layouts. This draft spreads the same ergonomics to **registration** so trainers can register partial slices or layout-permuted tensors while the system computes canonical bytes, hashes, and variant metadata on their behalf.
+
+Key ingredients we can reuse today:
+
+- Canonical index v3 enforcement (`StoreEngine`, SDK) and the normalized JSON rebuild.
+- `ViewPlanner`/`TransformPlan` infrastructure that already knows how to map canonical → view.
+- Global Store tables + RPCs that persist variant specs, sizes, hashes, and leaf digests.
+- Variant-aware residency keys and orchestration path in the daemon.
+
+The registration design therefore focuses on the inverse data path (view → canonical), lifecycle wiring, and SDK ergonomics, rather than brand-new primitives.
+
+# Goals
+
+1. Allow Python SDK users to call `Store.register_view(...)` with either a `ViewSpec` or `view_id` and upload **only** the bytes required for that view (slices or transpose).
+2. Ensure the daemon/core transform uploaded view bytes back into canonical ByteSpace, compute canonical + variant tree hashes, and persist both via Global Store.
+3. Support partial canonical coverage: multiple view registrations (e.g., TP shards) can collectively compose the canonical artifact while each shard only transfers its slice.
+4. Maintain parity with retrieval placement semantics (SERVER vs CLIENT) and reuse `ViewPlanner` so semantics stay symmetrical.
+5. Preserve existing registration metrics/telemetry and extend them with view identifiers without regressing canonical flows.
+
+# Non-Goals
+
+- No changes to canonical chunk-directory routing or replica discovery (still anchored on canonical ByteSpace).
+- Do not introduce new transform kinds beyond narrow + transpose.
+- Do not reintroduce schema_version downgrade paths; everything stays v3-only.
+- Out of scope: orchestrating automatic view merges across multiple tenants; we just enforce consistent metadata and integrity.
+
+# Current Gaps
+
+| Layer | Retrieval status | Registration gap |
+|-------|------------------|------------------|
+| SDK   | `get_view`, `get_view_into` shipped; `register_view` missing | Need user-facing API, argument validation, placement defaults |
+| Daemon Proto | `MaterializeReplica` carries view spec/id | `RegisterArtifact` fields exist in proto but daemon ignores them |
+| Core Engine | View planning/execution for load path | No ingest path that maps view bytes back into canonical storage |
+| Global Store | Variant metadata + leaf persistence wired for loads | Registration path never calls `UpdateArtifactViewState`; canonical leaves not updated during partial writes |
+| Tests | Load path tests & Python view API unit suite | Lack end-to-end coverage for register flows (slice + transpose) |
+
+# Proposed Design
+
+## 1. Bidirectional View Plans in Core
+
+### 1.1 Extend `ViewPlanner`
+
+`ViewPlanner::compute_view_plan` currently emits:
+
+- `SelectionPlan` mapping canonical offsets → view offsets (`src_offset`, `dst_offset`, len).
+- `TransformPlan` describing forward permutations (canonical → view).
+- Metadata booleans (alias eligibility, requires_materialization, view size bytes, etc.).
+
+For registration we need the inverse:
+
+1. **WritePlan** — describes how to write view bytes into canonical storage.
+   - For every `kData` range in `SelectionPlan`, create a `ViewWritePlan::Chunk` with `view_offset`, `canonical_offset`, `length`, and `is_segment_aligned`.
+   - Preserve PAD semantics: skips canonical gaps unless the view provided zero-fill (should not happen for narrow).
+2. **InverseTransformPlan** — reuse the exact tensor metadata but invert permutations.
+   - Precompute inverse permutation vectors (e.g., `[1,2,0]` -> `[2,0,1]`) so ingestion can call `permute` once on the view tensor to reconstruct canonical layout.
+   - Flag tensors that require materialisation (transpose) so ingestion can allocate staging buffers or use in-place operations depending on placement.
+
+Implementation sketch:
+
+```cpp
+struct ViewWritePlan {
+  struct Chunk {
+    uint64_t canonical_offset;
+    uint64_t view_offset;
+    uint64_t length;
+    bool segment_aligned;
+  };
+  std::vector<Chunk> chunks;
+};
+
+struct BidirectionalViewPlan {
+  SelectionPlan forward;
+  TransformPlan forward_transform;
+  ViewWritePlan inverse;
+  TransformPlan inverse_transform; // permutations inverted, sizes identical
+};
+```
+
+`ViewPlanner` produces `BidirectionalViewPlan`. Existing retrieval code uses `forward`; registration code consumes `inverse`.
+
+### 1.2 Ingest Executor
+
+Add `core/store/loader/view_ingest_executor.{h,cc}`:
+
+- Mirrors `view_plan_source` but performs writes.
+- Input: `BidirectionalViewPlan`, `SeekableSink` (wrapper over canonical backing buffer or DMA writer), pointer to view staging buffer.
+- For narrow (no transform): iterate `chunks`, memcpy from view buffer into canonical sink. When `segment_aligned == true`, use alias path via UMA to avoid extra copy.
+- For transpose: apply `inverse_transform` using LibTorch. Implementation mirrors `execute_transform` but runs permutations first (view → canonical) and writes to canonical buffer.
+- Expose status metrics: bytes written, number of staging copies, GPU vs CPU path, etc.
+
+Reuse the newly added executor inside `StoreEngine::register_artifact_impl`.
+
+## 2. Daemon & Engine Integration
+
+### 2.1 Request Flow
+
+1. SDK sends `RegisterArtifactRequest` with `view` or `view_id` + `placement`.
+2. Daemon’s `RegistrationController` (or equivalent template) normalises:
+   - If only `view_id`, fetch `ViewSpec` from GS via `GetArtifactInfoById(include_view_meta=true)` to keep server canonical.
+   - Populate `MaterializeHints::variant` (already exists) with view identity + placement.
+3. Pass hints to `StoreEngine::register_artifact`.
+
+### 2.2 Engine Flow
+
+Inside registration path (currently canonical-only):
+
+1. Fetch canonical index JSON (already mandatory v3).
+2. Invoke `ViewPlanner::compute_view_plan` if a view is present.
+3. Allocate canonical replica buffer as usual (VRAM lease, UMA, etc.).
+4. Materialise view bytes:
+   - If placement `SERVER`: the incoming buffers (e.g., gRPC stream, LIP) contain view layout. Use `ViewIngestExecutor` to write into canonical buffer.
+   - If placement `CLIENT`: assert that view is identity after normalisation; accept canonical data (defer to existing path).
+5. Compute hashes:
+   - Canonical `TreeHash` over full ByteSpace (existing path).
+   - Variant `TreeHash` using `ViewPlanSource` (replay forward plan over canonical buffer). Reuses retrieval helper so we don’t duplicate hashing logic.
+6. Collect leaf digests for variant ByteSpace. If the view fully covers canonical ranges exactly aligned with chunk boundaries, optionally update canonical leaves (existing pipeline already knows how to write canonical leaves; we can reuse by converting `ViewWritePlan::Chunk` into chunk ranges).
+7. Update verification metadata on disk (`verification.view_<id>.json`) using existing code.
+
+### 2.3 Global Store Mutations
+
+After successful registration + verification:
+
+1. Call `UpdateArtifactViewState` with:
+   - `VariantUpsert { view_id, view_spec_json, view_size, view_data_hash, mark_verified=true }`.
+   - `LeafWrite` entries for variant ByteSpace. Optionally include canonical leaf writes for ranges that were fully populated.
+2. Continue to call `register_replica_with_global_store` (already view-aware) so the canonical replica is visible.
+
+Error handling:
+
+- If validation fails (unknown tensor, invalid narrow length, etc.), return `INVALID_ARGUMENT` early.
+- On partial coverage (e.g., this registration doesn’t provide bytes for a canonical range yet): include `PartialCoverageDetail` with canonical ByteSpace to help orchestrators schedule remaining shards.
+
+## 3. SDK API & Ergonomics
+
+### 3.1 Surface
+
+```python
+store.register_view(
+    tensors=my_tp_shard,
+    *,
+    key="model:v2",
+    slices={"wte.weight": (slice(tp_off, tp_off + tp_len),)},
+    transpose=None,
+    placement="SERVER",
+    ttl_ms=3600,
+) -> RegisteredArtifact
+```
+
+Semantics:
+
+- `tensors` follows the same contract as `Store.register`: in-memory torch tensors matching the view output layout.
+- `_resolve_view_inputs` (already used for retrieval) normalises `ViewSpec`, ensures per-tensor exclusivity, folds identities.
+- Placement default:
+  - If any transpose op present → default `CLIENT` (upload canonical bytes, transform locally).
+  - For narrow-only → default `SERVER` (min-byte transfer).
+- When `view_id` supplied, skip normalisation and treat request as referencing an existing spec (still verify after fetch from GS).
+
+### 3.2 Registration Loop
+
+`Store._perform_registration` gains a fast path:
+
+1. Build view spec and placement.
+2. Annotate registration options (proto) with view fields.
+3. During stream upload, send view tensors only (not canonical) when placement==SERVER.
+4. Receive `RegisterArtifactResponse` containing `view_index_json` + `view_data_hash`; store inside `RegisteredArtifact` (new fields).
+5. On completion, call Global Store helper to persist variant metadata/leaves (mirrors load path but for registration we call immediately).
+
+Error surfacing:
+
+- If daemon responds `FAILED_PRECONDITION` (e.g., server lacks GPU for transpose SERVER placement), rethrow `ArtifactError` with suggestion to retry `placement="CLIENT"`.
+- If `PartialCoverageDetail` indicates missing canonical ranges, capture in exception to allow orchestrators to schedule remaining shards.
+
+## 4. Global Store Enhancements
+
+The infrastructure already exists; we need minor additions:
+
+- `ViewStateService` (new) exposes helper `record_variant_registration(...)` to wrap `UpdateArtifactViewState` with retries + telemetry.
+- CLI or admin tooling to inspect `variants`/`leaves` now includes registration timestamp, view size, view hash.
+- Telemetry: counters for number of variant writes, bytes per view.
+
+# Implementation Plan (High Level)
+
+| Phase | Scope | Notes |
+|-------|-------|-------|
+| **P0 — API plumbing** | SDK arg validation + proto fields plumbed end-to-end (no-op on daemon) | Canonical registrations continue to flow unchanged when `view` is omitted |
+| **P1 — Core ingest plan** | `BidirectionalViewPlan`, `ViewIngestExecutor`, engine integration for in-memory registration | Feature-gated until P2 ready |
+| **P2 — Global Store updates** | Hook registration completion → `UpdateArtifactViewState`, ensure canonical leaf writes optional | End-to-end slice coverage tests |
+| **P3 — Transpose support** | GPU/CPU transpose ingestion, placement fallback handling, LibTorch kernels | Perf tests on CUDA + fake CUDA |
+| **P4 — SDK+Tests** | Python API, unit tests, integration tests with fake daemon, doc updates | Includes docs/design sync |
+
+# Validation Strategy
+
+- **Unit tests:** new Catch2 suite `//core/store/loader:view_ingest_executor_test` verifying narrow + transpose ingestion (CPU + fake CUDA).
+- **Integration tests:** extend `//core/store:store_engine_test` and Python `tests/python/test_store_view_api.py` with end-to-end `register_view` flows (slice + transpose).
+- **Global Store tests:** add coverage in `tests/python/global_store/test_services.py` for variant upsert during registration.
+- **Perf smoke:** measure registration throughput vs canonical baseline; ensure slice registration reduces bytes transferred and CPU time remains within +5%.
+
+# Residual Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| View ingestion bug corrupts canonical replica | Symmetric test suite + `ABSL_CHECK` invariants comparing number of written bytes vs plan total |
+| Transpose server placement requires large staging buffer | Apply streaming kernels (tile-based permute) with bounded scratch; fallback to CLIENT placement when GPU mem insufficient |
+| Variants table grows rapidly with per-shard registrations | Introduce TTL/retention policy per view_id; add metrics to track growth |
+| Canonical leaf alignment ambiguous for partial slices | Extend `ViewPlanner` to flag chunk-aligned ranges; only write canonical leaves when aligned, otherwise defer |
+
+# Open Questions
+
+1. **Registration dedupe:** Should we allow multiple registrations for the same view_id to skip re-upload when view already verified? Proposed answer: yes—daemon short-circuits if view replica already canonical + verified (similar to retrieval fast-path).
+2. **Conflict detection:** How do we handle overlapping narrow registrations uploading different bytes? Suggest: same as today—latest write wins; add optional checksum guard (future work).
+3. **Client tensor management:** For transpose SERVER placement, do we expect clients to pre-permute? Proposed: no; server handles but we warn about GPU requirement.
+
+# Next Steps
+
+- Circulate this draft with core + daemon owners for feedback (focus on bidirectional plan shape and GS update timing).
+- Once approved, spin out execution plan `docs/plans/0018-artifact-view-registration.md` referencing the phases above.

--- a/docs/plans/0018-artifact-view-registration.md
+++ b/docs/plans/0018-artifact-view-registration.md
@@ -1,0 +1,132 @@
+---
+slug: 0018-artifact-view-registration-plan
+title: Plan — Variant View Registration (v1.5)
+links:
+  design: ../designs/0018-artifact-view-registration.md
+areas: ["core","daemon","global_store","sdk"]
+related_code:
+  - core/store/**
+  - daemon/**
+  - tensorcast/api/**
+  - tensorcast/global_store/**
+status: in_progress
+---
+
+# Objective
+
+Bridge the current codebase to the design in `../designs/0018-artifact-view-registration.md` so SDK callers can register slice/transpose views while the daemon and Store Engine reconstruct canonical ByteSpace, persist hashes, and publish variant metadata to Global Store without regressing canonical registration flows.
+
+# Baseline & Gaps
+
+- SDK client now supports explicit `SERVER` and `CLIENT` placements; remaining work is better retry guidance and surfacing daemon errors to orchestrators.
+- Daemon publishes view descriptors and now pushes variant leaf digests plus canonical coverage into Global Store; metrics/CLI surfacing remain.
+- Integration coverage is limited to unit plumbing; we still lack end-to-end registration tests in Python exercising fake CUDA + daemon loops.
+
+# Progress Update (current)
+
+- Phase 0 complete: proto surfaces, feature flag plumbing, and Buf regeneration landed.
+- Phase 1 now wired end-to-end: StoreEngine stores bidirectional plans, ingests view bytes, and computes variant hashes; daemon plumbing is underway.
+- Global Store integration online: StoreEngine publishes `UpdateArtifactViewState` via the new client helper, now including variant leaf digests and canonical coverage. SDK emits canonical index v3 bytes and captures view metadata from commit responses.
+- Test coverage run during this iteration: `bazel test //daemon:grpc_service_impl_registration_test --define=use_fake_cuda=true`, `bazel test //core/store:registration_memory_replica_test --define=use_fake_cuda=true`, `uv run pytest tests/python/global_store/test_services.py`.
+- Global Store metrics expose `tc_view_registration_total`/`tc_view_partial_backlog_bytes`, and SDK now surfaces actionable placement guidance (new pytest coverage for both paths).
+- Open items before feature completion: capture rollout/backout SOP, finalize owner reviews, and confirm staging telemetry matches expectations.
+
+# Phases & Milestones
+
+- [x] Phase 0: Protocol surfaces
+  - [x] Extend `proto/tensorcast/daemon/v1/store_daemon.proto` with `ViewRegistrationOptions` (fields: `string view_id`, `ViewSpec spec`, `TransformPlacement placement`, `uint64 canonical_size_bytes`, repeated `CanonicalRange ranges`, `bool allow_partial`) and add optional `view` field to `BeginRegisterArtifactRequest`.
+  - [x] Add `ViewUploadChunk` (offset/length) branch to `FeedRegisterArtifactStreamRequest.feed` while retaining canonical lease segments.
+  - [x] Regenerate stubs via `bash tools/build_proto_python.sh` and update Bazel deps; adjust `tensorcast/proto/__init__` exports if needed.
+  - [x] (Rolled back) Removed the temporary `enable_view_registration` feature flag; the daemon now always accepts view registrations.
+
+- [x] Phase 1: Core bidirectional planning & ingestion
+  - [x] Extend `core/store/loader/view_planner.{h,cc}` with `ViewWritePlan` + `BidirectionalViewPlan` that invert selection/permutations for registration.
+  - [x] Add `view_ingest_executor.{h,cc}` to apply inverse transforms and write view chunks into canonical GPU memory; include Catch2 tests (`//core/store/loader:view_ingest_executor_test`).
+  - [x] Update `StoreEngine::begin_register_artifact` / `commit_registered_artifact` to accept optional `BidirectionalViewPlan`, stream view chunks, compute canonical + view hashes, and persist verification metadata.
+  - [x] Ensure canonical hash computation remains guarded by `schema_version="v3"`; replace any lingering `IndexV2` assumptions discovered during implementation.
+
+- [x] Phase 2: Daemon registration pipeline
+  - [x] Plumb new proto fields through `RegistrationController::begin/feed/commit`, requesting bidirectional plans from `StoreEngine` when `req.has_view()`.
+  - [x] Implement streaming handler that copies uploaded view byte ranges into the pending replica using the core executor while tracking canonical coverage.
+  - [x] Enforce explicit placement honoring: daemon surfaces `FAILED_PRECONDITION` when server placement is unavailable.
+  - [x] Collect telemetry (bytes transferred, view ids, coverage) and surface via existing metrics registry.
+
+- [x] Phase 3: Global Store publication
+  - [x] Add Global Store client helper that wraps `UpdateArtifactViewState` with retries so StoreEngine can publish variant metadata.
+  - [x] Populate `UpdateArtifactViewState` requests with variant leaf digests and canonical coverage; add retry/backoff logging for failures.
+  - [x] Extend Global Store CLI/metrics to expose `tc_view_registration_total` and `tc_view_partial_backlog_bytes` counters so operators can track partial coverage backlog.
+
+- [x] Phase 4: SDK API + tests
+  - [x] Replace `IndexV2.build_bytes` path in `_register._prepare_build` with canonical index v3 emission (reuse `_C.build_canonical_index_from_safetensors` or new helper) and ensure `schema_version="v3"` is sent.
+  - [x] Implement `Store.register_view(...)` in `tensorcast/api/store.py`, reusing `_resolve_view_inputs` and honoring caller-specified placement.
+  - [x] Update `_register_artifact_core` and uploader paths to stream view chunks when placement is SERVER, and reconstruct canonical tensors on the client path before invoking the legacy upload loop.
+  - [x] Add SDK unit + integration tests: extend `tests/python/test_store_view_api.py` with registration failure guidance coverage and expand `tests/python/global_store/test_services.py` for metrics/backlog handling.
+
+- [ ] Phase 5: Rollout & migration cleanup
+  - [x] Staged rollout in CI: exercised view registration using fake CUDA env, captured metrics baseline, and confirmed the feature is always enabled post-flag removal.
+  - [x] Backfill documentation cross-links (docs/architecture/p2p-transfer-strategies.md, module READMEs) to describe registration data path.
+
+# Tasks
+
+- [x] Proto & build
+  - [x] Modify `proto/tensorcast/daemon/v1/store_daemon.proto` structures as described; add Bazel deps for new messages.
+  - [x] Run `bash tools/build_proto_python.sh` and update generated code references.
+  - [x] Adjust `tensorcast/daemon/v1/store_daemon_pb2.pyi` export expectations if type hints break *(regen confirmed no deltas needed)*.
+
+- [x] Core implementation
+  - [x] Define `ViewWritePlan` structs alongside `SelectionPlan` in `view_planner.h`; ensure serialization stays deterministic.
+  - [x] Implement inverse permutation logic in `view_planner.cc`, covering mixed narrow+transpose cases.
+  - [x] Create `view_ingest_executor.{h,cc}` to materialize canonical buffers from view uploads (CPU + GPU paths); integrate into Bazel BUILD.
+  - [x] Extend `StoreEngine::PendingRegistrationEntry` to store bidirectional plans + coverage bookkeeping; update commit path hashing to use canonicalized memory post-ingest.
+
+- [x] Daemon changes
+  - [x] Update `daemon/service/controllers/registration_controller.cc` begin/feed/commit to propagate view descriptors, call new engine entrypoints, and manage partial coverage accounting in `RegistrationManager`.
+  - [x] Extend `RegistrationManager` metadata structs to track view id/spec, placement, canonical coverage map, and feature flag state.
+  - [x] Wire new telemetry into OTEL counters (`tc_register_view_bytes_total`, `tc_register_view_partials_total`).
+
+- [x] Global Store integration
+  - [x] Add helper utility for `UpdateArtifactViewState` (Global Store service now exposes `record_variant_registration` for daemon and SDK callers).
+  - [x] Update daemon commit path to populate variant leaf digests and canonical coverage via the helper (with retries + logging).
+  - [x] Expand `tests/python/global_store/test_services.py` to assert variant registration via new helper.
+
+- [x] SDK + docs
+  - [x] Improve client retry guidance when daemon rejects a placement (surface actionable `ArtifactError`).
+  - [x] Update `tensorcast/api/_register.py` to interpret new response fields and store them on `RegistrationResult`.
+  - [x] Document registration flow changes in `tensorcast/api/README.md` and `docs/architecture/p2p-transfer-strategies.md`.
+
+# Test / Rollout / Backout
+
+- **Unit / component tests**
+  - [x] `bazel test //core/store/loader:view_ingest_executor_test --define=use_fake_cuda=true`
+  - [x] `bazel test //core/store:store_engine_test --define=use_fake_cuda=true` (add view registration cases)
+  - [x] `bazel test //daemon:grpc_service_impl_registration_test --define=use_fake_cuda=true`
+  - [x] `bazel test //core/store:registration_memory_replica_test --define=use_fake_cuda=true`
+  - [x] `uv run pytest tests/python/test_store_view_api.py`
+  - [x] `uv run pytest tests/python/global_store/test_services.py`
+
+- **Integration**
+  - End-to-end registration harness in `tests/python` using fake daemon + fake CUDA to assert canonical hash parity and Global Store updates.
+  - Benchmark canonical vs view registration throughput (target ≥50% byte reduction for narrow-only uploads; ≤5% CPU regression).
+
+- **Rollout**
+  - Exercise view registration flows in staging and monitor OTEL counters / Global Store metrics before production rollout.
+
+- **Backout**
+  - Publish operational SOP for temporarily blocking view registrations (e.g., via config hotfix) until a full fix is deployed.
+  - Provide script to prune inconsistent variant metadata if ingestion fails mid-rollout.
+
+# Risks & Tracking
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Inverse plan calculation corrupts canonical ByteSpace | High | Comprehensive Catch2 coverage + invariant checks in `StoreEngine::commit_registered_artifact` |
+| GPU transpose requires large scratch buffers | Medium | Capability probe; document when callers should choose CLIENT placement |
+| Proto change breaks legacy clients | Medium | Keep daemon tolerant of missing view fields and document SDK upgrade path |
+| Global Store metadata growth from partial uploads | Medium | Add TTL/retention in helper and monitor metrics |
+| SDK placement negotiation regress canonical flows | Low | Expand integration tests covering canonical + view registration |
+
+# Owner Checklist
+
+- [ ] Secure reviews from core, daemon, SDK, and Global Store owners.
+- [ ] Confirm documentation updates land alongside code changes.
+- [ ] Capture rollout/backout runbook in internal wiki once staging validation passes.

--- a/proto/tensorcast/daemon/v1/store_daemon.proto
+++ b/proto/tensorcast/daemon/v1/store_daemon.proto
@@ -128,6 +128,20 @@ message ViewSpec {
   map<string, TensorViewOps> tensors = 1;
 }
 
+message CanonicalRange {
+  uint64 offset = 1;
+  uint64 length = 2;
+}
+
+message ViewRegistrationOptions {
+  string view_id = 1;
+  ViewSpec spec = 2;
+  TransformPlacement placement = 3;
+  uint64 canonical_size_bytes = 4;
+  repeated CanonicalRange ranges = 5;
+  bool allow_partial = 6;
+}
+
 message MaterializeReplicaRequest {
   // RFC-0007: Use content-addressed artifact_id when available.
   // Exactly one of artifact_id or disk_path (or legacy disk_path) should be provided.
@@ -399,6 +413,8 @@ message BeginRegisterArtifactRequest {
     CoalescedOptions coalesced = 10;
     LeaseOptions lease = 12;
   }
+
+  ViewRegistrationOptions view = 1001;
 }
 
 // Tensor index data with metadata
@@ -442,6 +458,7 @@ message FeedRegisterArtifactStreamRequest {
   string registration_id = 1;
   oneof feed {
     LeaseSegments lease_segments = 11;
+    ViewUploadChunk view_chunk = 12;
   }
   // Optional deduplicated storage table and tensor alias metadata. Clients send
   // these fields when using the unified registration flow; legacy clients omit them.
@@ -449,6 +466,12 @@ message FeedRegisterArtifactStreamRequest {
   repeated TensorAlias tensor_aliases = 21;
 }
 message FeedRegisterArtifactStreamResponse {}
+
+message ViewUploadChunk {
+  uint64 canonical_offset = 1;
+  uint64 view_offset = 2;
+  bytes data = 3;
+}
 
 message LeaseSegments {
   repeated LeasedSegment segments = 1;
@@ -503,6 +526,11 @@ message CommitRegisteredArtifactResponse {
   // device and the daemon returned the existing descriptor while joining a
   // lightweight reference for this registration. See docs/internals/model-loading.md.
   bool existed = 2;
+  string view_id = 1001;
+  bytes view_index_json = 1002;
+  string view_data_hash = 1003;
+  repeated CanonicalRange canonical_ranges = 1004;
+  bool allow_partial = 1005;
 }
 
 // Abort registration request

--- a/proto/tensorcast/global_store/v1/global_store.proto
+++ b/proto/tensorcast/global_store/v1/global_store.proto
@@ -261,12 +261,18 @@ message UpdateArtifactViewStateResponse {
   Status status = 1;
 }
 
+message CanonicalCoverage {
+  uint64 total_bytes = 1;
+  uint64 covered_bytes = 2;
+}
+
 message VariantUpsert {
   string view_id = 1;
   string view_spec_json = 2;
   uint64 view_size = 3;
   string view_data_hash = 4;
   google.protobuf.Timestamp verified_at = 5;
+  CanonicalCoverage canonical_coverage = 6;
 }
 
 enum ByteSpaceKind {

--- a/tensorcast/__init__.py
+++ b/tensorcast/__init__.py
@@ -120,6 +120,7 @@ from tensorcast.api.store import (  # noqa: E402
     put_async,
     register,
     register_async,
+    register_view,
     store,
 )
 from tensorcast.startup import init, is_initialized, shutdown  # noqa: E402
@@ -147,6 +148,7 @@ __all__ = [
     "store",
     "register",
     "register_async",
+    "register_view",
     "put",
     "put_async",
     "get",

--- a/tensorcast/api/README.md
+++ b/tensorcast/api/README.md
@@ -10,6 +10,27 @@ transpose views return buffers in the expected orientation. Client-side
 execution is intentionally disabled until a local transform engine exists; the
 API still accepts `placement="CLIENT"` explicitly for forward compatibility.
 
+## View Registration
+
+`Store.register_view()` mirrors retrieval semantics so trainers can upload only
+the bytes required for a narrow or transpose view while the daemon rebuilds the
+canonical artifact. Key behaviours:
+
+- Placement defaults to `SERVER` for pure narrow views and `CLIENT` when any
+  transpose is present. Users can override via the `placement` keyword.
+- When the daemon lacks GPU support for a server-side transpose it returns a
+  `FAILED_PRECONDITION` status. The client surfaces a clear `ArtifactError`
+  instructing callers to retry with `placement="CLIENT"`.
+- `allow_partial=True` permits uploading subsets of canonical byte-space when
+  composing shards; the commit response includes `canonical_ranges` describing
+  the covered offsets. These ranges are forwarded to Global Store so metrics can
+  expose the remaining backlog for each view.
+
+The API returns a `RegisteredArtifact` whose `registration_result` carries the
+view identifier, canonical coverage ranges, and variant hash for downstream
+automation.
+See the [Variant View Registration Telemetry](../../docs/architecture/p2p-transfer-strategies.md#variant-view-registration-telemetry) guide for the full daemon ↔ Global Store ↔ SDK flow.
+
 ## Tensor Storage Graph Helper
 
 `build_tensor_storage_graph()` inspects a `dict[str, torch.Tensor]` and returns

--- a/tensorcast/api/_register.py
+++ b/tensorcast/api/_register.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import json
 import logging
 import threading
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import CancelledError
 from dataclasses import dataclass
 from pathlib import Path
@@ -18,15 +19,16 @@ from opentelemetry import trace
 from opentelemetry.trace import SpanKind
 
 from tensorcast._C import (
+    compute_view_registration_plan,
     get_cuda_memory_handle,
     get_cuda_memory_ptr,
     restore_tensors,
 )
-from tensorcast.api._indices import calculate_tensor_device_offsets
 from tensorcast.api._tensor_graph import TensorStorageGraph, build_tensor_storage_graph
 
 if TYPE_CHECKING:  # for static type checkers only
     from tensorcast.daemon_ctl import DaemonCtl
+
 from tensorcast.api._config import PlanType, RegisterArtifactOptions
 from tensorcast.api._device import resolve_device
 from tensorcast.api._errors import (
@@ -39,14 +41,16 @@ from tensorcast.api._indices import (
     TensorDataIndex,
     TensorDeviceOffsets,
     TensorMetaIndex,
-    build_v2_index_bytes,
+    calculate_tensor_device_offsets,
 )
 from tensorcast.api._io_disk import save_dict
 from tensorcast.api._runtime import require_runtime
 from tensorcast.api._utils import validate_disk_index_matches
 from tensorcast.observability.otel import ensure_client_otel
+from tensorcast.proto.daemon.v1 import store_daemon_pb2
 from tensorcast.types import (
     ArtifactDescriptor,
+    CanonicalRange,
     CoalescedHandshake,
     CoalescedPlan,
     Handshake,
@@ -59,6 +63,10 @@ from tensorcast.types import (
 # Internal alignment hint for layout computation.
 # Currently unused by the underlying calculator but kept for API clarity.
 DEFAULT_ALIGN = 1
+
+
+NormalizedViewOp = Mapping[str, int | str]
+NormalizedViewOps = Mapping[str, Sequence[NormalizedViewOp]]
 
 
 @dataclass
@@ -77,9 +85,57 @@ class RegistrationResult:
     layout: "CoalescedLayout"
     index_bytes: bytes
     plan: PlanType
+    view_id: str | None = None
+    view_index_json: bytes | None = None
+    view_data_hash: str | None = None
+    canonical_ranges: tuple[CanonicalRange, ...] = ()
+    allow_partial: bool = False
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ViewPlanChunk:
+    canonical_offset: int
+    view_offset: int
+    length: int
+    segment_aligned: bool
+
+
+@dataclass(frozen=True)
+class InverseTensorPlan:
+    tensor_name: str
+    dst_offset: int
+    canonical_offset: int
+    storage_offset_elements: int
+    canonical_shape: tuple[int, ...]
+    canonical_stride: tuple[int, ...]
+    view_shape: tuple[int, ...]
+    view_stride: tuple[int, ...]
+    permutation: tuple[int, ...]
+    dtype: str
+    element_size_bytes: int
+
+
+@dataclass(frozen=True)
+class ViewPlanMetadata:
+    view_size_bytes: int
+    view_index_json: bytes
+    write_chunks: tuple[ViewPlanChunk, ...]
+    inverse_requires_materialization: bool
+    inverse_tensors: tuple[InverseTensorPlan, ...]
+
+
+@dataclass
+class ViewRegistrationContext:
+    canonical_index_bytes: bytes
+    view_options: "store_daemon_pb2.ViewRegistrationOptions"
+    placement: int
+    plan: ViewPlanMetadata
+    tensors: dict[str, torch.Tensor]
+    canonical_ranges: tuple[CanonicalRange, ...]
+    allow_partial: bool
 
 
 class RegisteredArtifact:
@@ -437,20 +493,28 @@ class CoalescedLayout:
         )
 
 
-class IndexV2:
-    @staticmethod
-    def build_bytes(
-        tensor_meta_index: TensorMetaIndex,
-        tensor_source_index: TensorDataIndex,
-        tensor_device_offsets: TensorDeviceOffsets,
-        device_id: int,
-    ) -> bytes:
-        return build_v2_index_bytes(
-            tensor_meta_index,
-            tensor_source_index,
-            tensor_device_offsets,
-            int(device_id),
+def build_canonical_index_bytes(
+    tensor_meta_index: TensorMetaIndex,
+    tensor_source_index: TensorDataIndex,
+    tensor_device_offsets: TensorDeviceOffsets,
+    device_id: int,
+) -> bytes:
+    canonical_index: dict[str, tuple[int, int, list[int], list[int], str, int]] = {}
+    for name in sorted(tensor_meta_index.keys()):
+        shape, stride, dtype, storage_offset = tensor_meta_index[name]
+        _, storage_size = tensor_source_index[name]
+        dst_off = int(tensor_device_offsets[int(device_id)][name])
+        canonical_index[name] = (
+            dst_off,
+            int(storage_size),
+            list(shape),
+            list(stride),
+            dtype,
+            int(storage_offset),
         )
+    return json.dumps(canonical_index, separators=(",", ":"), sort_keys=True).encode(
+        "utf-8"
+    )
 
 
 def _prepare_build(
@@ -462,10 +526,248 @@ def _prepare_build(
     layout = CoalescedLayout.compute(
         ctx.tensor_source_index, ctx.device_id, align=DEFAULT_ALIGN
     )
-    index_bytes = IndexV2.build_bytes(
+    index_bytes = build_canonical_index_bytes(
         ctx.tensor_meta_index, ctx.tensor_source_index, layout.offsets, ctx.device_id
     )
     return ctx, layout, index_bytes
+
+
+def _tensor_indices_from_canonical_index_bytes(
+    index_bytes: bytes,
+) -> tuple[TensorMetaIndex, TensorDataIndex]:
+    try:
+        index_obj = json.loads(index_bytes.decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise TensorCastError(
+            "Failed to parse canonical index bytes for view registration"
+        ) from exc
+    tensor_meta_index: TensorMetaIndex = {}
+    tensor_data_index: TensorDataIndex = {}
+    for name, meta in index_obj.items():
+        if not isinstance(meta, list | tuple) or len(meta) != 6:
+            raise TensorCastError(
+                f"Invalid canonical index entry for '{name}': expected 6 fields"
+            )
+        offset, size, shape, stride, dtype, storage_offset = meta
+        tensor_meta_index[name] = (
+            [int(v) for v in shape],
+            [int(v) for v in stride],
+            str(dtype),
+            int(storage_offset),
+        )
+        tensor_data_index[name] = (int(offset), int(size))
+    return tensor_meta_index, tensor_data_index
+
+
+def _build_context_from_canonical_index(
+    index_bytes: bytes,
+    device_id: int,
+) -> tuple["BuildContext", "CoalescedLayout"]:
+    tensor_meta_index, tensor_data_index = _tensor_indices_from_canonical_index_bytes(
+        index_bytes
+    )
+    tensor_device_offsets, unique_chunks = calculate_tensor_device_offsets(
+        tensor_data_index, device_id
+    )
+    chunk_list = unique_chunks.get(device_id, [])
+    total_size = 0
+    for offset, size, _, _ in chunk_list:
+        total_size = max(total_size, int(offset) + int(size))
+
+    storage_graph = TensorStorageGraph(
+        storages={},
+        aliases={},
+        tensor_meta_index=tensor_meta_index,
+        tensor_source_index=tensor_data_index,
+    )
+    ctx = BuildContext(
+        device_id=device_id,
+        input_mode="cpu",
+        tensor_meta_index=tensor_meta_index,
+        tensor_source_index=tensor_data_index,
+        storage_graph=storage_graph,
+    )
+    layout = CoalescedLayout(
+        device_id=device_id,
+        offsets=tensor_device_offsets,
+        unique_chunks=chunk_list,
+        total_size=total_size,
+    )
+    return ctx, layout
+
+
+def _merge_canonical_ranges(
+    chunks: Sequence[ViewPlanChunk],
+) -> tuple[CanonicalRange, ...]:
+    sorted_chunks = sorted(
+        (chunk.canonical_offset, chunk.canonical_offset + chunk.length)
+        for chunk in chunks
+        if chunk.length > 0
+    )
+    if not sorted_chunks:
+        return ()
+    merged: list[CanonicalRange] = []
+    current_start, current_end = sorted_chunks[0]
+    for start, end in sorted_chunks[1:]:
+        if start <= current_end:
+            current_end = max(current_end, end)
+        else:
+            merged.append(
+                CanonicalRange(
+                    offset=int(current_start), length=int(current_end - current_start)
+                )
+            )
+            current_start, current_end = start, end
+    merged.append(
+        CanonicalRange(
+            offset=int(current_start), length=int(current_end - current_start)
+        )
+    )
+    return tuple(merged)
+
+
+def _compute_view_plan_metadata(
+    canonical_index_bytes: bytes,
+    normalized_ops: NormalizedViewOps,
+) -> ViewPlanMetadata:
+    if not normalized_ops:
+        raise TensorCastError("View registration requires explicit view operations")
+    native_plan = compute_view_registration_plan(canonical_index_bytes, normalized_ops)
+    forward = native_plan["forward"]
+    write_chunks = tuple(
+        ViewPlanChunk(
+            canonical_offset=int(chunk["canonical_offset"]),
+            view_offset=int(chunk["view_offset"]),
+            length=int(chunk["length"]),
+            segment_aligned=bool(chunk["segment_aligned"]),
+        )
+        for chunk in native_plan.get("write_chunks", [])
+    )
+    inverse_native = native_plan.get("inverse_transform", {})
+    inverse_tensors = tuple(
+        InverseTensorPlan(
+            tensor_name=str(tp["tensor_name"]),
+            dst_offset=int(tp["dst_offset"]),
+            canonical_offset=int(tp["canonical_offset"]),
+            storage_offset_elements=int(tp["storage_offset_elements"]),
+            canonical_shape=tuple(int(v) for v in tp["canonical_shape"]),
+            canonical_stride=tuple(int(v) for v in tp["canonical_stride"]),
+            view_shape=tuple(int(v) for v in tp["view_shape"]),
+            view_stride=tuple(int(v) for v in tp["view_stride"]),
+            permutation=tuple(int(v) for v in tp["permutation"]),
+            dtype=str(tp["dtype"]),
+            element_size_bytes=int(tp["element_size_bytes"]),
+        )
+        for tp in inverse_native.get("tensors", [])
+    )
+    return ViewPlanMetadata(
+        view_size_bytes=int(forward["view_size_bytes"]),
+        view_index_json=bytes(forward["view_index_json"]),
+        write_chunks=write_chunks,
+        inverse_requires_materialization=bool(
+            inverse_native.get("requires_materialization", False)
+        ),
+        inverse_tensors=inverse_tensors,
+    )
+
+
+def _linearize_view_tensors(
+    tensors: Mapping[str, torch.Tensor],
+    plan: ViewPlanMetadata,
+) -> bytearray:
+    if plan.view_size_bytes == 0:
+        return bytearray()
+    try:
+        layout_index = json.loads(plan.view_index_json.decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise TensorCastError("Failed to parse view_index_json from plan") from exc
+
+    buffer = bytearray(plan.view_size_bytes)
+    mv = memoryview(buffer)
+    for name in sorted(layout_index.keys()):
+        if name not in tensors:
+            raise TensorCastError(
+                f"View tensor '{name}' missing from registration payload"
+            )
+        tensor = tensors[name]
+        if not isinstance(tensor, torch.Tensor):
+            raise TensorCastError(f"View tensor '{name}' must be a torch.Tensor")
+        offset, size_bytes, _, _, dtype_str, _ = layout_index[name]
+        expected_bytes = int(size_bytes)
+        src_dtype = str(tensor.dtype)
+        if src_dtype != str(dtype_str):
+            raise TensorCastError(
+                f"Tensor '{name}' dtype mismatch: expected {dtype_str}, found {src_dtype}"
+            )
+        contiguous = tensor.detach()
+        if contiguous.device.type != "cpu":
+            contiguous = contiguous.to(torch.device("cpu"), non_blocking=False)
+        contiguous = contiguous.contiguous()
+        data_bytes = contiguous.numpy().tobytes()
+        if len(data_bytes) != expected_bytes:
+            raise TensorCastError(
+                f"Tensor '{name}' byte size mismatch: expected {expected_bytes}, got {len(data_bytes)}"
+            )
+        start = int(offset)
+        mv[start : start + expected_bytes] = data_bytes
+    return buffer
+
+
+def _torch_dtype_from_string(dtype_str: str) -> torch.dtype:
+    if hasattr(torch, dtype_str.split(".")[-1]):
+        return getattr(torch, dtype_str.split(".")[-1])
+    raise TensorCastError(f"Unsupported dtype for view registration: {dtype_str}")
+
+
+def _materialize_canonical_tensors(
+    canonical_index_bytes: bytes,
+    normalized_ops: NormalizedViewOps,
+    tensors: Mapping[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    tensor_meta_index, _ = _tensor_indices_from_canonical_index_bytes(
+        canonical_index_bytes
+    )
+    canonical_tensors: dict[str, torch.Tensor] = {}
+    for name, (shape, _, dtype_str, _) in tensor_meta_index.items():
+        if name not in tensors:
+            raise TensorCastError(f"View registration missing tensor '{name}'")
+        tensor = tensors[name]
+        if not isinstance(tensor, torch.Tensor):
+            raise TensorCastError(f"Tensor '{name}' must be a torch.Tensor")
+        tensor_cpu = tensor.detach()
+        if tensor_cpu.device.type != "cpu":
+            tensor_cpu = tensor_cpu.to(torch.device("cpu"), non_blocking=False)
+        tensor_cpu = tensor_cpu.contiguous()
+        ops = list(normalized_ops.get(name, []))
+        # Apply inverse operations (reverse order)
+        for op in reversed(ops):
+            if op["type"] == "transpose":
+                tensor_cpu = tensor_cpu.transpose(int(op["dim0"]), int(op["dim1"]))
+            elif op["type"] == "narrow":
+                dim = int(op["dim"])
+                start = int(op["start"])
+                length = int(op["length"])
+                full = torch.zeros(
+                    tuple(int(d) for d in shape),
+                    dtype=tensor_cpu.dtype,
+                )
+                slice_spec = [slice(None)] * full.ndim
+                slice_spec[dim] = slice(start, start + length)
+                full[tuple(slice_spec)].copy_(tensor_cpu)
+                tensor_cpu = full
+            else:
+                raise TensorCastError(f"Unsupported view operation type: {op['type']}")
+        # Ensure dtype matches canonical requirements
+        target_dtype = _torch_dtype_from_string(dtype_str)
+        if tensor_cpu.dtype != target_dtype:
+            tensor_cpu = tensor_cpu.to(target_dtype)
+        expected_shape = tuple(int(d) for d in shape)
+        if tuple(tensor_cpu.shape) != expected_shape:
+            raise TensorCastError(
+                f"Tensor '{name}' has shape {tuple(tensor_cpu.shape)}, expected {expected_shape}"
+            )
+        canonical_tensors[name] = tensor_cpu
+    return canonical_tensors
 
 
 def make_plan_model(
@@ -658,6 +960,7 @@ def _register_artifact_core(
     daemon_address: str | None = None,
     cancel_event: threading.Event | None = None,
     on_begin: Callable[[RegisteredArtifact], None] | None = None,
+    view: ViewRegistrationContext | None = None,
 ) -> RegistrationResult:
     if client is None:
         runtime = require_runtime()
@@ -671,10 +974,29 @@ def _register_artifact_core(
     if not artifact:
         raise TensorCastError("artifact must not be empty")
 
-    ctx, layout, index_bytes = _prepare_build(artifact, device_id)
+    target_device_id: int | None = None
+    if isinstance(device_id, torch.device):
+        target_device_id = resolve_device(device_id)
+    elif isinstance(device_id, int):
+        target_device_id = int(device_id)
+
+    if view is None:
+        ctx, layout, index_bytes = _prepare_build(artifact, device_id)
+        if target_device_id is None:
+            target_device_id = ctx.device_id
+        else:
+            ctx.device_id = target_device_id
+    else:
+        if target_device_id is None:
+            target_device_id = 0
+        ctx, layout = _build_context_from_canonical_index(
+            view.canonical_index_bytes, target_device_id
+        )
+        index_bytes = view.canonical_index_bytes
 
     if (
-        prevalidate_disk
+        view is None
+        and prevalidate_disk
         and options.disk_path is not None
         and options.disk_path.strip() != ""
     ):
@@ -703,6 +1025,8 @@ def _register_artifact_core(
         raise DeviceMismatch(
             "vram_leased plan requires CUDA tensors (device_id must be inferred)"
         )
+    if view is not None and plan_type is not PlanType.VRAM_COALESCED:
+        raise InvalidPlan("View registration requires vram_coalesced plan")
 
     span_names = {
         PlanType.VRAM_COALESCED: "Client/RegisterArtifact.Coalesced",
@@ -716,8 +1040,9 @@ def _register_artifact_core(
             ttl_ms=ttl_ms,
             tensor_index_data=index_bytes,
             encoding="json",
-            schema_version="v2",
+            schema_version="v3",
             plan=plan_model,
+            view=view.view_options if view is not None else None,
             timeout_s=60.0,
         )
         handle = RegisteredArtifact(
@@ -733,6 +1058,55 @@ def _register_artifact_core(
             with contextlib.suppress(Exception):
                 handle.abort(timeout_s=5.0)
             raise CancelledError
+
+        if view is not None:
+            if view.placement == store_daemon_pb2.TRANSFORM_PLACEMENT_SERVER:
+                with handle:
+                    try:
+                        if cancel_event and cancel_event.is_set():
+                            raise CancelledError
+                        payload = _linearize_view_tensors(view.tensors, view.plan)
+                        ok = ctl.feed_register_artifact_view_chunks(
+                            handle.registration_id,
+                            payload,
+                        )
+                        if not ok:
+                            raise TensorCastError(
+                                "Failed to stream view registration bytes to daemon"
+                            )
+                        if cancel_event and cancel_event.is_set():
+                            raise CancelledError
+                        commit_res = handle.commit(timeout_s=60.0)
+                        desc = commit_res.descriptor
+                        _persist_publish_if_needed(
+                            desc=desc,
+                            options=options,
+                            state_dict_to_save=None,
+                            client=ctl,
+                        )
+                        return RegistrationResult(
+                            state_dict=None,
+                            descriptor=desc,
+                            lease=None,
+                            build=ctx,
+                            layout=layout,
+                            index_bytes=index_bytes,
+                            plan=plan_type,
+                            view_id=commit_res.view_id,
+                            view_index_json=commit_res.view_index_json,
+                            view_data_hash=commit_res.view_data_hash,
+                            canonical_ranges=commit_res.canonical_ranges
+                            or view.canonical_ranges,
+                            allow_partial=view.allow_partial,
+                        )
+                    except CancelledError:
+                        with contextlib.suppress(Exception):
+                            handle.abort(timeout_s=5.0)
+                        raise
+            elif view.placement != store_daemon_pb2.TRANSFORM_PLACEMENT_CLIENT:
+                raise TensorCastError(
+                    "Unknown transform placement for view registration"
+                )
 
         registrar = PLAN_REGISTRY[plan_type]
         with handle:
@@ -765,6 +1139,11 @@ def _register_artifact_core(
                         layout=layout,
                         index_bytes=index_bytes,
                         plan=plan_type,
+                        view_id=commit_res.view_id,
+                        view_index_json=commit_res.view_index_json,
+                        view_data_hash=commit_res.view_data_hash,
+                        canonical_ranges=commit_res.canonical_ranges,
+                        allow_partial=commit_res.allow_partial,
                     )
 
                 if isinstance(registrar, _LeaseUploader):
@@ -802,6 +1181,11 @@ def _register_artifact_core(
                         layout=layout,
                         index_bytes=index_bytes,
                         plan=plan_type,
+                        view_id=commit_res.view_id,
+                        view_index_json=commit_res.view_index_json,
+                        view_data_hash=commit_res.view_data_hash,
+                        canonical_ranges=commit_res.canonical_ranges,
+                        allow_partial=commit_res.allow_partial,
                     )
             except CancelledError:
                 with contextlib.suppress(Exception):

--- a/tensorcast/api/store.py
+++ b/tensorcast/api/store.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Generic, Iterator, Literal, TypeVar, cast
 
+import grpc
 import torch
 from opentelemetry import trace
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode
@@ -42,6 +43,10 @@ from tensorcast.api._register import (
 from tensorcast.api._register import (
     RegisteredLease,
     RegistrationResult,
+    ViewRegistrationContext,
+    _compute_view_plan_metadata,
+    _materialize_canonical_tensors,
+    _merge_canonical_ranges,
     _register_artifact_core,
 )
 from tensorcast.api._runtime import require_runtime
@@ -76,6 +81,9 @@ ArtifactStatusCode = Literal[
     "CANCELLED",
     "UNKNOWN",
 ]
+
+NormalizedViewOpDict = dict[str, int | str]
+MutableNormalizedViewOps = dict[str, list[NormalizedViewOpDict]]
 
 
 class ArtifactError(RuntimeError):
@@ -776,6 +784,29 @@ class Store:
             return ArtifactError(
                 message, status_code="FAILED_PRECONDITION", retryable=False
             )
+        if isinstance(exc, grpc.RpcError):
+            status_code = exc.code()
+            details = exc.details() or message
+            status_name = status_code.name if status_code is not None else "UNKNOWN"
+            if (
+                status_code == grpc.StatusCode.FAILED_PRECONDITION
+                and "retry with placement=CLIENT" in details
+            ):
+                guidance = (
+                    "Daemon rejected SERVER placement for view registration; "
+                    "retry with placement='CLIENT'."
+                )
+                return ArtifactError(
+                    guidance,
+                    status_code="FAILED_PRECONDITION",
+                    retryable=False,
+                )
+            retryable = status_code in {
+                grpc.StatusCode.UNAVAILABLE,
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+                grpc.StatusCode.ABORTED,
+            }
+            return ArtifactError(details, status_code=status_name, retryable=retryable)
         if isinstance(exc, RuntimeError) and "not available" in message.lower():
             return ArtifactError(message, status_code="UNAVAILABLE", retryable=True)
         return ArtifactError(message, status_code="UNKNOWN", retryable=False)
@@ -791,11 +822,18 @@ class Store:
         options_override: RegisterArtifactOptions | None = None,
         ttl_override: int | None = None,
         device_override: int | torch.device | None = None,
+        view_registration: ViewRegistrationContext | None = None,
     ) -> RegisteredArtifact:
         material = dict(tensors)
         if not material:
             raise ArtifactError(
                 "Artifact tensors must not be empty",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        if view_registration is not None and plan is not PlanType.VRAM_COALESCED:
+            raise ArtifactError(
+                "View registration requires vram_coalesced plan",
                 status_code="INVALID_ARGUMENT",
                 retryable=False,
             )
@@ -841,6 +879,7 @@ class Store:
                 daemon_address=self._daemon_endpoint,
                 cancel_event=cancel_event,
                 on_begin=on_begin,
+                view=view_registration,
             )
         except Exception as exc:  # noqa: BLE001
             raise self._map_registration_error(exc) from exc
@@ -909,6 +948,7 @@ class Store:
         options_override: RegisterArtifactOptions | None = None,
         ttl_override: int | None = None,
         device_override: int | torch.device | None = None,
+        view_registration: ViewRegistrationContext | None = None,
     ) -> RegisteredArtifact:
         method = "register" if plan is PlanType.VRAM_LEASED else "put"
         span_name = "Store/Register" if plan is PlanType.VRAM_LEASED else "Store/Put"
@@ -952,6 +992,7 @@ class Store:
                         options_override=options_override,
                         ttl_override=ttl_override,
                         device_override=device_override,
+                        view_registration=view_registration,
                     )
                     record_outcome("OK")
                     span.set_attribute("tc.store.retry.count", attempt)
@@ -1424,9 +1465,13 @@ class Store:
         canonical_index: CanonicalIndex,
         slices: Mapping[str, Sequence[object]] | None,
         transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
-    ) -> tuple[store_daemon_pb2.ViewSpec | None, bool]:
+    ) -> tuple[
+        store_daemon_pb2.ViewSpec | None,
+        bool,
+        MutableNormalizedViewOps,
+    ]:
         if not slices and not transpose:
-            return None, False
+            return None, False, {}
 
         entry_map: dict[str, CanonicalIndexEntry] = {
             entry.name: entry for entry in canonical_index.entries
@@ -1444,12 +1489,14 @@ class Store:
             )
 
         tensor_ops: dict[str, store_daemon_pb2.TensorViewOps] = {}
+        normalized_ops: MutableNormalizedViewOps = {}
         has_ops = False
         has_transpose = False
 
         def ensure_ops(name: str) -> store_daemon_pb2.TensorViewOps:
             if name not in tensor_ops:
                 tensor_ops[name] = store_daemon_pb2.TensorViewOps()
+            normalized_ops.setdefault(name, [])
             return tensor_ops[name]
 
         # Narrow handling (single-dimension)
@@ -1550,6 +1597,14 @@ class Store:
                 op.narrow.dim = int(dim)
                 op.narrow.start = int(start)
                 op.narrow.length = int(length)
+                normalized_ops[name].append(
+                    {
+                        "type": "narrow",
+                        "dim": int(dim),
+                        "start": int(start),
+                        "length": int(length),
+                    }
+                )
                 has_ops = True
 
         if transpose:
@@ -1600,16 +1655,23 @@ class Store:
                         current[source_idx],
                         current[target_idx],
                     )
+                    normalized_ops[name].append(
+                        {
+                            "type": "transpose",
+                            "dim0": int(target_idx),
+                            "dim1": int(source_idx),
+                        }
+                    )
                     has_ops = True
                     has_transpose = True
 
         if not has_ops:
-            return None, False
+            return None, False, {}
 
         spec = store_daemon_pb2.ViewSpec()
         for name in sorted(tensor_ops.keys()):
             spec.tensors[name].CopyFrom(tensor_ops[name])
-        return spec, has_transpose
+        return spec, has_transpose, normalized_ops
 
     def _resolve_view_inputs(
         self,
@@ -1620,7 +1682,14 @@ class Store:
         slices: Mapping[str, Sequence[object]] | None,
         transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
         view_id: str | None,
-    ) -> tuple[str, bytes | None, store_daemon_pb2.ViewSpec | None, bool, str | None]:
+    ) -> tuple[
+        str,
+        bytes | None,
+        store_daemon_pb2.ViewSpec | None,
+        bool,
+        str | None,
+        MutableNormalizedViewOps,
+    ]:
         resolved_artifact_id, resolved_key = artifact_id, key
         resolved_artifact_id, resolved_key = self._resolve_identifiers(
             resolved_artifact_id, resolved_key, None
@@ -1643,6 +1712,7 @@ class Store:
         canonical_index_bytes: bytes | None = None
         view_spec: store_daemon_pb2.ViewSpec | None = None
         has_transpose = False
+        normalized_ops: MutableNormalizedViewOps = {}
 
         if view_id is not None:
             if slices or transpose:
@@ -1657,6 +1727,7 @@ class Store:
                 view_spec,
                 has_transpose,
                 disk_path_hint,
+                normalized_ops,
             )
 
         # Building a spec requires canonical metadata.
@@ -1669,7 +1740,7 @@ class Store:
 
         canonical_index_bytes = client.get_artifact_index_by_id(resolved_artifact_id)
         canonical_index = self._canonical_index_from_bytes(canonical_index_bytes)
-        view_spec, has_transpose = self._build_view_spec(
+        view_spec, has_transpose, normalized_ops = self._build_view_spec(
             canonical_index=canonical_index,
             slices=slices,
             transpose=transpose,
@@ -1680,12 +1751,13 @@ class Store:
             view_spec,
             has_transpose,
             disk_path_hint,
+            normalized_ops,
         )
 
     @staticmethod
     def _resolve_transform_placement(
         placement: str | None, *, has_transpose: bool
-    ) -> TransformPlacement | None:
+    ) -> TransformPlacement:
         if placement is None:
             # Default to server-side execution until the client transform path exists.
             return TransformPlacement.TRANSFORM_PLACEMENT_SERVER
@@ -2054,6 +2126,103 @@ class Store:
 
         return ArtifactFuture(future, cancel_callback=_cancel)
 
+    def register_view(
+        self,
+        tensors: TensorDict,
+        *,
+        artifact_id: str | None = None,
+        key: str | None = None,
+        slices: Mapping[str, Sequence[object]] | None = None,
+        transpose: Mapping[str, Sequence[tuple[int, int]]] | None = None,
+        view_id: str | None = None,
+        placement: Literal["SERVER", "CLIENT"] | None = None,
+        ttl_ms: int | None = None,
+        allow_partial: bool = False,
+        options: RegisterArtifactOptions | None = None,
+    ) -> RegisteredArtifact:
+        if view_id is not None and view_id.strip() == "":
+            raise ArtifactError(
+                "view_id must not be empty",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        client = self._ensure_client()
+        (
+            resolved_artifact_id,
+            canonical_index_bytes,
+            view_spec,
+            has_transpose,
+            _,
+            normalized_ops,
+        ) = self._resolve_view_inputs(
+            client=client,
+            artifact_id=artifact_id,
+            key=key,
+            slices=slices,
+            transpose=transpose,
+            view_id=view_id,
+        )
+        if view_spec is None:
+            raise ArtifactError(
+                "View registration via pre-existing view_id is not supported yet",
+                status_code="UNIMPLEMENTED",
+                retryable=False,
+            )
+        placement_choice = placement
+        if placement_choice is None:
+            placement_choice = "CLIENT" if has_transpose else "SERVER"
+        placement_enum = self._resolve_transform_placement(
+            placement_choice, has_transpose=has_transpose
+        )
+        assert canonical_index_bytes is not None
+        canonical_index = self._canonical_index_from_bytes(canonical_index_bytes)
+        plan_metadata = _compute_view_plan_metadata(
+            canonical_index_bytes, normalized_ops
+        )
+        canonical_ranges = _merge_canonical_ranges(plan_metadata.write_chunks)
+        view_options = store_daemon_pb2.ViewRegistrationOptions()
+        if view_id:
+            view_options.view_id = view_id
+        view_options.spec.CopyFrom(view_spec)
+        view_options.placement = placement_enum
+        view_options.canonical_size_bytes = canonical_index.total_size_bytes
+        for rng in canonical_ranges:
+            range_proto = view_options.ranges.add()
+            range_proto.offset = rng.offset
+            range_proto.length = rng.length
+        view_options.allow_partial = bool(allow_partial)
+        upload_tensors: dict[str, torch.Tensor]
+        if placement_enum == TransformPlacement.TRANSFORM_PLACEMENT_SERVER:
+            upload_tensors = dict(tensors)
+        elif placement_enum == TransformPlacement.TRANSFORM_PLACEMENT_CLIENT:
+            upload_tensors = _materialize_canonical_tensors(
+                canonical_index_bytes, normalized_ops, tensors
+            )
+        else:
+            raise ArtifactError(
+                "Unsupported placement for register_view",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+
+        view_ctx = ViewRegistrationContext(
+            canonical_index_bytes=canonical_index_bytes,
+            view_options=view_options,
+            placement=placement_enum,
+            plan=plan_metadata,
+            tensors=dict(tensors),
+            canonical_ranges=canonical_ranges,
+            allow_partial=allow_partial,
+        )
+        return self._perform_registration(
+            upload_tensors,
+            key=key,
+            plan=PlanType.VRAM_COALESCED,
+            options_override=options,
+            ttl_override=ttl_ms,
+            view_registration=view_ctx,
+        )
+
     def put(
         self,
         tensors: TensorDict,
@@ -2162,6 +2331,7 @@ class Store:
             view_spec,
             has_transpose,
             disk_path_hint,
+            _,
         ) = self._resolve_view_inputs(
             client=client,
             artifact_id=artifact_id,
@@ -2401,6 +2571,7 @@ class Store:
             view_spec,
             has_transpose,
             disk_path_hint,
+            _,
         ) = self._resolve_view_inputs(
             client=client,
             artifact_id=artifact_id,
@@ -2569,6 +2740,33 @@ def register_async(
         key=key,
         options=options,
         ttl_ms=ttl_ms,
+    )
+
+
+def register_view(
+    tensors: TensorDict,
+    *,
+    artifact_id: str | None = None,
+    key: str | None = None,
+    slices: Mapping[str, Sequence[object]] | None = None,
+    transpose: Mapping[str, Sequence[tuple[int, int]]] | None = None,
+    view_id: str | None = None,
+    placement: Literal["SERVER", "CLIENT"] | None = None,
+    ttl_ms: int | None = None,
+    allow_partial: bool = False,
+    options: RegisterArtifactOptions | None = None,
+) -> RegisteredArtifact:
+    return _coerce_store().register_view(
+        tensors,
+        artifact_id=artifact_id,
+        key=key,
+        slices=slices,
+        transpose=transpose,
+        view_id=view_id,
+        placement=placement,
+        ttl_ms=ttl_ms,
+        allow_partial=allow_partial,
+        options=options,
     )
 
 

--- a/tensorcast/csrc/checkpoint_py.cc
+++ b/tensorcast/csrc/checkpoint_py.cc
@@ -9,6 +9,8 @@
 #include <cstdint>
 #include <ranges>
 
+#include <pybind11/stl.h>
+
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "core/checkpoint/checkpoint.h"
@@ -33,6 +35,7 @@
 #include "core/store/loader/file_partition_source.h"
 #include "core/store/loader/safetensors_util.h"
 #include "core/store/loader/source_hash.h"
+#include "core/store/loader/view_planner.h"
 
 namespace py = pybind11;
 
@@ -45,6 +48,11 @@ using tensorcast::common::ArtifactVerificationInfo;
 using tensorcast::common::ArtifactVerifier;
 using tensorcast::common::compute_index_multihash;
 using tensorcast::common::VerificationLevel;
+using tensorcast::store::loader::BidirectionalViewPlan;
+using tensorcast::store::loader::TensorTransformPlan;
+using tensorcast::store::loader::ViewOp;
+using tensorcast::store::loader::ViewPlanner;
+using tensorcast::store::loader::ViewSpec;
 
 // Helper function to convert ArtifactVerificationInfo to Python dictionary
 py::dict verification_info_to_dict(const ArtifactVerificationInfo& info) {
@@ -113,6 +121,145 @@ ArtifactVerificationInfo dict_to_verification_info(const py::dict& dict) {
 
   return info;
 }
+
+namespace {
+
+ViewSpec build_view_spec_from_py(const py::dict& spec_dict) {
+  ViewSpec spec;
+  for (const auto& item : spec_dict) {
+    const std::string tensor_name = item.first.cast<std::string>();
+    py::list ops_list = item.second.cast<py::list>();
+    tensorcast::store::loader::TensorViewOps ops;
+    for (py::handle handle : ops_list) {
+      if (!py::isinstance<py::dict>(handle)) {
+        PY_THROW_WITH_LOG(PyExc_TypeError, "View operation specification must be dictionaries with 'type' field");
+      }
+      py::dict op_dict = handle.cast<py::dict>();
+      if (!op_dict.contains("type")) {
+        PY_THROW_WITH_LOG(PyExc_KeyError, "View operation missing 'type'");
+      }
+      const std::string kind = op_dict["type"].cast<std::string>();
+      if (kind == "narrow") {
+        if (!op_dict.contains("dim") || !op_dict.contains("start") || !op_dict.contains("length")) {
+          PY_THROW_WITH_LOG(PyExc_KeyError, "Narrow operation requires 'dim', 'start', and 'length'");
+        }
+        tensorcast::store::loader::NarrowOp narrow;
+        narrow.dim = op_dict["dim"].cast<int32_t>();
+        narrow.start = op_dict["start"].cast<int64_t>();
+        narrow.length = op_dict["length"].cast<uint64_t>();
+        ops.ops.push_back(ViewOp::Narrow(narrow));
+      } else if (kind == "transpose") {
+        if (!op_dict.contains("dim0") || !op_dict.contains("dim1")) {
+          PY_THROW_WITH_LOG(PyExc_KeyError, "Transpose operation requires 'dim0' and 'dim1'");
+        }
+        tensorcast::store::loader::TransposeOp transpose;
+        transpose.dim0 = op_dict["dim0"].cast<int32_t>();
+        transpose.dim1 = op_dict["dim1"].cast<int32_t>();
+        ops.ops.push_back(ViewOp::Transpose(transpose));
+      } else {
+        PY_THROW_WITH_LOG(PyExc_ValueError, absl::StrCat("Unsupported view operation: ", kind));
+      }
+    }
+    spec.tensors.emplace(tensor_name, std::move(ops));
+  }
+  return spec;
+}
+
+py::dict tensor_transform_plan_to_dict(const TensorTransformPlan& plan) {
+  py::dict out;
+  out["tensor_name"] = plan.tensor_name;
+  out["dst_offset"] = py::int_(plan.dst_offset);
+  out["canonical_offset"] = py::int_(plan.canonical_offset);
+  out["storage_offset_elements"] = py::int_(plan.storage_offset_elements);
+  py::list canonical_shape;
+  for (int64_t v : plan.canonical_shape) {
+    canonical_shape.append(py::int_(v));
+  }
+  out["canonical_shape"] = canonical_shape;
+  py::list canonical_stride;
+  for (int64_t v : plan.canonical_stride) {
+    canonical_stride.append(py::int_(v));
+  }
+  out["canonical_stride"] = canonical_stride;
+  py::list view_shape;
+  for (int64_t v : plan.view_shape) {
+    view_shape.append(py::int_(v));
+  }
+  out["view_shape"] = view_shape;
+  py::list view_stride;
+  for (int64_t v : plan.view_stride) {
+    view_stride.append(py::int_(v));
+  }
+  out["view_stride"] = view_stride;
+  py::list permutation;
+  for (int64_t v : plan.permutation) {
+    permutation.append(py::int_(v));
+  }
+  out["permutation"] = permutation;
+  out["dtype"] = plan.dtype;
+  out["element_size_bytes"] = py::int_(plan.element_size_bytes);
+  return out;
+}
+
+py::dict selection_range_to_dict(const tensorcast::store::loader::SelectionPlan::Range& range) {
+  py::dict out;
+  out["kind"] = range.kind == tensorcast::store::loader::SelectionPlan::Range::Kind::kData ? "data" : "pad";
+  out["src_offset"] = py::int_(range.src_offset);
+  out["dst_offset"] = py::int_(range.dst_offset);
+  out["length"] = py::int_(range.length);
+  return out;
+}
+
+py::dict compute_view_registration_plan_wrapper(py::bytes canonical_index_bytes, const py::dict& spec_dict) {
+  const std::string canonical_index_json = canonical_index_bytes.cast<std::string>();
+  ViewSpec spec = build_view_spec_from_py(spec_dict);
+
+  absl::StatusOr<BidirectionalViewPlan> plan_or =
+      ViewPlanner::compute_bidirectional_view_plan(canonical_index_json, spec);
+  if (!plan_or.ok()) {
+    PY_THROW_WITH_LOG(PyExc_RuntimeError, plan_or.status().ToString());
+  }
+  const BidirectionalViewPlan& plan = *plan_or;
+
+  py::dict result;
+  py::dict forward;
+  forward["is_identity"] = plan.forward.is_identity;
+  forward["view_size_bytes"] = py::int_(plan.forward.view_size_bytes);
+  forward["view_index_json"] = py::bytes(plan.forward.view_index_json);
+  forward["selection_total_bytes"] = py::int_(plan.forward.selection.total_bytes);
+  forward["selection_is_contiguous"] = plan.forward.selection.is_contiguous;
+  forward["selection_is_segment_aligned"] = plan.forward.selection.is_segment_aligned;
+  py::list selection_ranges;
+  for (const auto& range : plan.forward.selection.ranges) {
+    selection_ranges.append(selection_range_to_dict(range));
+  }
+  forward["selection_ranges"] = selection_ranges;
+  result["forward"] = forward;
+
+  py::list write_chunks;
+  for (const auto& chunk : plan.write.chunks) {
+    py::dict chunk_dict;
+    chunk_dict["canonical_offset"] = py::int_(chunk.canonical_offset);
+    chunk_dict["view_offset"] = py::int_(chunk.view_offset);
+    chunk_dict["length"] = py::int_(chunk.length);
+    chunk_dict["segment_aligned"] = chunk.segment_aligned;
+    write_chunks.append(chunk_dict);
+  }
+  result["write_chunks"] = write_chunks;
+
+  py::dict inverse;
+  inverse["requires_materialization"] = plan.inverse_transform.requires_materialization;
+  py::list inverse_tensors;
+  for (const TensorTransformPlan& tensor_plan : plan.inverse_transform.tensors) {
+    inverse_tensors.append(tensor_transform_plan_to_dict(tensor_plan));
+  }
+  inverse["tensors"] = inverse_tensors;
+  result["inverse_transform"] = inverse;
+
+  return result;
+}
+
+} // namespace
 
 // Wrapper function for generate_verification_info_from_disk
 py::dict generate_artifact_verification_info_wrapper(const std::string& disk_path, int verification_level = 1) {
@@ -708,6 +855,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("path"),
           py::arg("config") = py::dict(),
           "Unified save: writes data, tensor_index.json, artifact_descriptor.json and returns descriptor")
+      .def(
+          "compute_view_registration_plan",
+          &compute_view_registration_plan_wrapper,
+          py::arg("canonical_index_json"),
+          py::arg("view_ops"),
+          "Compute bidirectional view registration plan using the core ViewPlanner")
       .def("restore_tensors", &tensorcast::checkpoint::restore_tensors, "Restore a state dict")
       .def(
           "restore_tensors_from_disk",

--- a/tensorcast/daemon_ctl.py
+++ b/tensorcast/daemon_ctl.py
@@ -26,6 +26,7 @@ from tensorcast.proto.daemon.v1 import (
 from tensorcast.types import (
     ArtifactDescriptor,
     BeginRegisterArtifactResult,
+    CanonicalRange,
     CoalescedHandshake,
     CommitResult,
     LeaseHandshake,
@@ -655,6 +656,7 @@ class DaemonCtl:
         schema_version: str = "v2",
         plan: Plan | None = None,
         timeout_s: float = 30.0,
+        view: store_daemon_pb2.ViewRegistrationOptions | None = None,
     ) -> BeginRegisterArtifactResult:
         """Begin unified artifact registration (RFC-0014).
 
@@ -705,6 +707,8 @@ class DaemonCtl:
             plan = _DefaultPlan()
         kind = plan.kind
         plan.apply_to_begin_request(req)
+        if view is not None:
+            req.view.CopyFrom(view)
 
         with self._client_span("Client/BeginRegisterArtifact") as span:
             set_span_attributes(
@@ -809,7 +813,24 @@ class DaemonCtl:
                 encoding=desc.encoding,
                 total_size=int(desc.total_size),
             )
-            return CommitResult(descriptor=ad, existed=existed)
+            canonical_ranges: tuple[CanonicalRange, ...] = tuple(
+                CanonicalRange(offset=int(r.offset), length=int(r.length))
+                for r in resp.canonical_ranges
+            )
+            view_index_json = (
+                bytes(resp.view_index_json) if resp.view_index_json else None
+            )
+            view_id = resp.view_id or None
+            view_data_hash = resp.view_data_hash or None
+            return CommitResult(
+                descriptor=ad,
+                existed=existed,
+                view_id=view_id,
+                view_index_json=view_index_json,
+                view_data_hash=view_data_hash,
+                canonical_ranges=canonical_ranges,
+                allow_partial=bool(resp.allow_partial),
+            )
 
     def abort_registered_artifact(
         self, registration_id: str, *, timeout_s: float = 15.0
@@ -901,6 +922,36 @@ class DaemonCtl:
             return True
         except grpc.RpcError as e:  # noqa: BLE001
             logger.error(f"FeedRegisterArtifactStream(lease) failed: {e}")
+            return False
+
+    def feed_register_artifact_view_chunks(
+        self,
+        registration_id: str,
+        data: bytes | bytearray | memoryview,
+        *,
+        chunk_bytes: int = 4 * 1024 * 1024,
+    ) -> bool:
+        mv = memoryview(data)
+
+        def _iter():
+            offset = 0
+            while offset < mv.nbytes:
+                chunk = mv[offset : offset + chunk_bytes]
+                req = store_daemon_pb2.FeedRegisterArtifactStreamRequest(
+                    registration_id=registration_id
+                )
+                req.view_chunk.view_offset = int(offset)
+                req.view_chunk.data = bytes(chunk)
+                yield req
+                offset += len(chunk)
+
+        try:
+            self._unary_call(
+                self.stub.FeedRegisterArtifactStream, _iter(), timeout=30.0, retries=0
+            )
+            return True
+        except grpc.RpcError as e:  # noqa: BLE001
+            logger.error(f"FeedRegisterArtifactStream(view) failed: {e}")
             return False
 
     def keep_alive_registered_artifact(

--- a/tensorcast/global_store/README.md
+++ b/tensorcast/global_store/README.md
@@ -246,6 +246,7 @@ Replica selection is claimed atomically in SQL (`ReplicaRepository.find_availabl
   - `update_view_state()` persists variant metadata (`variants`) and leaf digests (`leaves`) in a single transaction, leaving canonical `chunk_directory` entries untouched.
   - Groups `LeafWritePayload` batches by ByteSpace (`space_kind`, `space_id`) and normalises case, guaranteeing idempotent upserts.
   - Provides the business logic backing `UpdateArtifactViewState` so daemons have a single helper for publishing variant identities and verification leaves.
+  - Emits Prometheus counters (`tc_view_registration_total`) and gauges (`tc_view_partial_backlog_bytes`) to highlight partial coverage backlog per view; refer to [Variant View Registration Telemetry](../../docs/architecture/p2p-transfer-strategies.md#variant-view-registration-telemetry) for the cross-component flow.
 
 ## gRPC Facade (GlobalStoreServicer)
 

--- a/tensorcast/global_store/grpc_service.py
+++ b/tensorcast/global_store/grpc_service.py
@@ -492,6 +492,11 @@ class GlobalStoreServicer(global_store_pb2_grpc.GlobalStoreServiceServicer):
                     else None
                 )
                 view_data_hash = variant.view_data_hash or None
+                canonical_size: Optional[int] = None
+                canonical_covered: Optional[int] = None
+                if variant.HasField("canonical_coverage"):
+                    canonical_size = int(variant.canonical_coverage.total_bytes)
+                    canonical_covered = int(variant.canonical_coverage.covered_bytes)
                 variant_payload = VariantUpsertPayload(
                     artifact_id=artifact_id,
                     view_id=variant.view_id,
@@ -499,6 +504,8 @@ class GlobalStoreServicer(global_store_pb2_grpc.GlobalStoreServiceServicer):
                     view_size=variant.view_size,
                     view_data_hash=view_data_hash,
                     verified_at=verified_at,
+                    canonical_size_bytes=canonical_size,
+                    canonical_bytes_covered=canonical_covered,
                 )
 
             leaf_payloads: list[LeafWritePayload] = []

--- a/tensorcast/global_store/metrics.py
+++ b/tensorcast/global_store/metrics.py
@@ -131,6 +131,20 @@ ACTIVE_TRANSPORTS_GAUGE = Gauge(
     "Current number of in-flight (not yet completed) artifact transports.",
 )
 
+# View registration ----------------------------------------------------------
+
+VIEW_REGISTRATION_COUNTER = Counter(
+    "tc_view_registration_total",
+    "Total number of view registrations recorded by the Global Store.",
+    labelnames=("result",),  # result=complete|partial
+)
+
+VIEW_PARTIAL_BACKLOG_GAUGE = Gauge(
+    "tc_view_partial_backlog_bytes",
+    "Canonical byte backlog for partial view registrations.",
+    labelnames=("artifact_id", "view_id"),
+)
+
 # Recovery / state-sync ------------------------------------------------------
 
 STATE_SYNC_COUNTER = Counter(
@@ -204,6 +218,22 @@ def set_replicas_per_memtype(memory_type: str, count: int) -> None:
     """Set per-memory-type replica gauge."""
 
     REPLICA_PER_MEMTYPE_GAUGE.labels(memory_type=memory_type).set(count)
+
+
+def inc_view_registration(result: str) -> None:
+    """Increment the view registration counter."""
+
+    VIEW_REGISTRATION_COUNTER.labels(result=result).inc()
+
+
+def set_view_partial_backlog(
+    artifact_id: str, view_id: str, backlog_bytes: int
+) -> None:
+    """Track outstanding canonical bytes for a view registration."""
+
+    VIEW_PARTIAL_BACKLOG_GAUGE.labels(artifact_id=artifact_id, view_id=view_id).set(
+        backlog_bytes
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tensorcast/global_store/services/view_state_service.py
+++ b/tensorcast/global_store/services/view_state_service.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+from tensorcast.global_store import metrics
 from tensorcast.global_store.repositories.leaf_repository import LeafRepository
 from tensorcast.global_store.repositories.variant_repository import VariantRepository
 from tensorcast.logger import init_logger
@@ -26,6 +27,8 @@ class VariantUpsertPayload:
     view_size: int
     view_data_hash: Optional[str]
     verified_at: Optional[datetime]
+    canonical_size_bytes: Optional[int] = None
+    canonical_bytes_covered: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -110,6 +113,56 @@ class ViewStateService:
                         entries=entries,
                         cursor=cursor,
                     )
+
+        if variant is not None:
+            total = variant.canonical_size_bytes
+            covered = variant.canonical_bytes_covered
+            backlog = None
+            if total is not None and covered is not None and total > 0:
+                capped_covered = min(total, covered)
+                backlog = max(0, total - capped_covered)
+                metrics.set_view_partial_backlog(
+                    variant.artifact_id, variant.view_id, backlog
+                )
+            elif total is not None and total == 0:
+                metrics.set_view_partial_backlog(
+                    variant.artifact_id, variant.view_id, 0
+                )
+            result = "partial" if backlog and backlog > 0 else "complete"
+            metrics.inc_view_registration(result)
+            if backlog is None:
+                metrics.set_view_partial_backlog(
+                    variant.artifact_id, variant.view_id, 0
+                )
+
+    def record_variant_registration(
+        self,
+        *,
+        artifact_id: str,
+        view_id: str,
+        view_spec_json: str,
+        view_size: int,
+        view_data_hash: Optional[str],
+        verified_at: Optional[datetime],
+        canonical_size_bytes: Optional[int] = None,
+        canonical_bytes_covered: Optional[int] = None,
+        leaf_writes: Optional[Sequence[LeafWritePayload]] = None,
+    ) -> None:
+        """Convenience wrapper to persist variant metadata after registration."""
+        variant = VariantUpsertPayload(
+            artifact_id=artifact_id,
+            view_id=view_id,
+            view_spec_json=view_spec_json,
+            view_size=view_size,
+            view_data_hash=view_data_hash,
+            verified_at=verified_at,
+            canonical_size_bytes=canonical_size_bytes,
+            canonical_bytes_covered=canonical_bytes_covered,
+        )
+        self.update_view_state(
+            variant=variant,
+            leaf_writes=leaf_writes or (),
+        )
 
     # ------------------------------------------------------------------
     # Queries

--- a/tensorcast/types.py
+++ b/tensorcast/types.py
@@ -78,6 +78,15 @@ class ArtifactDescriptor(BaseModel):
     total_size: int
 
 
+class CanonicalRange(BaseModel):
+    """Canonical byte range populated during view registration."""
+
+    model_config = ConfigDict(frozen=True)
+
+    offset: int
+    length: int
+
+
 class CommitResult(BaseModel):
     """Commit result with descriptor and idempotency flag."""
 
@@ -85,6 +94,11 @@ class CommitResult(BaseModel):
 
     descriptor: ArtifactDescriptor
     existed: bool = False
+    view_id: str | None = None
+    view_index_json: bytes | None = None
+    view_data_hash: str | None = None
+    canonical_ranges: tuple[CanonicalRange, ...] = ()
+    allow_partial: bool = False
 
 
 # ------------------------------ Plan models --------------------------------
@@ -191,6 +205,7 @@ __all__ = [
     "Handshake",
     "BeginRegisterArtifactResult",
     "ArtifactDescriptor",
+    "CanonicalRange",
     "CommitResult",
     "PlanBase",
     "CoalescedPlan",

--- a/tests/python/global_store/test_services.py
+++ b/tests/python/global_store/test_services.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+from tensorcast.global_store import metrics
 from tensorcast.global_store.exceptions import (
     NotFoundError,
     TimeoutError,
@@ -617,6 +618,8 @@ class TestServices:
             view_size=128,
             view_data_hash="mhash",
             verified_at=now,
+            canonical_size_bytes=128,
+            canonical_bytes_covered=128,
         )
         leaf_payloads = [
             LeafWritePayload(
@@ -657,6 +660,93 @@ class TestServices:
         assert len(leaves) == 2
         assert leaves[0][0] == 0
         assert leaves[0][1] == b"\x01" * 32
+
+    def test_view_state_service_record_variant_registration(self, services):
+        """record_variant_registration delegates to update_view_state."""
+        view_state_service = services["view_state"]
+        now = datetime.now(timezone.utc)
+        leaf_payloads = [
+            LeafWritePayload(
+                artifact_id="mi2:index:data",
+                space_kind="V",
+                space_id="view-2",
+                leaf_idx=0,
+                digest=b"\x03" * 32,
+            )
+        ]
+
+        view_state_service.record_variant_registration(
+            artifact_id="mi2:index:data",
+            view_id="view-2",
+            view_spec_json='{"tensor":"weights"}',
+            view_size=512,
+            view_data_hash="mhash-2",
+            verified_at=now,
+            canonical_size_bytes=512,
+            canonical_bytes_covered=512,
+            leaf_writes=leaf_payloads,
+        )
+
+        stored_variant = view_state_service.get_variant(
+            artifact_id="mi2:index:data",
+            view_id="view-2",
+        )
+        assert stored_variant is not None
+        assert stored_variant["view_size"] == 512
+        assert stored_variant["view_data_hash"] == "mhash-2"
+
+        leaves = list(
+            view_state_service.get_leaves(
+                artifact_id="mi2:index:data",
+                space_kind="V",
+                space_id="view-2",
+            )
+        )
+        assert len(leaves) == 1
+        assert leaves[0][0] == 0
+        assert leaves[0][1] == b"\x03" * 32
+
+    def test_view_state_service_metrics_track_backlog(self, services):
+        view_state_service = services["view_state"]
+        metrics.VIEW_PARTIAL_BACKLOG_GAUGE.clear()
+        complete_counter = metrics.VIEW_REGISTRATION_COUNTER.labels(result="complete")
+        partial_counter = metrics.VIEW_REGISTRATION_COUNTER.labels(result="partial")
+        baseline_complete = complete_counter._value.get()
+        baseline_partial = partial_counter._value.get()
+
+        view_state_service.record_variant_registration(
+            artifact_id="mi2:index:metrics",
+            view_id="view-metrics",
+            view_spec_json="{}",
+            view_size=256,
+            view_data_hash=None,
+            verified_at=None,
+            canonical_size_bytes=1024,
+            canonical_bytes_covered=512,
+        )
+
+        backlog_value = metrics.VIEW_PARTIAL_BACKLOG_GAUGE.labels(
+            artifact_id="mi2:index:metrics", view_id="view-metrics"
+        )._value.get()
+        assert backlog_value == 512
+        assert partial_counter._value.get() == baseline_partial + 1
+
+        view_state_service.record_variant_registration(
+            artifact_id="mi2:index:metrics",
+            view_id="view-metrics",
+            view_spec_json="{}",
+            view_size=256,
+            view_data_hash=None,
+            verified_at=None,
+            canonical_size_bytes=1024,
+            canonical_bytes_covered=1024,
+        )
+
+        backlog_after = metrics.VIEW_PARTIAL_BACKLOG_GAUGE.labels(
+            artifact_id="mi2:index:metrics", view_id="view-metrics"
+        )._value.get()
+        assert backlog_after == 0
+        assert complete_counter._value.get() == baseline_complete + 1
 
     def test_view_state_service_rejects_mismatched_artifact(self, services):
         """Leaf writes must share artifact_id."""

--- a/tests/python/test_store_view_api.py
+++ b/tests/python/test_store_view_api.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
+import contextlib
 import threading
 from typing import Any, cast
+from types import SimpleNamespace
 
+import grpc
 import pytest
 import torch
 
+from tensorcast import _C
 from tensorcast.api.store import (
     CanonicalIndex,
     CanonicalIndexEntry,
     MaterializedArtifact,
     Store,
     StoreOptions,
+    ArtifactError,
 )
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
 
@@ -53,13 +58,26 @@ def _fresh_store() -> Store:
     store._pending_futures = set()
     store._key_cache = {}
     store._key_cache_lock = threading.RLock()
+    store._metadata_lock = threading.RLock()
+    store._metadata = {}
     return store
+
+
+class _PlacementRpcError(grpc.RpcError):
+    def __init__(self, details: str) -> None:
+        self._details = details
+
+    def code(self) -> grpc.StatusCode:
+        return grpc.StatusCode.FAILED_PRECONDITION
+
+    def details(self) -> str:
+        return self._details
 
 
 def test_build_view_spec_narrow_normalizes_length() -> None:
     store = _fresh_store()
     canonical = _make_canonical_index()
-    view_spec, has_transpose = Store._build_view_spec(
+    view_spec, has_transpose, ops = Store._build_view_spec(
         store,
         canonical_index=canonical,
         slices={"weights": (slice(32, 96),)},
@@ -68,18 +86,19 @@ def test_build_view_spec_narrow_normalizes_length() -> None:
     assert view_spec is not None
     assert not has_transpose
     assert "weights" in view_spec.tensors
-    ops = view_spec.tensors["weights"].ops
-    assert len(ops) == 1
-    narrow = ops[0].narrow
+    view_ops = view_spec.tensors["weights"].ops
+    assert len(view_ops) == 1
+    narrow = view_ops[0].narrow
     assert narrow.dim == 0
     assert narrow.start == 32
     assert narrow.length == 64
+    assert ops["weights"][0]["type"] == "narrow"
 
 
 def test_build_view_spec_identity_returns_none() -> None:
     store = _fresh_store()
     canonical = _make_canonical_index()
-    view_spec, has_transpose = Store._build_view_spec(
+    view_spec, has_transpose, _ = Store._build_view_spec(
         store,
         canonical_index=canonical,
         slices={"weights": (slice(0, 256),)},
@@ -92,7 +111,7 @@ def test_build_view_spec_identity_returns_none() -> None:
 def test_build_view_spec_transpose_canonicalizes_sequence() -> None:
     store = _fresh_store()
     canonical = _make_three_dim_index()
-    view_spec, has_transpose = Store._build_view_spec(
+    view_spec, has_transpose, ops_map = Store._build_view_spec(
         store,
         canonical_index=canonical,
         slices=None,
@@ -103,6 +122,8 @@ def test_build_view_spec_transpose_canonicalizes_sequence() -> None:
     ops = view_spec.tensors["tensor"].ops
     # Canonical ordering should be deterministic
     assert [(op.transpose.dim0, op.transpose.dim1) for op in ops] == [(0, 2), (1, 2)]
+    assert len(ops_map["tensor"]) == 2
+    assert ops_map["tensor"][0]["type"] == "transpose"
 
 
 def test_get_view_invokes_perform_with_spec(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -123,11 +144,37 @@ def test_get_view_invokes_perform_with_spec(monkeypatch: pytest.MonkeyPatch) -> 
         slices: Any,
         transpose: Any,
         view_id: str | None,
-    ) -> tuple[str, bytes | None, store_daemon_pb2.ViewSpec | None, bool, str | None]:
+    ) -> tuple[
+        str,
+        bytes | None,
+        store_daemon_pb2.ViewSpec | None,
+        bool,
+        str | None,
+        dict[str, list[dict[str, int | str]]],
+    ]:
         assert client is fake_client
-        return "artifact-123", b"{}", fake_spec, False, None
+        return "artifact-123", b"{}", fake_spec, False, None, {
+            "weights": [{"type": "narrow", "dim": 0, "start": 0, "length": 16}]
+        }
 
     monkeypatch.setattr(Store, "_resolve_view_inputs", fake_resolve)
+
+    fake_span = SimpleNamespace(
+        add_event=lambda *args, **kwargs: None,
+        set_attribute=lambda *args, **kwargs: None,
+        set_status=lambda *args, **kwargs: None,
+        record_exception=lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        Store,
+        "_operation_span",
+        lambda self, *args, **kwargs: contextlib.nullcontext(fake_span),
+    )
+    monkeypatch.setattr(
+        store,
+        "_operation_span",
+        lambda *args, **kwargs: contextlib.nullcontext(fake_span),
+    )
     placement_value = store_daemon_pb2.TransformPlacement.TRANSFORM_PLACEMENT_SERVER
     monkeypatch.setattr(
         Store,
@@ -181,8 +228,15 @@ def test_get_view_into_uses_layout_index(monkeypatch: pytest.MonkeyPatch) -> Non
         slices: Any,
         transpose: Any,
         view_id: str | None,
-    ) -> tuple[str, bytes | None, store_daemon_pb2.ViewSpec | None, bool, str | None]:
-        return "artifact-123", b"{}", None, False, None
+    ) -> tuple[
+        str,
+        bytes | None,
+        store_daemon_pb2.ViewSpec | None,
+        bool,
+        str | None,
+        dict[str, list[dict[str, int | str]]],
+    ]:
+        return "artifact-123", b"{}", None, False, None, {}
 
     monkeypatch.setattr(Store, "_resolve_view_inputs", fake_resolve)
 
@@ -217,3 +271,94 @@ def test_get_view_into_uses_layout_index(monkeypatch: pytest.MonkeyPatch) -> Non
     assert torch.allclose(target["weights"], torch.ones(16))
     assert captured_index["shapes"] == [(16,)]
     assert released.get("called") is True
+
+
+def test_compute_view_registration_plan_binding_narrow() -> None:
+    canonical_index = b'{"weights":[0,16,[4],[1],"torch.float32",0]}'
+    ops = {"weights": [{"type": "narrow", "dim": 0, "start": 1, "length": 2}]}
+    plan = _C.compute_view_registration_plan(canonical_index, ops)
+    forward = plan["forward"]
+    assert forward["view_size_bytes"] == 8
+    chunks = plan["write_chunks"]
+    assert len(chunks) == 1
+    first = chunks[0]
+    assert first["canonical_offset"] == 4
+    assert first["length"] == 8
+
+
+def test_register_view_client_placement_builds_canonical(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _fresh_store()
+    fake_client = object()
+    monkeypatch.setattr(Store, "_ensure_client", lambda self: fake_client)
+
+    canonical_index = b'{"weights":[0,16,[4],[1],"torch.float32",0]}'
+    view_spec = store_daemon_pb2.ViewSpec()
+    narrow = view_spec.tensors["weights"].ops.add().narrow
+    narrow.dim = 0
+    narrow.start = 1
+    narrow.length = 2
+
+    def fake_resolve(
+        self,
+        *,
+        client: Any,
+        artifact_id: str | None,
+        key: str | None,
+        slices: Any,
+        transpose: Any,
+        view_id: str | None,
+    ) -> tuple[
+        str,
+        bytes | None,
+        store_daemon_pb2.ViewSpec | None,
+        bool,
+        str | None,
+        dict[str, list[dict[str, int | str]]],
+    ]:
+        return (
+            "artifact-123",
+            canonical_index,
+            view_spec,
+            False,
+            None,
+            {"weights": [{"type": "narrow", "dim": 0, "start": 1, "length": 2}]},
+        )
+
+    monkeypatch.setattr(Store, "_resolve_view_inputs", fake_resolve)
+
+    captured: dict[str, Any] = {}
+
+    def fake_perform(self, upload_tensors, **kwargs):
+        captured["tensors"] = upload_tensors
+        captured["view_registration"] = kwargs.get("view_registration")
+        return SimpleNamespace()
+
+    monkeypatch.setattr(Store, "_perform_registration", fake_perform)
+
+    view_tensor = torch.tensor([10.0, 20.0], dtype=torch.float32)
+    result = Store.register_view(
+        store,
+        tensors={"weights": view_tensor},
+        artifact_id="artifact-123",
+        placement="CLIENT",
+    )
+    assert isinstance(result, SimpleNamespace)
+    canonical = captured["tensors"]["weights"]
+    assert torch.allclose(canonical, torch.tensor([0.0, 10.0, 20.0, 0.0]))
+    assert canonical.dtype == torch.float32
+    view_reg = captured["view_registration"]
+    assert view_reg.placement == store_daemon_pb2.TRANSFORM_PLACEMENT_CLIENT
+
+
+def test_register_view_server_placement_error_guidance() -> None:
+    store = _fresh_store()
+    failure = _PlacementRpcError(
+        "SERVER placement for view registration requires GPU transpose support on device 0; "
+        "retry with placement=CLIENT (mock device missing)"
+    )
+
+    mapped = store._map_registration_error(failure)
+    assert isinstance(mapped, ArtifactError)
+    assert mapped.status_code == "FAILED_PRECONDITION"
+    assert mapped.retryable is False
+    assert "placement='CLIENT'" in str(mapped)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> End-to-end variant view registration (slice/transpose) is added across core, daemon, SDK, and Global Store, including streaming ingest, hashing/telemetry, and APIs/protos/metrics with tests.
> 
> - **Core (C++)**:
>   - **View planning/ingest**: Add bidirectional planning in `core/store/loader:view_planner` (`ViewWritePlan`, `BidirectionalViewPlan`) and new `ViewIngestExecutor` to stream view bytes into canonical memory and apply inverse transforms.
>   - **StoreEngine**: Extend registration to accept `ViewRegistration` (SERVER/CLIENT), stream chunks (`ingest_view_registration_chunk`), finalize transforms, compute view/canonical hashes + leaf digests, and publish via Global Store; enrich commit result with `view_id`, `view_index_json`, `view_data_multihash`, and canonical coverage.
>   - **GlobalStoreClient**: Add `update_artifact_view_state(VariantViewUpdate)` RPC wrapper; minor helpers/utilities.
>   - BUILD: new targets/tests for view ingest.
> - **Daemon**:
>   - **Controller/Proto**: Add `ViewRegistrationOptions` and `ViewUploadChunk` to `Begin/Feed/Commit`; stream view chunks to engine; enforce placement and TTL handling; surface view fields in commit response; README notes view upload.
>   - **RegistrationManager**: Track view meta (placement, coverage, progress).
> - **Global Store**:
>   - **RPC/Service**: Implement `UpdateArtifactViewState` (variant upsert + leaves); add metrics (`tc_view_registration_total`, `tc_view_partial_backlog_bytes`); extend models/services to track canonical coverage.
> - **Python SDK**:
>   - **API**: Add `register_view()` (SERVER/CLIENT); plan via `_C.compute_view_registration_plan`; linearize/upload view or client-materialize canonical; surface view fields in `RegistrationResult`.
>   - **Bindings**: Expose `compute_view_registration_plan` in `tensorcast._C`.
>   - **Exports**: Re-export `register_view` in `tensorcast.__init__`.
> - **Protos**:
>   - `daemon.v1`: `ViewRegistrationOptions`, `ViewUploadChunk`, commit view fields; stricter index schema v3.
>   - `global_store.v1`: extend `VariantUpsert` (coverage), `LeafWrite`, and add `UpdateArtifactViewState` plumbing.
> - **Tests/Docs**:
>   - New/updated C++ and Python tests for view ingest/registration; design/plan docs for Variant View Registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f69ece6785536e102cdb33f1038677149d051c26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->