### PR TITLE
refactor(store): refactor verification metadata coordination and enhance async copy management

### DIFF
--- a/core/common/BUILD
+++ b/core/common/BUILD
@@ -92,6 +92,7 @@ sc_cc_library(
     hdrs = ["artifact_verification.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":artifact_hash_lib",
         ":cuda_api_lib",
         ":error_handling_lib",
         "@abseil-cpp//absl/strings",

--- a/core/common/artifact_verification.cc
+++ b/core/common/artifact_verification.cc
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstring>
 #include <numeric>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -14,6 +15,8 @@
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "core/common/artifact_hash.h"
 #include "core/common/cuda_api.h"
 #include "core/common/error_handling.h"
 
@@ -41,20 +44,35 @@ std::string bytes_to_hex(absl::Span<const uint8_t> bytes) {
   return out;
 }
 
-// JSON serialization using nlohmann/json
-std::string ArtifactVerificationInfo::to_json() const {
+std::string bytes_to_compact_hex(absl::Span<const uint8_t> bytes) {
+  std::string out;
+  out.reserve(bytes.size() * 2);
+  for (uint8_t byte : bytes) {
+    absl::StrAppendFormat(&out, "%02x", byte);
+  }
+  return out;
+}
+
+json build_base_verification_json(const ArtifactVerificationInfo& info) {
   json j;
   j["version"] = "1.0";
-  if (!byte_space_id.empty()) {
-    j["byte_space_id"] = byte_space_id;
+  if (!info.byte_space_id.empty()) {
+    j["byte_space_id"] = info.byte_space_id;
   }
-  j["artifact_size"] = artifact_size;
-  j["full_hash"] = full_hash;
-  j["segment_hashes"] = segment_hashes;
-  j["sample_values"] = sample_values;
-  j["key_values"] = key_values;
+  j["artifact_size"] = info.artifact_size;
+  j["full_hash"] = info.full_hash;
+  j["segment_hashes"] = info.segment_hashes;
+  j["sample_values"] = info.sample_values;
+  j["key_values"] = info.key_values;
+  return j;
+}
 
-  return j.dump(2); // Pretty print with 2-space indentation
+// JSON serialization using nlohmann/json
+std::string ArtifactVerificationInfo::to_json() const {
+  json base = build_base_verification_json(*this);
+  json enriched = base;
+  enriched["metadata_signature"] = compute_metadata_signature();
+  return enriched.dump(2); // Pretty print with 2-space indentation
 }
 
 // JSON deserialization using nlohmann/json
@@ -63,6 +81,17 @@ absl::StatusOr<ArtifactVerificationInfo> ArtifactVerificationInfo::from_json(con
     json j = json::parse(json_str);
 
     ArtifactVerificationInfo info;
+
+    std::optional<std::string> provided_signature;
+    if (j.contains("metadata_signature")) {
+      if (!j["metadata_signature"].is_string()) {
+        return absl::InvalidArgumentError("metadata_signature must be a string");
+      }
+      provided_signature = j["metadata_signature"].get<std::string>();
+      j.erase("metadata_signature");
+    } else {
+      return absl::FailedPreconditionError("metadata_signature missing from verification metadata");
+    }
 
     if (j.contains("byte_space_id") && j["byte_space_id"].is_string()) {
       info.byte_space_id = j["byte_space_id"].get<std::string>();
@@ -108,6 +137,19 @@ absl::StatusOr<ArtifactVerificationInfo> ArtifactVerificationInfo::from_json(con
       }
     }
 
+    const std::string computed_signature = info.compute_metadata_signature();
+    info.metadata_signature = computed_signature;
+    info.signature_present = true;
+    if (!provided_signature.has_value()) {
+      info.signature_valid = false;
+      return absl::FailedPreconditionError("metadata_signature missing after parse");
+    }
+    if (computed_signature != *provided_signature) {
+      info.signature_valid = false;
+      return absl::DataLossError("metadata_signature mismatch");
+    }
+    info.signature_valid = true;
+
     return info;
 
   } catch (const json::parse_error& e) {
@@ -117,6 +159,20 @@ absl::StatusOr<ArtifactVerificationInfo> ArtifactVerificationInfo::from_json(con
   } catch (const std::exception& e) {
     return absl::InvalidArgumentError(absl::StrCat("JSON processing error: ", e.what()));
   }
+}
+
+std::string ArtifactVerificationInfo::compute_metadata_signature() const {
+  json base = build_base_verification_json(*this);
+  const std::string canonical = base.dump();
+  const auto digest = common::sha256_digest_bytes(
+      absl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(canonical.data()), canonical.size()));
+  return bytes_to_compact_hex(digest);
+}
+
+void ArtifactVerificationInfo::refresh_metadata_signature() {
+  metadata_signature = compute_metadata_signature();
+  signature_present = true;
+  signature_valid = true;
 }
 
 // Rotate left
@@ -350,6 +406,11 @@ absl::StatusOr<ArtifactVerificationInfo> ArtifactVerifier::generate_verification
   }
   info.key_values[2] = *last_val;
 
+  auto fmt_hex = [](uint64_t value) { return absl::StrCat("0x", absl::Hex(value, absl::kZeroPad16)); };
+  LOG(INFO) << "ArtifactVerifier::generate_verification_info device_id=" << device_id << " size=" << info.artifact_size
+            << " key_values=[" << fmt_hex(info.key_values[0]) << ", " << fmt_hex(info.key_values[1]) << ", "
+            << fmt_hex(info.key_values[2]) << "]";
+
   // 2. Sample values (16 evenly distributed points) - minimal data copying
   for (size_t i = 0; i < NUM_SAMPLES; ++i) {
     size_t offset = (info.artifact_size * i) / NUM_SAMPLES;
@@ -536,8 +597,19 @@ absl::Status ArtifactVerifier::verify_artifact_data(
       if (!val.ok()) {
         return val.status();
       }
-      if (*val != expected_info.sample_values.at(i)) {
-        return absl::DataLossError(absl::StrCat("Sample value mismatch at offset ", offset));
+      const uint64_t expected = expected_info.sample_values.at(i);
+      const uint64_t actual = *val;
+      if (actual != expected) {
+        LOG(ERROR) << "ArtifactVerifier sample mismatch offset=" << offset << " actual=0x" << absl::Hex(actual)
+                   << " expected=0x" << absl::Hex(expected);
+        return absl::DataLossError(
+            absl::StrCat(
+                "Sample value mismatch at offset ",
+                offset,
+                ": actual=0x",
+                absl::Hex(actual),
+                " expected=0x",
+                absl::Hex(expected)));
       }
     }
   }

--- a/core/common/artifact_verification.h
+++ b/core/common/artifact_verification.h
@@ -31,9 +31,24 @@ struct ArtifactVerificationInfo {
   std::array<uint64_t, 16> sample_values = {}; // Values at 16 sample points
   std::array<uint64_t, 3> key_values = {}; // Values at start, middle, end
 
+  // Integrity metadata for persisted verification artifacts.
+  // `metadata_signature` is the canonical SHA-256 hex digest of the serialized
+  // verification payload (excluding the signature field itself). These fields
+  // are derived data and are populated by the serializer/deserializer helpers.
+  std::string metadata_signature;
+  bool signature_present = false;
+  bool signature_valid = false;
+
   // Serialize to/from JSON string for storage
   [[nodiscard]] std::string to_json() const;
   static absl::StatusOr<ArtifactVerificationInfo> from_json(const std::string& json_str);
+
+  // Recompute and refresh the metadata signature fields based on current
+  // verification values.
+  void refresh_metadata_signature();
+
+  // Compute the canonical metadata signature without mutating the struct.
+  [[nodiscard]] std::string compute_metadata_signature() const;
 } __attribute__((aligned(128)));
 
 class ArtifactVerifier {

--- a/core/common/async_copy_manager.cc
+++ b/core/common/async_copy_manager.cc
@@ -404,6 +404,29 @@ absl::StatusOr<CopyHandle> AsyncCopyManager::submit_h2h(
   return handle;
 }
 
+absl::Status AsyncCopyManager::synchronize_h2d_stream(int device_id) {
+  if (device_id < 0) {
+    return absl::InvalidArgumentError("invalid device_id for H2D stream synchronize");
+  }
+  cudaStream_t stream = nullptr;
+  {
+    absl::MutexLock lock(&mu_);
+    auto it = h2d_streams_.find(device_id);
+    if (it == h2d_streams_.end()) {
+      return absl::OkStatus();
+    }
+    stream = it->second;
+  }
+  if (stream == nullptr) {
+    return absl::OkStatus();
+  }
+  auto set_dev_status = cuda::set_device(device_id);
+  if (!set_dev_status.ok()) {
+    return set_dev_status;
+  }
+  return cuda::stream_synchronize(stream);
+}
+
 void AsyncCopyManager::enqueue_callback_(std::function<void()> cb) {
   if (!cb) {
     return;

--- a/core/common/async_copy_manager.h
+++ b/core/common/async_copy_manager.h
@@ -92,6 +92,11 @@ class AsyncCopyManager {
   // other async submissions, enabling CPU-only tests to exercise pump logic.
   absl::StatusOr<CopyHandle> submit_h2h(const HostRegion& src, const HostRegion& dst, const CopyOptions& opts = {});
 
+  // Synchronize the per-device H2D stream to guarantee that all outstanding
+  // host→device copies have completed. If no stream has been created for the
+  // device, this returns OK immediately.
+  absl::Status synchronize_h2d_stream(int device_id);
+
   // Destroy all lazily-created per-device streams. Safe to call multiple times.
   void shutdown();
 

--- a/core/common/memory/streaming_pinned_buffer.cc
+++ b/core/common/memory/streaming_pinned_buffer.cc
@@ -320,7 +320,6 @@ absl::Status StreamingPinnedBuffer::mark_chunk_ready(int slot_id, size_t global_
   set_slot_state_unsafe(slot_id, SlotState::kReady);
   chunks_produced_++;
   ready_cv_.Signal();
-
   return absl::OkStatus();
 }
 
@@ -355,7 +354,6 @@ absl::StatusOr<StreamingPinnedBuffer::ReadyChunk> StreamingPinnedBuffer::get_rea
   }
   set_slot_state_unsafe(chunk.slot_id, SlotState::kConsumerOwned);
   slot_chunk_ids_[chunk.slot_id] = chunk.global_chunk_id;
-
   return chunk;
 }
 
@@ -384,7 +382,6 @@ absl::Status StreamingPinnedBuffer::return_chunk(int slot_id) {
   free_queue_.push(slot_id);
   chunks_consumed_++;
   free_cv_.Signal();
-
   return absl::OkStatus();
 }
 

--- a/core/store/BUILD
+++ b/core/store/BUILD
@@ -161,6 +161,45 @@ sc_cc_library(
     ],
 )
 
+sc_cc_library(
+    name = "eviction_service",
+    srcs = ["components/eviction_service.cc"],
+    hdrs = ["components/eviction_service.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":device_manager",
+        ":metrics_collector",
+        ":replica_registry",
+        "//core/common:memory_location_lib",
+        "//core/common:pinned_buffer_pool_lib",
+        "//core/store:device_types",
+        "//core/store/replica",
+        "@abseil-cpp//absl/functional:function_ref",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "eviction_service_test",
+    srcs = ["components/eviction_service_test.cc"],
+    deps = [
+        ":eviction_service",
+        "//core/testing:catch_main",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@catch2//:catch2_main",
+    ],
+)
+
+cc_test(
+    name = "multi_gpu_verification_race_test",
+    srcs = ["multi_gpu_verification_race_test.cc"],
+    deps = [
+        "//core/store/loader:verification_utils",
+        "//core/testing:catch_main",
+        "@catch2//:catch2_main",
+    ],
+)
+
 # ========== Loading orchestration ==========
 
 # materialize_orchestrator is now part of store_engine target to avoid circular dependency
@@ -197,6 +236,19 @@ sc_cc_library(
     ],
 )
 
+sc_cc_library(
+    name = "view_utils",
+    srcs = ["view_utils.cc"],
+    hdrs = ["view_utils.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/store/loader:view_planner",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/types:span",
+        "@nlohmann_json//:json",
+    ],
+)
+
 # ========== Main Store Engine ==========
 
 sc_cc_library(
@@ -216,12 +268,14 @@ sc_cc_library(
         ":device_manager",
         ":device_registry",
         ":device_types",
+        ":eviction_service",
         ":global_store_client",
         ":loading_spec",
         ":metrics_collector",
         ":replica_registration_helper",
         ":replica_registry",
         ":store_engine_options",
+        ":view_utils",
         "//core/checkpoint:checkpoint_lib",
         "//core/common:artifact_hash_lib",
         "//core/common:artifact_verification_lib",
@@ -233,9 +287,11 @@ sc_cc_library(
         "//core/store/loader",
         "//core/store/loader:canonical_index",
         "//core/store/loader:disk_loader",
+        "//core/store/loader:index_reader",
         "//core/store/loader:p2p_loader",
         "//core/store/loader:segment_plan_source",
         "//core/store/loader:source_hash",
+        "//core/store/loader:verification_utils",
         "//core/store/loader:view_ingest_executor",
         "//core/store/loader:view_plan_source",
         "//core/store/loader:view_planner",

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -18,6 +18,11 @@ Key files:
 - Replica + ReplicaLoadController: core/store/replica/*
 - Loaders and pump: core/store/loader/*
 - View planning + execution: core/store/loader/view_planner.{h,cc}, core/store/loader/view_plan_source.{h,cc}
+- Service helpers:
+  - IndexService: core/store/loader/index_reader.{h,cc}
+  - VerificationService: core/store/loader/verification_utils.{h,cc}
+  - EvictionService: core/store/components/eviction_service.{h,cc}
+  - View spec helpers: core/store/view_utils.{h,cc}
 - Components: core/store/components/*
 - Types: core/store/loading/loading_spec.h, core/store/device_types.h, core/store/communication_types.h
 
@@ -250,7 +255,7 @@ stateDiagram-v2
 
 
 - GPU allocations are lazily created via UMA on first use; VS CPU region is reserved at construction.
-- Transfers and loading are pipelined via `TransferService` and `pump_ranges`, using a per-session `StreamingPinnedBuffer` backed by the shared `PinnedBufferPool`. TransferService tracks every in-flight H2D submission and waits for the outstanding `AsyncCopyManager` handles before completing so GPU residency is fully committed prior to verification.
+- Transfers and loading are pipelined via `TransferService` and `pump_ranges`, using a per-session `StreamingPinnedBuffer` backed by the shared `PinnedBufferPool`. `TransferService` now synchronises the per-device H2D stream via `AsyncCopyManager::synchronize_h2d_stream()` followed by `cuda::device_synchronize()` so GPU residency is fully committed before verification and metadata persistence run.
 
 ### Async Copy Manager Integration
 
@@ -410,7 +415,8 @@ Implementation: `try_evict_gpu_memory_impl()` in store_engine.cc. CPU VS memory 
 - Variant replica registration still publishes canonical residency to Global Store. The engine issues a best-effort `record_variant_residency` call so the daemon can start wiring the future RPC; until Global Store implements it the call returns `UNIMPLEMENTED` and is logged at `VLOG(1)`.
 
 For broader architectural context, see docs/architecture.md and docs/state-management.md.
-- Note on verification: canonical replicas reuse `verification.json`. Variant views persist per-view metadata under `verification.view_<sanitized_view_id>.json`; each record carries the `byte_space_id` so canonical metadata is never reused for a variant. When the P2P source provides `verification_json` (e.g., via a sender daemon’s `LockTransportChunks`), `StoreEngine::ingest_from_p2p_internal()` parses it and performs fast KEY_POINTS verification of the loaded replica (CPU/GPU). Verification failure returns a DataLoss error and aborts materialization.
+- Verification metadata: canonical replicas reuse `verification.json`. Variant views persist per-view metadata under `verification.view_<sanitized_view_id>.json`; each record carries the `byte_space_id` so canonical metadata is never reused for a variant. Every persisted payload now embeds a `metadata_signature` (canonical SHA-256 of the serialized payload). The loader re-reads the on-disk JSON on every materialization, validates the signature, and compares the payload fingerprint against any cached entry before reuse. Tampered or truncated files trigger `DataLoss` (cache is invalidated) and force regeneration, while cached entries are only reused when the file is absent and a fresh persistence will rewrite it. P2P senders may still provide inline `verification_json`; `StoreEngine::ingest_from_p2p_internal()` parses it and performs fast KEY_POINTS verification of the loaded replica (CPU/GPU). Verification failure returns a `DataLoss` error and aborts materialization. All metadata reads/writes are serialized through `VerificationMetadataGuard`, persisted via an atomic write helper (`open` → `write` → `fsync` → `rename` + directory `fsync`), and accompanied by structured `verification_metadata_write_{succeeded,failed}` logs that surface artifact, byte-space, guard wait, and write durations.
+- Debug visibility: enabling `--v=1` (or higher) now emits the key-point triplet and artifact size whenever verification metadata is regenerated or reused. These logs include the active CUDA device id so stale metadata vs. stale GPU residency issues can be distinguished quickly when diagnosing DataLoss failures.
 ## Granularity Terminology and Invariants
 
 - Artifact layout chunk: `artifact_chunk_bytes` (VS/UMA)

--- a/core/store/README.md
+++ b/core/store/README.md
@@ -260,7 +260,7 @@ stateDiagram-v2
 ### Async Copy Manager Integration
 
 - H2D/D2H transfers submit via `AsyncCopyManager` (ACM), which wraps `cudaMemcpyAsync` with traced host callbacks and forwards completions onto a dedicated CPU worker to avoid making CUDA Runtime calls inside `cudaLaunchHostFunc`.
-- StreamingPinnedBuffer slots stay owned by the pump consumer until ACM completion; the completion callback is the only place that returns slots, preventing early reuse while the GPU DMA is still active. Callers that need post-callback state (e.g., VS writes) must also block on the callback’s completion signal before reporting success.
+- StreamingPinnedBuffer slots remain owned by the pump consumer. ACM callbacks now only publish their completion status (and may request a `BufferPool::shutdown()` on failure); the consumer thread waits for that status and then returns the slot. Callbacks must not mutate `PumpState` or hand the slot back directly.
 - Use `StreamingChunkGuard` (from `core/common/memory/streaming_chunk_guard.h`) when staging chunks for AsyncCopyManager. The guard acquires slots, promotes them to consumer ownership, and guarantees cleanup if submission fails, so callers cannot forget the `promote_producer_slot_to_consumer` transition.
 - For H2D, UMA state should advance from the completion callback (if the caller needs it) using the `absl::Status` argument as proof of success; per-chunk `stream_synchronize` remains unnecessary.
 - ACM owns per-device non-blocking streams per direction (H2D/D2H/D2D) and routes all copies through them; external stream injection has been removed.

--- a/core/store/components/eviction_service.cc
+++ b/core/store/components/eviction_service.cc
@@ -1,0 +1,100 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/store/components/eviction_service.h"
+
+#include "absl/functional/function_ref.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "core/common/memory/memory_location.h"
+#include "core/common/memory/pinned_buffer_pool.h"
+#include "core/store/components/device_manager.h"
+#include "core/store/components/metrics_collector.h"
+#include "core/store/components/replica_registry.h"
+#include "core/store/device_types.h"
+
+namespace tensorcast::store::components {
+
+namespace detail {
+
+absl::Status evict_core(
+    absl::FunctionRef<std::vector<loading::ReplicaKey>()> get_candidates,
+    absl::FunctionRef<absl::Status(const loading::ReplicaKey&)> try_release,
+    absl::FunctionRef<void()> record_eviction,
+    absl::FunctionRef<bool()> has_freed_enough,
+    absl::FunctionRef<void(const loading::ReplicaKey&)> on_evicted) {
+  auto candidates = get_candidates();
+  for (const auto& key : candidates) {
+    if (!try_release(key).ok()) {
+      continue;
+    }
+    record_eviction();
+    on_evicted(key);
+    if (has_freed_enough()) {
+      return absl::OkStatus();
+    }
+  }
+  return absl::ResourceExhaustedError("Could not free enough memory");
+}
+
+} // namespace detail
+
+absl::Status evict_for_gpu(
+    ReplicaRegistry& registry,
+    DeviceManager& device_manager,
+    MetricsCollector& metrics,
+    int device_id,
+    size_t required_bytes) {
+  auto free_before_or = device_manager.get_free_memory(device_id);
+  if (!free_before_or.ok()) {
+    return free_before_or.status();
+  }
+  const size_t free_before = free_before_or.value();
+
+  return detail::evict_core(
+      [&] { return registry.get_lru_instances(); },
+      [&](const loading::ReplicaKey& key) -> absl::Status {
+        if (key.device.type != DeviceType::GPU || key.device.ordinal != device_id) {
+          return absl::FailedPreconditionError("not target device");
+        }
+        auto replica_or = registry.find(key);
+        if (!replica_or.ok()) {
+          return replica_or.status();
+        }
+        const auto& replica = replica_or.value();
+        if (replica->get_memory_state(common::memory::MemoryLocation::GPU) != replica::MemoryState::LOADED) {
+          return absl::FailedPreconditionError("not loaded");
+        }
+        return replica->release_memory(common::memory::MemoryLocation::GPU);
+      },
+      [&] { metrics.record_memory_eviction(); },
+      [&] {
+        auto free_now_or = device_manager.get_free_memory(device_id);
+        return free_now_or.ok() && (free_now_or.value() - free_before) >= required_bytes;
+      },
+      [](const loading::ReplicaKey&) {});
+}
+
+absl::Status evict_for_cpu(
+    ReplicaRegistry& registry,
+    tensorcast::common::memory::PinnedBufferPool& memory_pool,
+    MetricsCollector& metrics,
+    size_t required_pinned_pool_bytes) {
+  return detail::evict_core(
+      [&] { return registry.get_lru_instances(); },
+      [&](const loading::ReplicaKey& key) -> absl::Status {
+        auto replica_or = registry.find(key);
+        if (!replica_or.ok()) {
+          return replica_or.status();
+        }
+        return replica_or.value()->release_memory(common::memory::MemoryLocation::CPU);
+      },
+      [&] { metrics.record_memory_eviction(); },
+      [&] { return memory_pool.get_available_size() >= required_pinned_pool_bytes; },
+      [&](const loading::ReplicaKey& key) {
+        LOG(INFO) << "Evicted replica " << key.artifact_id
+                  << " (device=" << (key.device.type == DeviceType::CPU ? "CPU" : "GPU") << ":" << key.device.ordinal
+                  << ") from CPU memory";
+      });
+}
+
+} // namespace tensorcast::store::components

--- a/core/store/components/eviction_service.h
+++ b/core/store/components/eviction_service.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
+#include "core/store/loading/loading_spec.h"
+
+namespace tensorcast::common::memory {
+class PinnedBufferPool;
+} // namespace tensorcast::common::memory
+
+namespace tensorcast::store::components {
+
+class DeviceManager;
+class MetricsCollector;
+class ReplicaRegistry;
+
+absl::Status evict_for_gpu(
+    ReplicaRegistry& registry,
+    DeviceManager& device_manager,
+    MetricsCollector& metrics,
+    int device_id,
+    size_t required_bytes);
+
+absl::Status evict_for_cpu(
+    ReplicaRegistry& registry,
+    tensorcast::common::memory::PinnedBufferPool& memory_pool,
+    MetricsCollector& metrics,
+    size_t required_pinned_pool_bytes);
+
+namespace detail {
+
+absl::Status evict_core(
+    absl::FunctionRef<std::vector<loading::ReplicaKey>()> get_candidates,
+    absl::FunctionRef<absl::Status(const loading::ReplicaKey&)> try_release,
+    absl::FunctionRef<void()> record_eviction,
+    absl::FunctionRef<bool()> has_freed_enough,
+    absl::FunctionRef<void(const loading::ReplicaKey&)> on_evicted = [](const loading::ReplicaKey&) {});
+
+} // namespace detail
+
+} // namespace tensorcast::store::components

--- a/core/store/components/eviction_service_test.cc
+++ b/core/store/components/eviction_service_test.cc
@@ -1,0 +1,246 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/store/components/eviction_service.h"
+
+#include <memory>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
+#include "core/store/loading/loading_spec.h"
+#include "core/store/replica/memory_state.h"
+
+using tensorcast::DeviceType;
+using tensorcast::store::DeviceKey;
+using tensorcast::store::components::detail::evict_core;
+using tensorcast::store::loading::ReplicaKey;
+using tensorcast::store::loading::ReplicaKeyHash;
+
+namespace {
+
+struct FakeDeviceManager {
+  absl::StatusOr<size_t> get_free_memory(int /*device_id*/) const {
+    return free_bytes;
+  }
+
+  void increase_free(size_t delta) {
+    free_bytes += delta;
+  }
+
+  size_t free_bytes{0};
+};
+
+struct FakeMemoryPool {
+  size_t get_available_size() const {
+    return available;
+  }
+
+  void increase(size_t delta) {
+    available += delta;
+  }
+
+  size_t available{0};
+};
+
+struct FakeMetricsCollector {
+  void record_memory_eviction() {
+    ++eviction_count;
+  }
+
+  int eviction_count{0};
+};
+
+struct FakeReplica {
+  absl::Status release_memory(tensorcast::common::memory::MemoryLocation location) {
+    switch (location) {
+      case tensorcast::common::memory::MemoryLocation::GPU:
+        if (!gpu_loaded) {
+          return absl::FailedPreconditionError("GPU not loaded");
+        }
+        gpu_loaded = false;
+        if (device_manager != nullptr) {
+          device_manager->increase_free(gpu_bytes);
+        }
+        return absl::OkStatus();
+      case tensorcast::common::memory::MemoryLocation::CPU:
+        if (!cpu_loaded) {
+          return absl::FailedPreconditionError("CPU not loaded");
+        }
+        cpu_loaded = false;
+        if (memory_pool != nullptr) {
+          memory_pool->increase(cpu_bytes);
+        }
+        return absl::OkStatus();
+      default:
+        return absl::InvalidArgumentError("unsupported location");
+    }
+  }
+
+  tensorcast::store::replica::MemoryState get_memory_state(tensorcast::common::memory::MemoryLocation location) const {
+    switch (location) {
+      case tensorcast::common::memory::MemoryLocation::GPU:
+        return gpu_loaded ? tensorcast::store::replica::MemoryState::LOADED
+                          : tensorcast::store::replica::MemoryState::UNALLOCATED;
+      case tensorcast::common::memory::MemoryLocation::CPU:
+        return cpu_loaded ? tensorcast::store::replica::MemoryState::LOADED
+                          : tensorcast::store::replica::MemoryState::UNALLOCATED;
+      default:
+        return tensorcast::store::replica::MemoryState::UNALLOCATED;
+    }
+  }
+
+  bool gpu_loaded{false};
+  bool cpu_loaded{false};
+  size_t gpu_bytes{0};
+  size_t cpu_bytes{0};
+  FakeDeviceManager* device_manager{nullptr};
+  FakeMemoryPool* memory_pool{nullptr};
+};
+
+struct FakeRegistry {
+  std::vector<ReplicaKey> get_lru_instances() const {
+    return order;
+  }
+
+  absl::StatusOr<std::shared_ptr<FakeReplica>> find(const ReplicaKey& key) const {
+    auto it = entries.find(key);
+    if (it == entries.end()) {
+      return absl::NotFoundError("not found");
+    }
+    return it->second;
+  }
+
+  std::vector<ReplicaKey> order;
+  absl::flat_hash_map<ReplicaKey, std::shared_ptr<FakeReplica>, ReplicaKeyHash> entries;
+};
+
+ReplicaKey make_gpu_key(int device_id) {
+  DeviceKey device{.type = DeviceType::GPU, .ordinal = device_id, .uuid = ""};
+  return ReplicaKey{.artifact_id = "artifact", .view_id = std::nullopt, .device = device, .replica = 0};
+}
+
+ReplicaKey make_cpu_key() {
+  DeviceKey device{.type = DeviceType::CPU, .ordinal = -1, .uuid = ""};
+  return ReplicaKey{.artifact_id = "artifact_cpu", .view_id = std::nullopt, .device = device, .replica = 0};
+}
+
+} // namespace
+
+TEST_CASE("EvictionService GPU path frees memory and records metrics", "[eviction][gpu]") {
+  FakeDeviceManager device_manager;
+  device_manager.free_bytes = 128;
+
+  FakeMetricsCollector metrics;
+  FakeRegistry registry;
+
+  ReplicaKey key = make_gpu_key(0);
+  auto replica = std::make_shared<FakeReplica>();
+  replica->gpu_loaded = true;
+  replica->gpu_bytes = 256;
+  replica->device_manager = &device_manager;
+
+  registry.entries.insert({key, replica});
+  registry.order.push_back(key);
+
+  const size_t required = 200;
+  const size_t free_before = device_manager.free_bytes;
+  auto status = evict_core(
+      [&] { return registry.get_lru_instances(); },
+      [&](const ReplicaKey& k) -> absl::Status {
+        if (k.device.type != DeviceType::GPU || k.device.ordinal != 0) {
+          return absl::FailedPreconditionError("not target device");
+        }
+        auto r = registry.find(k);
+        if (!r.ok())
+          return r.status();
+        if (r.value()->get_memory_state(tensorcast::common::memory::MemoryLocation::GPU) !=
+            tensorcast::store::replica::MemoryState::LOADED) {
+          return absl::FailedPreconditionError("not loaded");
+        }
+        return r.value()->release_memory(tensorcast::common::memory::MemoryLocation::GPU);
+      },
+      [&] { metrics.record_memory_eviction(); },
+      [&] { return (device_manager.free_bytes - free_before) >= required; },
+      [](const ReplicaKey&) {});
+  CHECK(status.ok());
+  CHECK_FALSE(replica->gpu_loaded);
+  CHECK(device_manager.free_bytes == 384);
+  CHECK(metrics.eviction_count == 1);
+}
+
+TEST_CASE("EvictionService GPU path returns resource exhausted when insufficient memory", "[eviction][gpu]") {
+  FakeDeviceManager device_manager;
+  device_manager.free_bytes = 64;
+
+  FakeMetricsCollector metrics;
+  FakeRegistry registry;
+
+  ReplicaKey key = make_gpu_key(1);
+  auto replica = std::make_shared<FakeReplica>();
+  replica->gpu_loaded = true;
+  replica->gpu_bytes = 32;
+  replica->device_manager = &device_manager;
+
+  registry.entries.insert({key, replica});
+  registry.order.push_back(key);
+
+  const size_t required = 256;
+  const size_t free_before = device_manager.free_bytes;
+  auto status = evict_core(
+      [&] { return registry.get_lru_instances(); },
+      [&](const ReplicaKey& k) -> absl::Status {
+        if (k.device.type != DeviceType::GPU || k.device.ordinal != 1) {
+          return absl::FailedPreconditionError("not target device");
+        }
+        auto r = registry.find(k);
+        if (!r.ok())
+          return r.status();
+        if (r.value()->get_memory_state(tensorcast::common::memory::MemoryLocation::GPU) !=
+            tensorcast::store::replica::MemoryState::LOADED) {
+          return absl::FailedPreconditionError("not loaded");
+        }
+        return r.value()->release_memory(tensorcast::common::memory::MemoryLocation::GPU);
+      },
+      [&] { metrics.record_memory_eviction(); },
+      [&] { return (device_manager.free_bytes - free_before) >= required; },
+      [](const ReplicaKey&) {});
+  CHECK_FALSE(status.ok());
+  CHECK(status.code() == absl::StatusCode::kResourceExhausted);
+  CHECK_FALSE(replica->gpu_loaded);
+  CHECK(metrics.eviction_count == 1);
+}
+
+TEST_CASE("EvictionService CPU path frees memory and triggers callback", "[eviction][cpu]") {
+  FakeMemoryPool pool;
+  FakeMetricsCollector metrics;
+  FakeRegistry registry;
+
+  ReplicaKey key = make_cpu_key();
+  auto replica = std::make_shared<FakeReplica>();
+  replica->cpu_loaded = true;
+  replica->cpu_bytes = 512;
+  replica->memory_pool = &pool;
+
+  registry.entries.insert({key, replica});
+  registry.order.push_back(key);
+
+  bool callback_invoked = false;
+  auto status = evict_core(
+      [&] { return registry.get_lru_instances(); },
+      [&](const ReplicaKey& k) -> absl::Status {
+        auto r = registry.find(k);
+        if (!r.ok())
+          return r.status();
+        return r.value()->release_memory(tensorcast::common::memory::MemoryLocation::CPU);
+      },
+      [&] { metrics.record_memory_eviction(); },
+      [&] { return pool.get_available_size() >= 256; },
+      [&](const ReplicaKey& evicted_key) { callback_invoked = (evicted_key.artifact_id == key.artifact_id); });
+
+  CHECK(status.ok());
+  CHECK_FALSE(replica->cpu_loaded);
+  CHECK(pool.available == 512);
+  CHECK(metrics.eviction_count == 1);
+  CHECK(callback_invoked);
+}

--- a/core/store/docs/architecture.md
+++ b/core/store/docs/architecture.md
@@ -215,7 +215,7 @@ classDiagram
 2. Create `FilePartitionSource` implementing `SeekableSource` — `core/store/loader/file_partition_source.{h,cc}`
 3. Return source handle for pump-based streaming — `DiskLoader::open_source()`
 4. Actual loading handled by `ReplicaLoadController::load_async_from_source()` using `TransferService` + `pump_ranges()`
-5. Data flows: FilePartitionSource → Pump → MemorySink (`CpuVaSink` for CPU or `GpuMemorySink` for GPU). For GPU targets, the pump detects sinks that implement `AsyncPositionedSink` and uses `AsyncCopyManager` to submit H2D copies; pinned slots are returned only after GPU DMA completion, and the pump waits on any remaining in-flight copies before exiting, ensuring the GPU buffer is fully materialized prior to verification.
+5. Data flows: FilePartitionSource → Pump → MemorySink (`CpuVaSink` for CPU or `GpuMemorySink` for GPU). For GPU targets, the pump detects sinks that implement `AsyncPositionedSink` and uses `AsyncCopyManager` to submit H2D copies. `TransferService` replays `AsyncCopyManager::synchronize_h2d_stream()` followed by `cuda::device_synchronize()` before returning to ensure the GPU buffer is fully materialised prior to verification and metadata persistence.
 
 **P2PLoader Workflow**:
 1. Validate `P2PSource` configuration (IP, port, memory keys) — `core/store/loader/p2p_loader.{h,cc}`
@@ -652,6 +652,7 @@ The system is designed with multiple extension points to support future requirem
 - **MemoryExportRegistry**: Handles P2P memory registration/export — `core/store/replica/memory_export_registry.h`
 - **MaterializeOrchestrator**: Coordinates the materialize_replica() API workflow — `core/store/loading/materialize_orchestrator.{h,cc}`
 - **MetricsCollector**: Tracks performance and resource usage — `core/store/components/metrics_collector.{h,cc}`
+- **Verification Metadata Coordination**: `core/store/loader/verification_utils.{h,cc}` provides the per-artifact `VerificationMetadataGuard`, in-process metadata cache, atomic write helper (`open` → `write` → `fsync` → `rename` + directory sync), and structured logging hooks (`verification_metadata_write_{succeeded,failed}`). `core/store/replica/transfer_service.cc` synchronises the per-device H2D stream via `AsyncCopyManager::synchronize_h2d_stream()` followed by `cuda::device_synchronize()` so verification always runs on fully materialised GPU buffers. Regression coverage lives in `core/store/loader:verification_utils_test` and `core/store:multi_gpu_verification_race_test`.
 
 ## Related Guides
 

--- a/core/store/loader/BUILD
+++ b/core/store/loader/BUILD
@@ -103,6 +103,20 @@ sc_cc_library(
 )
 
 sc_cc_library(
+    name = "index_reader",
+    srcs = ["index_reader.cc"],
+    hdrs = ["index_reader.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":canonical_index",
+        ":safetensors_util",
+        "//core/common:artifact_hash_lib",
+        "@abseil-cpp//absl/strings",
+        "@nlohmann_json//:json",
+    ],
+)
+
+sc_cc_library(
     name = "safetensors_source",
     srcs = ["safetensors_source.cc"],
     hdrs = ["safetensors_source.h"],
@@ -165,6 +179,25 @@ sc_cc_library(
         "//core/common:cuda_api_lib",
         "@abseil-cpp//absl/types:span",
         "@gsl",
+    ],
+)
+
+sc_cc_library(
+    name = "verification_utils",
+    srcs = ["verification_utils.cc"],
+    hdrs = ["verification_utils.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":safetensors_util",
+        ":source_hash",
+        "//core/common:artifact_hash_lib",
+        "//core/common:artifact_verification_lib",
+        "//core/common:cuda_api_lib",
+        "//core/common:memory_location_lib",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/types:span",
+        "@gsl",
+        "@nlohmann_json//:json",
     ],
 )
 
@@ -460,6 +493,34 @@ cc_test(
 )
 
 cc_test(
+    name = "index_reader_test",
+    srcs = ["index_reader_test.cc"],
+    deps = [
+        ":index_reader",
+        "//core/testing:catch_main",
+        "@catch2//:catch2_main",
+        "@nlohmann_json//:json",
+    ],
+)
+
+cc_test(
+    name = "verification_utils_test",
+    srcs = ["verification_utils_test.cc"],
+    deps = [
+        ":source_hash",
+        ":verification_utils",
+        "//core/common:artifact_hash_lib",
+        "//core/common:artifact_verification_lib",
+        "//core/common:cuda_api_lib",
+        "//core/testing:catch_main",
+        "//core/testing:common",
+        "@catch2//:catch2_main",
+        "@gsl",
+        "@nlohmann_json//:json",
+    ],
+)
+
+cc_test(
     name = "disk_loader_safetensors_test",
     srcs = ["disk_loader_safetensors_test.cc"],
     deps = [
@@ -640,13 +701,19 @@ cc_test(
     ],
     deps = [
         ":buffer_pool",
+        ":gpu_memory_sink",
         ":pump",
         ":sink",
         ":source",
+        ":streaming_buffer_adapter",
         "//core/common:async_copy_manager_lib",
+        "//core/common:cuda_api_lib",
+        "//core/common:pinned_buffer_pool_lib",
+        "//core/common:streaming_pinned_buffer_lib",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/types:span",
         "@catch2//:catch2_main",
+        "@gsl",
     ],
 )
 

--- a/core/store/loader/artifact_verifier_direct_test.cc
+++ b/core/store/loader/artifact_verifier_direct_test.cc
@@ -80,6 +80,7 @@ TEST_CASE("ArtifactVerifier Direct Testing", "[verification][direct]") {
     REQUIRE(!invalid.ok());
     REQUIRE_THAT(invalid.status().ToString(), ContainsSubstring("parse error"));
     auto incomplete = ArtifactVerificationInfo::from_json("{\"artifact_size\": 123}");
-    REQUIRE(incomplete.ok());
+    REQUIRE(!incomplete.ok());
+    CHECK(incomplete.status().code() == absl::StatusCode::kFailedPrecondition);
   }
 }

--- a/core/store/loader/index_reader.cc
+++ b/core/store/loader/index_reader.cc
@@ -1,0 +1,185 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/store/loader/index_reader.h"
+
+#include <algorithm>
+#include <fstream>
+#include <system_error>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "core/common/artifact_hash.h"
+#include "core/store/loader/canonical_index.h"
+#include "core/store/loader/safetensors_util.h"
+#include "nlohmann/json.hpp"
+
+namespace tensorcast::store::loader {
+namespace {
+
+uint64_t compute_total_size_bytes(const std::string& canonical_index_json) {
+  if (canonical_index_json.empty()) {
+    return 0;
+  }
+  try {
+    const nlohmann::json idx = nlohmann::json::parse(canonical_index_json, nullptr, true);
+    uint64_t total_size = 0;
+    for (auto it = idx.begin(); it != idx.end(); ++it) {
+      const auto& arr = it.value();
+      if (!arr.is_array() || arr.size() < 2) {
+        continue;
+      }
+      const uint64_t offset = arr[0].get<uint64_t>();
+      const uint64_t size = arr[1].get<uint64_t>();
+      total_size = std::max<uint64_t>(total_size, offset + size);
+    }
+    return total_size;
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Failed to parse canonical index JSON for total_size: " << e.what();
+    return 0;
+  }
+}
+
+absl::StatusOr<std::string> load_tensor_index_json(const std::filesystem::path& tensor_index_path) {
+  std::ifstream f(tensor_index_path);
+  if (!f.is_open()) {
+    return absl::NotFoundError(absl::StrCat("tensor_index.json not found at ", tensor_index_path.string()));
+  }
+  try {
+    nlohmann::json j;
+    f >> j;
+    return j.dump();
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Failed to read/parse tensor_index.json: " << e.what();
+    return absl::InternalError("Failed to parse tensor_index.json");
+  }
+}
+
+IndexInfo make_index_info(
+    std::string canonical_json,
+    bool is_safetensors,
+    std::optional<std::string_view> existing_index_multihash) {
+  IndexInfo info;
+  info.is_safetensors = is_safetensors;
+  info.total_size_bytes = compute_total_size_bytes(canonical_json);
+  info.canonical_index_json = std::move(canonical_json);
+  if (existing_index_multihash.has_value() && !existing_index_multihash->empty()) {
+    info.index_multihash = std::string(*existing_index_multihash);
+  } else {
+    auto index_mh_or = common::compute_index_multihash(
+        std::optional<std::string>(info.canonical_index_json), /*canonical_index_key=*/"");
+    if (!index_mh_or.ok()) {
+      LOG(WARNING) << "Index multihash computation failed: " << index_mh_or.status();
+      info.index_multihash.clear();
+    } else {
+      info.index_multihash = std::move(index_mh_or).value();
+    }
+  }
+  return info;
+}
+
+bool contains_safetensors(const std::filesystem::path& artifact_path) {
+  std::error_code ec;
+  for (const auto& entry : std::filesystem::directory_iterator(artifact_path, ec)) {
+    if (ec) {
+      LOG(WARNING) << "Failed to enumerate artifact directory '" << artifact_path.string() << "': " << ec.message();
+      return false;
+    }
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    const std::string name = entry.path().filename().string();
+    if (absl::EndsWith(name, ".safetensors")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<std::filesystem::path> collect_safetensors(const std::filesystem::path& artifact_path) {
+  std::vector<std::filesystem::path> files;
+  std::error_code ec;
+  for (const auto& entry : std::filesystem::directory_iterator(artifact_path, ec)) {
+    if (ec) {
+      LOG(WARNING) << "Failed to enumerate artifact directory '" << artifact_path.string() << "': " << ec.message();
+      break;
+    }
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    const std::string name = entry.path().filename().string();
+    if (absl::EndsWith(name, ".safetensors")) {
+      files.push_back(entry.path());
+    }
+  }
+  return files;
+}
+
+} // namespace
+
+absl::StatusOr<IndexInfo> canonicalize_from_raw_json(std::string raw_json, int target_device_id) {
+  if (raw_json.empty()) {
+    return absl::NotFoundError("canonical index JSON is empty");
+  }
+  auto rebuilt_or = loader::rebuild_stable_canonical_index(raw_json, target_device_id);
+  if (!rebuilt_or.ok()) {
+    return rebuilt_or.status();
+  }
+  return make_index_info(std::move(rebuilt_or).value(), /*is_safetensors=*/false, std::nullopt);
+}
+
+absl::StatusOr<IndexInfo> build_from_safetensors(
+    const std::vector<std::filesystem::path>& safetensor_files,
+    std::optional<std::string_view> existing_index_multihash) {
+  if (safetensor_files.empty()) {
+    return absl::NotFoundError("No safetensors files provided");
+  }
+  auto index_bytes_or = loader::BuildCanonicalIndexFromSafetensors(safetensor_files);
+  if (!index_bytes_or.ok()) {
+    LOG(WARNING) << "Failed to build canonical index from safetensors: " << index_bytes_or.status();
+    return index_bytes_or.status();
+  }
+  return make_index_info(std::move(index_bytes_or).value(), /*is_safetensors=*/true, existing_index_multihash);
+}
+
+absl::StatusOr<IndexInfo> read_from_artifact_dir(const std::filesystem::path& artifact_path, int target_device_id) {
+  std::error_code ec;
+  const bool exists = std::filesystem::exists(artifact_path, ec);
+  if (ec) {
+    return absl::ErrnoToStatus(
+        ec.value(), absl::StrCat("Failed to access artifact directory '", artifact_path.string(), "'"));
+  }
+  if (!exists) {
+    return absl::NotFoundError(absl::StrCat("Artifact directory not found: ", artifact_path.string()));
+  }
+  const bool is_dir = std::filesystem::is_directory(artifact_path, ec);
+  if (ec) {
+    return absl::ErrnoToStatus(
+        ec.value(), absl::StrCat("Failed to stat artifact directory '", artifact_path.string(), "'"));
+  }
+  if (!is_dir) {
+    return absl::FailedPreconditionError(
+        absl::StrCat("Expected artifact path to be a directory: ", artifact_path.string()));
+  }
+
+  if (contains_safetensors(artifact_path)) {
+    auto files = collect_safetensors(artifact_path);
+    return build_from_safetensors(files, std::nullopt);
+  }
+
+  const auto index_json_path = artifact_path / "tensor_index.json";
+  if (!std::filesystem::exists(index_json_path)) {
+    return absl::NotFoundError(
+        absl::StrCat("tensor_index.json not found in artifact directory: ", artifact_path.string()));
+  }
+
+  auto raw_or = load_tensor_index_json(index_json_path);
+  if (!raw_or.ok()) {
+    return raw_or.status();
+  }
+  return canonicalize_from_raw_json(std::move(raw_or).value(), target_device_id);
+}
+
+} // namespace tensorcast::store::loader

--- a/core/store/loader/index_reader.h
+++ b/core/store/loader/index_reader.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/status/statusor.h"
+
+namespace tensorcast::store::loader {
+
+struct IndexInfo {
+  std::string canonical_index_json;
+  std::string index_multihash;
+  uint64_t total_size_bytes{0};
+  bool is_safetensors{false};
+};
+
+absl::StatusOr<IndexInfo> read_from_artifact_dir(const std::filesystem::path& artifact_path, int target_device_id);
+
+absl::StatusOr<IndexInfo> canonicalize_from_raw_json(std::string raw_json, int target_device_id);
+
+absl::StatusOr<IndexInfo> build_from_safetensors(
+    const std::vector<std::filesystem::path>& safetensor_files,
+    std::optional<std::string_view> existing_index_multihash = std::nullopt);
+
+} // namespace tensorcast::store::loader

--- a/core/store/loader/index_reader_test.cc
+++ b/core/store/loader/index_reader_test.cc
@@ -1,0 +1,122 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/store/loader/index_reader.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <nlohmann/json.hpp>
+
+namespace fs = std::filesystem;
+using tensorcast::store::loader::build_from_safetensors;
+using tensorcast::store::loader::canonicalize_from_raw_json;
+using tensorcast::store::loader::IndexInfo;
+using tensorcast::store::loader::read_from_artifact_dir;
+
+namespace {
+
+fs::path make_temp_dir(const std::string& prefix) {
+  fs::path base = fs::temp_directory_path() / prefix;
+  fs::create_directories(base);
+  return base;
+}
+
+void write_text(const fs::path& path, const std::string& content) {
+  std::ofstream out(path, std::ios::trunc);
+  REQUIRE(out.is_open());
+  out << content;
+}
+
+std::string canonical_index_sample() {
+  // tensorB precedes tensorA in raw form to test ordering logic.
+  return R"({
+    "tensorB": [16, 8, [2], [1], "torch.float32", 0],
+    "tensorA": [0, 16, [4], [1], "torch.float32", 0]
+  })";
+}
+
+// Helper to write a simple safetensors file with header-only (no payload required for index building).
+void create_safetensors_file(const fs::path& path, const std::string& tensor_name, uint64_t size_bytes) {
+  // Basic safetensors layout: [header_size (u64 little-endian)][header_json][payload...]
+  const std::string header_json =
+      nlohmann::json({{tensor_name, {{"dtype", "U8"}, {"shape", {size_bytes}}, {"data_offsets", {0, size_bytes}}}}})
+          .dump();
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  REQUIRE(out.is_open());
+  uint64_t header_size = header_json.size();
+  for (int i = 0; i < 8; ++i) {
+    unsigned char byte = static_cast<unsigned char>((header_size >> (8 * i)) & 0xFF);
+    out.put(static_cast<char>(byte));
+  }
+  out.write(header_json.data(), static_cast<std::streamsize>(header_json.size()));
+  std::vector<char> payload(static_cast<size_t>(size_bytes), '\0');
+  if (!payload.empty()) {
+    out.write(payload.data(), static_cast<std::streamsize>(payload.size()));
+  }
+}
+
+} // namespace
+
+TEST_CASE("IndexReader loads canonical index from tensor_index.json", "[index_reader]") {
+  fs::path dir = make_temp_dir("index_reader_json");
+  write_text(dir / "tensor_index.json", canonical_index_sample());
+
+  auto info_or = read_from_artifact_dir(dir, /*target_device_id=*/0);
+  REQUIRE(info_or.ok());
+  const IndexInfo& info = info_or.value();
+
+  CHECK_FALSE(info.canonical_index_json.empty());
+  CHECK(info.total_size_bytes == 24);
+  CHECK_FALSE(info.index_multihash.empty());
+  CHECK_FALSE(info.is_safetensors);
+
+  nlohmann::json parsed = nlohmann::json::parse(info.canonical_index_json);
+  std::vector<std::string> keys;
+  for (auto it = parsed.begin(); it != parsed.end(); ++it) {
+    keys.push_back(it.key());
+  }
+  REQUIRE(keys.size() == 2);
+  CHECK(keys[0] == "tensorA");
+  CHECK(keys[1] == "tensorB");
+
+  fs::remove_all(dir);
+}
+
+TEST_CASE("IndexReader rebuilds canonical JSON ordering from raw bytes", "[index_reader]") {
+  const std::string raw = canonical_index_sample();
+  auto info_or = canonicalize_from_raw_json(raw, /*target_device_id=*/0);
+  REQUIRE(info_or.ok());
+  const IndexInfo& info = info_or.value();
+  CHECK(info.total_size_bytes == 24);
+  // canonicalize_from_raw_json marks safetensors false
+  CHECK_FALSE(info.is_safetensors);
+  nlohmann::json parsed = nlohmann::json::parse(info.canonical_index_json);
+  auto it = parsed.begin();
+  REQUIRE(it != parsed.end());
+  CHECK(it.key() == "tensorA");
+}
+
+TEST_CASE("IndexReader builds canonical index from safetensors files", "[index_reader][safetensors]") {
+  fs::path dir = make_temp_dir("index_reader_st");
+  create_safetensors_file(dir / "part0.safetensors", "weights", /*size_bytes=*/32);
+  create_safetensors_file(dir / "part1.safetensors", "bias", /*size_bytes=*/16);
+
+  auto info_or = read_from_artifact_dir(dir, /*target_device_id=*/0);
+  REQUIRE(info_or.ok());
+  const IndexInfo& info = info_or.value();
+  CHECK(info.is_safetensors);
+  CHECK(info.total_size_bytes == 48);
+  CHECK_FALSE(info.canonical_index_json.empty());
+
+  // Ensure build_from_safetensors works when invoked directly.
+  std::vector<fs::path> files{dir / "part0.safetensors", dir / "part1.safetensors"};
+  auto st_info_or = build_from_safetensors(files, std::nullopt);
+  REQUIRE(st_info_or.ok());
+  CHECK(st_info_or->is_safetensors);
+  CHECK(st_info_or->total_size_bytes == 48);
+
+  fs::remove_all(dir);
+}

--- a/core/store/loader/pump.cc
+++ b/core/store/loader/pump.cc
@@ -9,17 +9,17 @@
 #include <unordered_map>
 #include <vector>
 
+#include "absl/base/thread_annotations.h"
 #include "absl/cleanup/cleanup.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
-#include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "core/common/async_copy_manager.h"
-// Direct write grant handled via sink capability
+
 #include <cstdlib>
-// OpenTelemetry counters for copy failure tracking
+
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/metrics/meter.h"
 #include "opentelemetry/metrics/provider.h"
@@ -112,6 +112,31 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
       pool.return_chunk(slot_id);
     }
 
+    void record_status(const absl::Status& st) {
+      {
+        absl::MutexLock lock(&status_mutex);
+        callback_status = st;
+        has_status = true;
+      }
+      status_cv.SignalAll();
+    }
+
+    absl::Status await_final_status(const absl::Status& fallback) {
+      absl::MutexLock lock(&status_mutex);
+      while (!has_status) {
+        status_cv.Wait(&status_mutex);
+      }
+      has_status = false;
+      if (callback_status.ok()) {
+        return fallback;
+      }
+      return callback_status;
+    }
+
+    void request_pool_shutdown() {
+      pool.shutdown();
+    }
+
     BufferPool& pool;
     int slot_id;
     uint64_t global_chunk_id;
@@ -119,6 +144,10 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
     size_t bytes;
     SlotLease lease;
     std::atomic<bool> returned{false};
+    absl::Mutex status_mutex;
+    absl::CondVar status_cv;
+    absl::Status callback_status ABSL_GUARDED_BY(status_mutex) = absl::OkStatus();
+    bool has_status ABSL_GUARDED_BY(status_mutex) = false;
   };
 
   // Track in-flight async copies when destination supports async writes
@@ -133,7 +162,11 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
 
   std::vector<InFlight> inflight;
   auto* async = dynamic_cast<AsyncPositionedSink*>(&dst);
-  auto finalize_inflight = [&](InFlight& entry, const absl::Status& st) -> bool {
+  auto finalize_inflight = [&](InFlight& entry, const absl::Status& handle_status) -> bool {
+    absl::Status st = handle_status;
+    if (entry.slot_ctx) {
+      st = entry.slot_ctx->await_final_status(handle_status);
+    }
     const bool failed = !st.ok();
     if (failed) {
       {
@@ -217,19 +250,12 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
       const size_t chunk_bytes = chunk.bytes_in_chunk;
       write_opts.copy_options = copy_opts;
       auto slot_ctx = std::make_shared<AsyncSlot>(pool, slot_id, chunk_id, dest_offset, chunk_bytes);
-      write_opts.copy_options->callbacks.on_copy_done = [slot_ctx, state_ptr = &state](absl::Status st) {
+      write_opts.copy_options->callbacks.on_copy_done = [slot_ctx](absl::Status st) {
+        slot_ctx->record_status(st);
+        slot_ctx->return_if_needed();
         if (!st.ok()) {
           record_copy_failure_("gpu");
-          {
-            absl::MutexLock lock(&state_ptr->status_mutex);
-            if (state_ptr->consumer_status.ok()) {
-              state_ptr->consumer_status = st;
-            }
-          }
-          state_ptr->should_stop.store(true, std::memory_order_release);
-          state_ptr->drain_requested.store(true, std::memory_order_release);
-          slot_ctx->pool.shutdown();
-          slot_ctx->return_if_needed();
+          slot_ctx->request_pool_shutdown();
         }
         VLOG(2) << "pump_async_callback slot=" << slot_ctx->slot_id << " chunk_id=" << slot_ctx->global_chunk_id
                 << " dest_offset=" << slot_ctx->dest_offset << " bytes=" << slot_ctx->bytes << " status=" << st;
@@ -271,15 +297,16 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
       }
     }
 
-    // Sweep completed in-flight operations and return their slots.
-    // Drop completed handles whose wait() already succeeded via callback.
+    // Sweep in-flight operations: process any handle that is completed
+    // (success or failure). Skip only pending operations by probing with a
+    // zero-timeout wait.
     if (!inflight.empty()) {
       for (size_t i = 0; i < inflight.size();) {
-        if (!inflight[i].handle.ok()) {
-          ++i;
+        absl::Status st = inflight[i].handle.wait(absl::ZeroDuration());
+        if (absl::IsDeadlineExceeded(st)) {
+          ++i; // still pending
           continue;
         }
-        absl::Status st = inflight[i].handle.wait();
         finalize_inflight(inflight[i], st);
         inflight.erase(inflight.begin() + i);
       }

--- a/core/store/loader/pump.cc
+++ b/core/store/loader/pump.cc
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <limits>
+#include <memory>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -13,6 +14,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "core/common/async_copy_manager.h"
 // Direct write grant handled via sink capability
@@ -28,6 +30,7 @@ namespace {
 
 struct PumpState {
   std::atomic<bool> should_stop{false};
+  std::atomic<bool> drain_requested{false};
   std::atomic<uint64_t> next_chunk_id{0};
   absl::Status producer_status;
   absl::Status consumer_status;
@@ -88,8 +91,35 @@ class SlotLease {
 };
 
 void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
-  LOG(INFO) << "Consumer thread started";
+  VLOG(1) << "Consumer thread started";
   bool draining = false;
+
+  struct AsyncSlot {
+    AsyncSlot(BufferPool& pool_in, int slot_in, uint64_t chunk_in, uint64_t dest_in, size_t bytes_in)
+        : pool(pool_in),
+          slot_id(slot_in),
+          global_chunk_id(chunk_in),
+          dest_offset(dest_in),
+          bytes(bytes_in),
+          lease(pool_in, slot_in) {}
+
+    void return_if_needed() {
+      bool expected = false;
+      if (!returned.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        return;
+      }
+      lease.release();
+      pool.return_chunk(slot_id);
+    }
+
+    BufferPool& pool;
+    int slot_id;
+    uint64_t global_chunk_id;
+    uint64_t dest_offset;
+    size_t bytes;
+    SlotLease lease;
+    std::atomic<bool> returned{false};
+  };
 
   // Track in-flight async copies when destination supports async writes
   struct InFlight {
@@ -98,14 +128,14 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
     uint64_t global_chunk_id;
     uint64_t dest_offset;
     size_t bytes;
+    std::shared_ptr<AsyncSlot> slot_ctx;
   };
 
   std::vector<InFlight> inflight;
   auto* async = dynamic_cast<AsyncPositionedSink*>(&dst);
-  auto finalize_inflight = [&](InFlight& entry, const absl::Status& st) {
+  auto finalize_inflight = [&](InFlight& entry, const absl::Status& st) -> bool {
     const bool failed = !st.ok();
     if (failed) {
-      record_copy_failure_("gpu");
       {
         absl::MutexLock lock(&state.status_mutex);
         if (state.consumer_status.ok()) {
@@ -113,14 +143,16 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
         }
       }
       state.should_stop.store(true, std::memory_order_release);
-    }
-    pool.return_chunk(entry.slot_id);
-    if (failed) {
+      state.drain_requested.store(true, std::memory_order_release);
       pool.shutdown();
       draining = true;
     }
+    if (entry.slot_ctx) {
+      entry.slot_ctx->return_if_needed();
+    }
     VLOG(2) << "pump_async_completion slot=" << entry.slot_id << " chunk_id=" << entry.global_chunk_id
             << " dest_offset=" << entry.dest_offset << " bytes=" << entry.bytes << " status=" << st;
+    return true;
   };
   auto flush_inflight = [&]() {
     if (inflight.empty()) {
@@ -134,6 +166,9 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
   };
   absl::Cleanup flush_guard = [&]() { flush_inflight(); };
   while (!state.should_stop.load(std::memory_order_acquire) || draining) {
+    if (state.drain_requested.load(std::memory_order_acquire)) {
+      draining = true;
+    }
     auto chunk_result = pool.get_ready_chunk();
     if (!chunk_result.ok()) {
       if (absl::IsUnavailable(chunk_result.status())) {
@@ -181,6 +216,24 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
       const uint64_t chunk_id = chunk.global_chunk_id;
       const size_t chunk_bytes = chunk.bytes_in_chunk;
       write_opts.copy_options = copy_opts;
+      auto slot_ctx = std::make_shared<AsyncSlot>(pool, slot_id, chunk_id, dest_offset, chunk_bytes);
+      write_opts.copy_options->callbacks.on_copy_done = [slot_ctx, state_ptr = &state](absl::Status st) {
+        if (!st.ok()) {
+          record_copy_failure_("gpu");
+          {
+            absl::MutexLock lock(&state_ptr->status_mutex);
+            if (state_ptr->consumer_status.ok()) {
+              state_ptr->consumer_status = st;
+            }
+          }
+          state_ptr->should_stop.store(true, std::memory_order_release);
+          state_ptr->drain_requested.store(true, std::memory_order_release);
+          slot_ctx->pool.shutdown();
+          slot_ctx->return_if_needed();
+        }
+        VLOG(2) << "pump_async_callback slot=" << slot_ctx->slot_id << " chunk_id=" << slot_ctx->global_chunk_id
+                << " dest_offset=" << slot_ctx->dest_offset << " bytes=" << slot_ctx->bytes << " status=" << st;
+      };
       auto hdl_or = async->write_at_async(dest_offset, chunk.data_ptr, chunk.bytes_in_chunk, write_opts);
       if (!hdl_or.ok()) {
         record_copy_failure_("gpu");
@@ -189,7 +242,7 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
           state.consumer_status = hdl_or.status();
         }
         // Return the slot and request shutdown
-        pool.return_chunk(chunk.slot_id);
+        slot_ctx->return_if_needed();
         state.should_stop.store(true, std::memory_order_release);
         pool.shutdown();
         // Switch to drain mode to return remaining ready chunks
@@ -201,7 +254,8 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
                 .slot_id = chunk.slot_id,
                 .global_chunk_id = chunk.global_chunk_id,
                 .dest_offset = dest_offset,
-                .bytes = chunk.bytes_in_chunk});
+                .bytes = chunk.bytes_in_chunk,
+                .slot_ctx = std::move(slot_ctx)});
       }
     } else {
       auto status = dst.write_at(dest_offset, chunk.data_ptr, chunk.bytes_in_chunk);
@@ -221,11 +275,11 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
     // Drop completed handles whose wait() already succeeded via callback.
     if (!inflight.empty()) {
       for (size_t i = 0; i < inflight.size();) {
-        absl::Status st = inflight[i].handle.wait(absl::ZeroDuration());
-        if (absl::IsDeadlineExceeded(st)) {
+        if (!inflight[i].handle.ok()) {
           ++i;
           continue;
         }
+        absl::Status st = inflight[i].handle.wait();
         finalize_inflight(inflight[i], st);
         inflight.erase(inflight.begin() + i);
       }
@@ -237,6 +291,7 @@ void run_consumer(PositionedSink& dst, BufferPool& pool, PumpState& state) {
     absl::Status st = item.handle.wait();
     finalize_inflight(item, st);
   }
+  inflight.clear();
 }
 
 void run_range_producer(
@@ -358,18 +413,6 @@ void run_range_producer(
       }
 
       // Emit lightweight diagnostics for chunk payload (first/last 8 bytes).
-      if (bytes_read >= sizeof(uint64_t)) {
-        const uint64_t first_sample = *reinterpret_cast<const uint64_t*>(buffer);
-        const uint64_t last_sample =
-            *reinterpret_cast<const uint64_t*>(static_cast<const uint8_t*>(buffer) + bytes_read - sizeof(uint64_t));
-        LOG(INFO) << "pump_producer chunk_id=" << chunk_id << " offset=" << current_offset << " bytes=" << bytes_read
-                  << " first=0x" << absl::Hex(first_sample, absl::kZeroPad16) << " last=0x"
-                  << absl::Hex(last_sample, absl::kZeroPad16);
-      } else {
-        LOG(INFO) << "pump_producer chunk_id=" << chunk_id << " offset=" << current_offset << " bytes=" << bytes_read
-                  << " (<8 bytes payload)";
-      }
-
       current_offset += bytes_read;
       remaining -= bytes_read;
       // Transfer ownership to consumer; avoid returning the slot here

--- a/core/store/loader/pump_async_test.cc
+++ b/core/store/loader/pump_async_test.cc
@@ -252,6 +252,63 @@ class DelayedAsyncSink : public PositionedSink, public AsyncPositionedSink {
   std::atomic<int> callbacks_{0};
 };
 
+// Async sink that defers error notification until after a fixed delay. The pump
+// completes before the callback fires, reproducing the post-teardown failure.
+class PostPumpFailureSink : public PositionedSink, public AsyncPositionedSink {
+ public:
+  explicit PostPumpFailureSink(absl::Duration delay)
+      : delay_(delay),
+        fired_count_(std::make_shared<std::atomic<int>>(0)),
+        failure_status_(absl::InternalError("async callback failure (delayed)")) {}
+
+  absl::Status write_at(uint64_t, const void*, size_t) override {
+    return absl::UnimplementedError("PostPumpFailureSink expects async write");
+  }
+
+  absl::Status close() override {
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<tensorcast::common::CopyHandle> write_at_async(
+      uint64_t,
+      const void* src,
+      size_t bytes,
+      const AsyncWriteOptions& options = AsyncWriteOptions{}) override {
+    tensorcast::common::HostRegion hsrc{.base = src, .length = bytes, .pinned = true};
+    if (scratch_.size() < bytes) {
+      scratch_.resize(bytes);
+    }
+    tensorcast::common::HostRegion hdst{.base = scratch_.data(), .length = bytes, .pinned = true};
+    tensorcast::common::CopyOptions copy_opts = options.copy_options.value_or(tensorcast::common::CopyOptions{});
+    auto downstream = copy_opts.callbacks.on_copy_done;
+    auto fired = fired_count_;
+    const absl::Duration delay = delay_;
+    const absl::Status failure = failure_status_;
+    copy_opts.callbacks.on_copy_done = [downstream, fired, delay, failure](absl::Status) {
+      std::thread([downstream, fired, delay, failure]() {
+        absl::SleepFor(delay);
+        if (downstream) {
+          downstream(failure);
+        }
+        if (fired) {
+          fired->fetch_add(1, std::memory_order_relaxed);
+        }
+      }).detach();
+    };
+    return tensorcast::common::AsyncCopyManager::instance().submit_h2h(hsrc, hdst, copy_opts);
+  }
+
+  int callbacks_fired() const {
+    return fired_count_ ? fired_count_->load(std::memory_order_relaxed) : 0;
+  }
+
+ private:
+  absl::Duration delay_;
+  std::shared_ptr<std::atomic<int>> fired_count_;
+  std::vector<char> scratch_;
+  const absl::Status failure_status_;
+};
+
 TEST_CASE("Pump uses AsyncPositionedSink path", "[pump][async]") {
   const size_t total = 32 * 1024;
   TestSeekableSource src(total);
@@ -309,4 +366,22 @@ TEST_CASE("Pump async tolerates delayed callbacks", "[pump][async][delay]") {
   REQUIRE(sink.max_inflight() >= 1);
   REQUIRE(pool.returned_slots().size() == total / pool.chunk_size());
   REQUIRE(sink.callback_count() == expected_chunks);
+}
+
+TEST_CASE("Pump async surfaces delayed callback failure", "[pump][async][regression]") {
+  const size_t total = 4 * 1024;
+  TestSeekableSource src(total);
+  PostPumpFailureSink sink(absl::Milliseconds(10));
+  TestBufferPool pool(/*chunk_size=*/4096, /*capacity=*/1);
+  std::vector<Range> ranges{{0ULL, total}};
+
+  auto status = pump_ranges(src, sink, pool, absl::MakeSpan(ranges), /*concurrency=*/1);
+
+  const absl::Time deadline = absl::Now() + absl::Milliseconds(200);
+  while (sink.callbacks_fired() == 0 && absl::Now() < deadline) {
+    absl::SleepFor(absl::Milliseconds(1));
+  }
+  REQUIRE(sink.callbacks_fired() > 0);
+  REQUIRE(!status.ok());
+  REQUIRE(status.message().find("async callback failure") != std::string::npos);
 }

--- a/core/store/loader/verification_utils.cc
+++ b/core/store/loader/verification_utils.cc
@@ -1,0 +1,870 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/store/loader/verification_utils.h"
+
+#include <algorithm>
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <system_error>
+#include <utility>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "absl/base/const_init.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "core/common/artifact_hash.h"
+#include "core/common/artifact_verification.h"
+#include "core/common/cuda_api.h"
+#include "core/store/loader/safetensors_util.h"
+#include "core/store/loader/source_hash.h"
+#include "gsl/pointers"
+#include "nlohmann/json.hpp"
+
+namespace tensorcast::store::loader::verification {
+struct VerificationMetadataGuard::Entry {
+  explicit Entry(std::string artifact_id_in) : artifact_id(std::move(artifact_id_in)) {}
+
+  std::string artifact_id;
+  absl::Mutex mutex;
+  int32_t ref_count = 0;
+  bool warn_emitted = false;
+};
+
+namespace {
+
+struct CachedVerification {
+  common::ArtifactVerificationInfo info;
+  std::string serialized;
+  std::string fingerprint;
+  std::filesystem::file_time_type last_write_time{};
+  absl::Time cached_at;
+};
+
+ABSL_CONST_INIT absl::Mutex g_guard_map_mu(absl::kConstInit);
+absl::flat_hash_map<std::string, VerificationMetadataGuard::EntryPtr> g_guard_entries ABSL_GUARDED_BY(g_guard_map_mu);
+
+ABSL_CONST_INIT absl::Mutex g_metadata_cache_mu(absl::kConstInit);
+absl::flat_hash_map<std::string, CachedVerification> g_metadata_cache ABSL_GUARDED_BY(g_metadata_cache_mu);
+std::atomic<uint64_t> g_temp_file_nonce{0};
+constexpr absl::Duration kGuardWarnThreshold = absl::Milliseconds(100);
+
+std::string build_cache_key(std::string_view artifact_id, std::string_view byte_space_id) {
+  if (artifact_id.empty()) {
+    return absl::StrCat("unknown|", byte_space_id);
+  }
+  return absl::StrCat(artifact_id, "|", byte_space_id);
+}
+
+std::optional<CachedVerification> lookup_cached_metadata(std::string_view artifact_id, std::string_view byte_space_id) {
+  absl::MutexLock lock(&g_metadata_cache_mu);
+  const std::string key = build_cache_key(artifact_id, byte_space_id);
+  auto it = g_metadata_cache.find(key);
+  if (it == g_metadata_cache.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+void store_cached_metadata(
+    std::string_view artifact_id,
+    std::string_view byte_space_id,
+    const CachedVerification& entry) {
+  absl::MutexLock lock(&g_metadata_cache_mu);
+  const std::string key = build_cache_key(artifact_id, byte_space_id);
+  g_metadata_cache[key] = entry;
+}
+
+void invalidate_cached_metadata(std::string_view artifact_id, std::string_view byte_space_id) {
+  absl::MutexLock lock(&g_metadata_cache_mu);
+  const std::string key = build_cache_key(artifact_id, byte_space_id);
+  g_metadata_cache.erase(key);
+}
+
+std::string fingerprint_payload(std::string_view payload) {
+  const auto digest = common::sha256_digest_bytes(
+      absl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(payload.data()), payload.size()));
+  std::string hex;
+  hex.reserve(digest.size() * 2);
+  for (uint8_t byte : digest) {
+    absl::StrAppendFormat(&hex, "%02x", byte);
+  }
+  return hex;
+}
+
+absl::StatusOr<CachedVerification> load_metadata_from_disk(const std::filesystem::path& verification_path) {
+  std::ifstream vf(verification_path, std::ios::binary);
+  if (!vf.is_open()) {
+    return absl::PermissionDeniedError(
+        absl::StrCat("Failed to open verification metadata at '", verification_path.string(), "'"));
+  }
+
+  std::stringstream vbuf;
+  vbuf << vf.rdbuf();
+  vf.close();
+  std::string payload = vbuf.str();
+  if (payload.empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Verification metadata at '", verification_path.string(), "' is empty"));
+  }
+
+  auto ver_or = common::ArtifactVerificationInfo::from_json(payload);
+  if (!ver_or.ok()) {
+    return ver_or.status();
+  }
+
+  CachedVerification entry;
+  entry.info = *ver_or;
+  entry.serialized = std::move(payload);
+  entry.fingerprint = fingerprint_payload(entry.serialized);
+  entry.cached_at = absl::Now();
+  std::error_code ec;
+  entry.last_write_time = std::filesystem::last_write_time(verification_path, ec);
+  if (ec) {
+    entry.last_write_time = std::filesystem::file_time_type::min();
+  }
+  return entry;
+}
+
+absl::StatusOr<std::optional<std::string>> infer_artifact_id_from_descriptor(
+    const std::filesystem::path& artifact_dir) {
+  const auto descriptor_path = artifact_dir / "artifact_descriptor.json";
+  if (!std::filesystem::exists(descriptor_path)) {
+    return std::optional<std::string>{};
+  }
+
+  std::ifstream in(descriptor_path);
+  if (!in.is_open()) {
+    return absl::PermissionDeniedError(absl::StrCat("DESCRIPTOR_NOT_READABLE: cannot open ", descriptor_path.string()));
+  }
+
+  try {
+    nlohmann::json j;
+    in >> j;
+    if (!j.contains("artifact_id")) {
+      return absl::FailedPreconditionError(
+          absl::StrCat("artifact_descriptor.json missing artifact_id at ", descriptor_path.string()));
+    }
+    if (!j["artifact_id"].is_string()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("artifact_descriptor.json artifact_id must be string at ", descriptor_path.string()));
+    }
+    const std::string artifact_id = j["artifact_id"].get<std::string>();
+    if (!absl::StartsWith(artifact_id, "mi2:")) {
+      return absl::InvalidArgumentError(absl::StrCat("artifact_id must start with 'mi2:' (got ", artifact_id, ")"));
+    }
+    return std::optional<std::string>(artifact_id);
+  } catch (const std::exception& e) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Failed to parse artifact_descriptor.json at ", descriptor_path.string(), ": ", e.what()));
+  }
+}
+
+std::string build_path_guard_key(const std::filesystem::path& artifact_dir) {
+  std::error_code ec;
+  const auto canonical_path = std::filesystem::weakly_canonical(artifact_dir, ec);
+  if (!ec) {
+    return canonical_path.string();
+  }
+  return artifact_dir.lexically_normal().string();
+}
+
+std::filesystem::path build_temp_path(const std::filesystem::path& final_path) {
+  const uint64_t nonce = g_temp_file_nonce.fetch_add(1, std::memory_order_relaxed);
+  const pid_t pid = getpid();
+  std::filesystem::path tmp = final_path;
+  tmp += absl::StrFormat(".tmp.%d.%llu", static_cast<int>(pid), static_cast<unsigned long long>(nonce));
+  return tmp;
+}
+
+absl::Status atomic_write_file(const std::filesystem::path& final_path, std::string_view payload) {
+  const std::filesystem::path tmp_path = build_temp_path(final_path);
+  const std::string tmp_path_str = tmp_path.string();
+  const std::string final_path_str = final_path.string();
+
+  int fd = ::open(tmp_path_str.c_str(), O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC, 0644);
+  if (fd < 0) {
+    return absl::ErrnoToStatus(
+        errno, absl::StrCat("Failed to open temporary file for verification metadata: ", tmp_path_str));
+  }
+
+  const char* data = payload.data();
+  size_t remaining = payload.size();
+  while (remaining > 0) {
+    const ssize_t written = ::write(fd, data, remaining);
+    if (written < 0) {
+      const int err = errno;
+      ::close(fd);
+      ::unlink(tmp_path_str.c_str());
+      return absl::ErrnoToStatus(err, absl::StrCat("Failed to write verification metadata: ", tmp_path_str));
+    }
+    data += written;
+    remaining -= static_cast<size_t>(written);
+  }
+
+  if (::fsync(fd) != 0) {
+    const int err = errno;
+    ::close(fd);
+    ::unlink(tmp_path_str.c_str());
+    return absl::ErrnoToStatus(err, absl::StrCat("Failed to fsync verification metadata: ", tmp_path_str));
+  }
+
+  if (::close(fd) != 0) {
+    const int err = errno;
+    ::unlink(tmp_path_str.c_str());
+    return absl::ErrnoToStatus(err, absl::StrCat("Failed to close verification metadata temp file: ", tmp_path_str));
+  }
+
+  if (::rename(tmp_path_str.c_str(), final_path_str.c_str()) != 0) {
+    const int err = errno;
+    ::unlink(tmp_path_str.c_str());
+    return absl::ErrnoToStatus(
+        err, absl::StrCat("Failed to atomically rename verification metadata to ", final_path_str));
+  }
+
+  const std::filesystem::path parent_dir = final_path.parent_path();
+  if (!parent_dir.empty()) {
+    const std::string parent_dir_str = parent_dir.string();
+    int dir_fd = ::open(parent_dir_str.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (dir_fd < 0) {
+      return absl::ErrnoToStatus(errno, absl::StrCat("Failed to open parent directory for fsync: ", parent_dir_str));
+    }
+    if (::fsync(dir_fd) != 0) {
+      const int err = errno;
+      ::close(dir_fd);
+      return absl::ErrnoToStatus(err, absl::StrCat("Failed to fsync parent directory: ", parent_dir_str));
+    }
+    ::close(dir_fd);
+  }
+
+  return absl::OkStatus();
+}
+
+std::string sanitize_view_id_for_filename(std::string_view view_id) {
+  if (view_id.empty()) {
+    return std::string("view");
+  }
+  std::string sanitized;
+  sanitized.reserve(view_id.size());
+  for (char ch : view_id) {
+    const unsigned char u = static_cast<unsigned char>(ch);
+    if ((u >= 'a' && u <= 'z') || (u >= 'A' && u <= 'Z') || (u >= '0' && u <= '9') || ch == '_' || ch == '-' ||
+        ch == '.') {
+      sanitized.push_back(ch);
+    } else {
+      sanitized.push_back('_');
+    }
+  }
+  constexpr size_t kMaxSuffixLength = 160;
+  if (sanitized.size() > kMaxSuffixLength) {
+    sanitized.erase(0, sanitized.size() - kMaxSuffixLength);
+  }
+  return sanitized;
+}
+
+std::filesystem::path verification_path_for_view(
+    const std::filesystem::path& artifact_path,
+    std::string_view byte_space_id) {
+  if (byte_space_id.empty()) {
+    return artifact_path / "verification.json";
+  }
+  return artifact_path / absl::StrCat("verification.view_", sanitize_view_id_for_filename(byte_space_id), ".json");
+}
+
+std::vector<void*> build_pointer_vector(const MemoryView& mem) {
+  if (mem.base_ptr == nullptr || mem.size_bytes == 0) {
+    return {};
+  }
+  return {mem.base_ptr};
+}
+
+std::vector<size_t> build_size_vector(const MemoryView& mem) {
+  if (mem.base_ptr == nullptr || mem.size_bytes == 0) {
+    return {};
+  }
+  return {static_cast<size_t>(mem.size_bytes)};
+}
+
+bool should_skip_gpu_hash(const MemoryView& mem) {
+  return mem.location != common::memory::MemoryLocation::GPU || mem.gpu_device_id == std::nullopt ||
+      mem.base_ptr == nullptr || mem.size_bytes == 0;
+}
+
+bool should_skip_cpu_hash(const MemoryView& mem) {
+  return mem.location != common::memory::MemoryLocation::CPU || mem.base_ptr == nullptr || mem.size_bytes == 0;
+}
+
+absl::Status persist_verification_json(const std::filesystem::path& verification_path, std::string_view payload) {
+  return atomic_write_file(verification_path, payload);
+}
+
+absl::StatusOr<std::vector<std::vector<uint8_t>>> compute_leaf_digests_from_cpu(
+    const MemoryView& mem,
+    absl::Span<const uint64_t> leaf_indices,
+    size_t chunk_bytes) {
+  const auto* base = static_cast<const uint8_t*>(mem.base_ptr);
+  if (base == nullptr) {
+    return absl::FailedPreconditionError("CPU pointer unavailable for canonical leaf digests");
+  }
+  std::vector<std::vector<uint8_t>> digests;
+  digests.reserve(leaf_indices.size());
+  for (uint64_t idx : leaf_indices) {
+    const uint64_t offset = idx * chunk_bytes;
+    if (offset + chunk_bytes > mem.size_bytes) {
+      continue;
+    }
+    digests.push_back(common::sha256_digest_bytes(absl::Span<const uint8_t>(base + offset, chunk_bytes)));
+  }
+  return digests;
+}
+
+absl::StatusOr<std::vector<std::vector<uint8_t>>> compute_leaf_digests_from_gpu(
+    const MemoryView& mem,
+    absl::Span<const uint64_t> leaf_indices,
+    size_t chunk_bytes) {
+  if (mem.gpu_device_id == std::nullopt) {
+    return absl::FailedPreconditionError("GPU device id unavailable for canonical leaf digests");
+  }
+  if (mem.base_ptr == nullptr) {
+    return absl::FailedPreconditionError("GPU pointer unavailable for canonical leaf digests");
+  }
+  std::vector<uint8_t> buffer(chunk_bytes);
+  std::vector<std::vector<uint8_t>> digests;
+  digests.reserve(leaf_indices.size());
+  for (uint64_t idx : leaf_indices) {
+    const uint64_t offset = idx * chunk_bytes;
+    if (offset + chunk_bytes > mem.size_bytes) {
+      continue;
+    }
+    if (auto st = tensorcast::cuda::set_device(*mem.gpu_device_id); !st.ok()) {
+      return st;
+    }
+    auto copy_status = tensorcast::cuda::memcpy(
+        buffer.data(), static_cast<uint8_t*>(mem.base_ptr) + offset, chunk_bytes, cudaMemcpyDeviceToHost);
+    if (!copy_status.ok()) {
+      return copy_status;
+    }
+    if (auto sync_status = tensorcast::cuda::device_synchronize(); !sync_status.ok()) {
+      return sync_status;
+    }
+    digests.push_back(common::sha256_digest_bytes(absl::Span<const uint8_t>(buffer.data(), chunk_bytes)));
+  }
+  return digests;
+}
+
+} // namespace
+
+void ClearVerificationMetadataCacheForTesting() {
+  absl::MutexLock lock(&g_metadata_cache_mu);
+  g_metadata_cache.clear();
+}
+
+VerificationMetadataGuard::ScopedLock::ScopedLock(
+    std::string artifact_id,
+    absl::Duration wait_duration,
+    std::shared_ptr<Entry> entry_handle)
+    : artifact_id_(std::move(artifact_id)), wait_duration_(wait_duration), entry_handle_(std::move(entry_handle)) {}
+
+VerificationMetadataGuard::ScopedLock::ScopedLock(ScopedLock&& other) noexcept {
+  artifact_id_ = std::move(other.artifact_id_);
+  wait_duration_ = other.wait_duration_;
+  entry_handle_ = std::move(other.entry_handle_);
+  other.wait_duration_ = absl::ZeroDuration();
+}
+
+VerificationMetadataGuard::ScopedLock& VerificationMetadataGuard::ScopedLock::operator=(ScopedLock&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  Reset();
+  artifact_id_ = std::move(other.artifact_id_);
+  wait_duration_ = other.wait_duration_;
+  entry_handle_ = std::move(other.entry_handle_);
+  other.wait_duration_ = absl::ZeroDuration();
+  return *this;
+}
+
+VerificationMetadataGuard::ScopedLock::~ScopedLock() {
+  Reset();
+}
+
+void VerificationMetadataGuard::ScopedLock::Reset() {
+  if (!entry_handle_) {
+    return;
+  }
+
+  entry_handle_->mutex.Unlock();
+  {
+    absl::MutexLock lock(&g_guard_map_mu);
+    auto it = g_guard_entries.find(artifact_id_);
+    if (it != g_guard_entries.end()) {
+      auto& entry_ptr = it->second;
+      if (entry_ptr && entry_ptr->ref_count > 0) {
+        entry_ptr->ref_count -= 1;
+      }
+      if (!entry_ptr || entry_ptr->ref_count == 0) {
+        g_guard_entries.erase(it);
+      }
+    }
+  }
+
+  entry_handle_.reset();
+  artifact_id_.clear();
+  wait_duration_ = absl::ZeroDuration();
+}
+
+VerificationMetadataGuard::ScopedLock VerificationMetadataGuard::Acquire(std::string artifact_id) {
+  return Acquire(std::move(artifact_id), kGuardWarnThreshold);
+}
+
+VerificationMetadataGuard::ScopedLock VerificationMetadataGuard::Acquire(
+    std::string artifact_id,
+    absl::Duration warn_after) {
+  if (artifact_id.empty()) {
+    artifact_id = "unknown";
+  }
+
+  std::shared_ptr<Entry> entry;
+  {
+    absl::MutexLock lock(&g_guard_map_mu);
+    auto& slot = g_guard_entries[artifact_id];
+    if (!slot) {
+      slot = std::make_shared<Entry>(artifact_id);
+    }
+    entry = slot;
+    entry->ref_count += 1;
+  }
+
+  const absl::Time wait_start = absl::Now();
+  entry->mutex.Lock();
+  const absl::Duration wait_duration = absl::Now() - wait_start;
+
+  if (warn_after > absl::ZeroDuration() && wait_duration > warn_after && !entry->warn_emitted) {
+    entry->warn_emitted = true;
+    LOG(WARNING) << absl::StrFormat(
+        "verification_metadata_guard_wait_exceeded artifact_id=%s wait_ms=%.2f threshold_ms=%.2f",
+        entry->artifact_id,
+        absl::ToDoubleMilliseconds(wait_duration),
+        absl::ToDoubleMilliseconds(warn_after));
+  }
+
+  return ScopedLock(std::move(artifact_id), wait_duration, std::move(entry));
+}
+
+absl::StatusOr<std::string> compute_data_multihash(const MemoryView& mem) {
+  if (mem.size_bytes == 0 || mem.base_ptr == nullptr) {
+    return absl::NotFoundError("Memory region unavailable for hashing");
+  }
+  if (mem.location == common::memory::MemoryLocation::GPU) {
+    if (should_skip_gpu_hash(mem)) {
+      return absl::NotFoundError("GPU hashing requirements not met");
+    }
+    auto hash_or = loader::compute_data_multihash_from_gpu_memory(
+        gsl::not_null<void*>{mem.base_ptr}, mem.size_bytes, *mem.gpu_device_id);
+    if (!hash_or.ok()) {
+      LOG(WARNING) << "compute_data_multihash_from_gpu_memory failed: " << hash_or.status();
+      return hash_or.status();
+    }
+    return hash_or.value();
+  }
+
+  if (should_skip_cpu_hash(mem)) {
+    return absl::NotFoundError("CPU hashing requirements not met");
+  }
+  auto hash_or =
+      loader::compute_data_multihash_from_cpu_memory(gsl::not_null<const void*>{mem.base_ptr}, mem.size_bytes);
+  if (!hash_or.ok()) {
+    LOG(WARNING) << "compute_data_multihash_from_cpu_memory failed: " << hash_or.status();
+    return hash_or.status();
+  }
+  return hash_or.value();
+}
+
+absl::StatusOr<ViewHashResult> compute_view_tree_hash_and_leaves(
+    loader::SeekableSource& base_source,
+    uint64_t total_size,
+    size_t leaf_chunk_bytes) {
+  if (total_size == 0) {
+    return absl::InvalidArgumentError("total_size must be > 0");
+  }
+  if (leaf_chunk_bytes == 0) {
+    return absl::InvalidArgumentError("leaf_chunk_bytes must be > 0");
+  }
+  std::vector<std::vector<uint8_t>> leaves;
+  leaves.reserve(static_cast<size_t>((total_size + leaf_chunk_bytes - 1) / leaf_chunk_bytes));
+  std::vector<uint8_t> buffer(leaf_chunk_bytes);
+  uint64_t processed = 0;
+  while (processed < total_size) {
+    const size_t to_read = static_cast<size_t>(std::min<uint64_t>(leaf_chunk_bytes, total_size - processed));
+    auto read_or = base_source.read_at(processed, buffer.data(), to_read);
+    if (!read_or.ok()) {
+      return read_or.status();
+    }
+    const size_t got = read_or.value();
+    if (got == 0) {
+      return absl::DataLossError("short read while computing tree hash");
+    }
+    leaves.push_back(common::sha256_digest_bytes(absl::Span<const uint8_t>(buffer.data(), got)));
+    processed += got;
+  }
+  ViewHashResult out;
+  out.multihash = common::multibase_multihash_sha256(common::compute_tree_hash_root_sha256(leaves));
+  out.leaf_digests = std::move(leaves);
+  return out;
+}
+
+absl::Status reuse_or_generate_verification_json(
+    const std::filesystem::path& artifact_dir,
+    std::string expected_byte_space_id,
+    const MemoryView& mem) {
+  auto artifact_id_or = infer_artifact_id_from_descriptor(artifact_dir);
+  if (!artifact_id_or.ok()) {
+    return artifact_id_or.status();
+  }
+  std::optional<std::string> artifact_id = *artifact_id_or;
+  std::string guard_key = artifact_id.value_or(build_path_guard_key(artifact_dir));
+  auto guard = VerificationMetadataGuard::Acquire(guard_key);
+  const auto verification_path = verification_path_for_view(artifact_dir, expected_byte_space_id);
+  const absl::Time op_start = absl::Now();
+  const bool had_existing_file = std::filesystem::exists(verification_path);
+  bool persist_required = !had_existing_file;
+
+  if (mem.location == common::memory::MemoryLocation::GPU && mem.gpu_device_id.has_value()) {
+    auto set_dev_status = tensorcast::cuda::set_device(*mem.gpu_device_id);
+    if (!set_dev_status.ok()) {
+      LOG(ERROR) << "Failed to set CUDA device before verification: " << set_dev_status;
+      return set_dev_status;
+    }
+    auto sync_status = tensorcast::cuda::device_synchronize();
+    if (!sync_status.ok()) {
+      LOG(ERROR) << "device_synchronize failed before verification: " << sync_status;
+      return sync_status;
+    }
+  }
+
+  const std::string cache_scope = artifact_id.value_or(guard_key);
+  const std::string artifact_ref = artifact_id.value_or(guard_key);
+
+  CachedVerification metadata_entry;
+  bool have_metadata = false;
+  bool reused_existing = false;
+  bool regenerated_metadata = false;
+  bool metadata_verified = false;
+  bool cache_hit = false;
+  bool need_regeneration = false;
+  bool persist_attempted = false;
+  bool persist_success = false;
+  bool persisted_cached_metadata = false;
+  absl::Duration persist_duration = absl::ZeroDuration();
+  absl::Status persist_status = absl::OkStatus();
+
+  std::optional<CachedVerification> cached = lookup_cached_metadata(cache_scope, expected_byte_space_id);
+  const bool verification_exists = std::filesystem::exists(verification_path);
+
+  if (verification_exists) {
+    auto disk_or = load_metadata_from_disk(verification_path);
+    if (disk_or.ok()) {
+      metadata_entry = *disk_or;
+      metadata_entry.cached_at = absl::Now();
+      have_metadata = true;
+      persist_required = false;
+      store_cached_metadata(cache_scope, expected_byte_space_id, metadata_entry);
+    } else {
+      LOG(WARNING) << "Failed to load verification metadata at '" << verification_path.string()
+                   << "': " << disk_or.status();
+      need_regeneration = true;
+      persist_required = true;
+      invalidate_cached_metadata(cache_scope, expected_byte_space_id);
+    }
+  } else if (cached.has_value()) {
+    metadata_entry = *cached;
+    metadata_entry.cached_at = absl::Now();
+    have_metadata = true;
+    cache_hit = true;
+    persist_required = true;
+  } else {
+    need_regeneration = true;
+  }
+
+  const std::vector<void*> ptrs = build_pointer_vector(mem);
+  const std::vector<size_t> sizes = build_size_vector(mem);
+
+  if (have_metadata) {
+    const auto& info = metadata_entry.info;
+    auto fmt_hex = [](uint64_t value) { return absl::StrCat("0x", absl::Hex(value, absl::kZeroPad16)); };
+    LOG(INFO) << "verification_utils: using cached metadata artifact_size=" << info.artifact_size << " key_values=["
+              << fmt_hex(info.key_values[0]) << ", " << fmt_hex(info.key_values[1]) << ", "
+              << fmt_hex(info.key_values[2]) << "]";
+    const bool byte_space_mismatch =
+        ((!expected_byte_space_id.empty() || !info.byte_space_id.empty()) &&
+         info.byte_space_id != expected_byte_space_id);
+    if (byte_space_mismatch) {
+      LOG(WARNING) << "Verification metadata at '" << verification_path.string() << "' recorded for artifact '"
+                   << artifact_ref << "' byte_space_id='" << info.byte_space_id << "', expected '"
+                   << expected_byte_space_id << "'; regenerating.";
+      need_regeneration = true;
+      have_metadata = false;
+      invalidate_cached_metadata(cache_scope, expected_byte_space_id);
+    } else if (!ptrs.empty()) {
+      absl::Status verify_status = common::ArtifactVerifier::verify_artifact_data(
+          ptrs, sizes, info, common::VerificationLevel::SEGMENT_HASHES, mem.gpu_device_id.value_or(-1));
+      if (!verify_status.ok()) {
+        LOG(ERROR) << "verification failed for artifact='" << artifact_ref << "' byte_space='" << expected_byte_space_id
+                   << "' status=" << verify_status;
+        const auto tensor_path = artifact_dir / "tensor.data_0";
+        if (std::filesystem::exists(tensor_path)) {
+          std::string msg = std::string(verify_status.message());
+          std::string marker = "offset ";
+          size_t pos = msg.find(marker);
+          if (pos != std::string::npos) {
+            pos += marker.size();
+            size_t end = msg.find_first_not_of("0123456789", pos);
+            std::string offset_str = msg.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
+            uint64_t offset = 0;
+            if (!offset_str.empty()) {
+              offset = static_cast<uint64_t>(std::strtoull(offset_str.c_str(), nullptr, 10));
+            }
+            std::array<unsigned char, 16> host_bytes{};
+            std::ifstream tf(tensor_path, std::ios::binary);
+            if (tf.is_open()) {
+              tf.seekg(static_cast<std::streamoff>(offset));
+              tf.read(reinterpret_cast<char*>(host_bytes.data()), host_bytes.size());
+              if (tf.gcount() > 0) {
+                std::string host_hex;
+                host_hex.reserve(static_cast<size_t>(tf.gcount()) * 3);
+                for (std::streamsize i = 0; i < tf.gcount(); ++i) {
+                  if (i != 0) {
+                    host_hex.push_back(' ');
+                  }
+                  absl::StrAppendFormat(&host_hex, "%02x", host_bytes[static_cast<size_t>(i)]);
+                }
+                LOG(ERROR) << "Host bytes at offset=" << offset << " (" << tf.gcount() << " bytes): [" << host_hex
+                           << "]";
+              }
+            }
+          }
+        }
+        invalidate_cached_metadata(cache_scope, expected_byte_space_id);
+        return absl::DataLossError(
+            absl::StrCat("ARTIFACT_ID_MISMATCH: verification failed: ", verify_status.message()));
+      }
+      metadata_verified = true;
+      reused_existing = true;
+    } else {
+      metadata_verified = true;
+      reused_existing = true;
+    }
+  }
+
+  if (!metadata_verified && need_regeneration && !ptrs.empty()) {
+    auto gen_or = common::ArtifactVerifier::generate_verification_info(
+        ptrs, sizes, mem.gpu_device_id.value_or(-1), common::VerificationLevel::SEGMENT_HASHES);
+    if (!gen_or.ok()) {
+      invalidate_cached_metadata(cache_scope, expected_byte_space_id);
+      return gen_or.status();
+    }
+    metadata_entry.info = *gen_or;
+    auto fmt_hex = [](uint64_t value) { return absl::StrCat("0x", absl::Hex(value, absl::kZeroPad16)); };
+    LOG(INFO) << "verification_utils: regenerated metadata artifact_size=" << metadata_entry.info.artifact_size
+              << " key_values=[" << fmt_hex(metadata_entry.info.key_values[0]) << ", "
+              << fmt_hex(metadata_entry.info.key_values[1]) << ", " << fmt_hex(metadata_entry.info.key_values[2])
+              << "]";
+    metadata_entry.info.byte_space_id = expected_byte_space_id;
+    metadata_entry.info.refresh_metadata_signature();
+    const std::string payload = metadata_entry.info.to_json();
+    metadata_entry.serialized = payload;
+    metadata_entry.fingerprint = fingerprint_payload(payload);
+    metadata_entry.cached_at = absl::Now();
+    metadata_entry.last_write_time = std::filesystem::file_time_type::min();
+    store_cached_metadata(cache_scope, expected_byte_space_id, metadata_entry);
+    persist_attempted = true;
+    const absl::Time persist_start = absl::Now();
+    persist_status = persist_verification_json(verification_path, payload);
+    persist_duration = absl::Now() - persist_start;
+    if (persist_status.ok()) {
+      persist_success = true;
+      persist_required = false;
+      std::error_code ec;
+      metadata_entry.last_write_time = std::filesystem::last_write_time(verification_path, ec);
+      if (ec) {
+        metadata_entry.last_write_time = std::filesystem::file_time_type::min();
+      }
+      metadata_entry.cached_at = absl::Now();
+      store_cached_metadata(cache_scope, expected_byte_space_id, metadata_entry);
+    }
+    metadata_verified = true;
+    regenerated_metadata = true;
+    need_regeneration = false;
+  } else if (!metadata_verified && need_regeneration && ptrs.empty()) {
+    VLOG(1) << "Skipping verification metadata regeneration for artifact '" << artifact_ref << "' (byte_space_id='"
+            << expected_byte_space_id << "') because no readable memory view was supplied.";
+  }
+
+  if (!persist_success && persist_required && (have_metadata || metadata_verified)) {
+    metadata_entry.info.refresh_metadata_signature();
+    const std::string payload = metadata_entry.info.to_json();
+    metadata_entry.serialized = payload;
+    metadata_entry.fingerprint = fingerprint_payload(payload);
+    persist_attempted = true;
+    const absl::Time persist_start = absl::Now();
+    persist_status = persist_verification_json(verification_path, payload);
+    persist_duration = absl::Now() - persist_start;
+    if (persist_status.ok()) {
+      persist_success = true;
+      persisted_cached_metadata = true;
+      persist_required = false;
+      std::error_code ec;
+      metadata_entry.last_write_time = std::filesystem::last_write_time(verification_path, ec);
+      if (ec) {
+        metadata_entry.last_write_time = std::filesystem::file_time_type::min();
+      }
+      metadata_entry.cached_at = absl::Now();
+      store_cached_metadata(cache_scope, expected_byte_space_id, metadata_entry);
+    }
+  }
+
+  const absl::Duration op_duration = absl::Now() - op_start;
+  VLOG(1) << absl::StrFormat(
+      "verification_metadata_status artifact_id=%s byte_space=%s reused=%s regenerated=%s cache_hit=%s wait_ms=%.2f duration_ms=%.2f write_attempted=%s write_ms=%.2f cached_persist=%s",
+      artifact_ref,
+      expected_byte_space_id,
+      reused_existing ? "true" : "false",
+      regenerated_metadata ? "true" : "false",
+      cache_hit ? "true" : "false",
+      absl::ToDoubleMilliseconds(guard.wait_duration()),
+      absl::ToDoubleMilliseconds(op_duration),
+      persist_attempted ? "true" : "false",
+      persist_attempted ? absl::ToDoubleMilliseconds(persist_duration) : -1.0,
+      persisted_cached_metadata ? "true" : "false");
+
+  if (persist_attempted) {
+    if (persist_success) {
+      LOG(INFO) << absl::StrFormat(
+          "verification_metadata_write_succeeded artifact=%s byte_space=%s wait_ms=%.2f write_ms=%.2f cached_persist=%s",
+          artifact_ref,
+          expected_byte_space_id,
+          absl::ToDoubleMilliseconds(guard.wait_duration()),
+          absl::ToDoubleMilliseconds(persist_duration),
+          persisted_cached_metadata ? "true" : "false");
+    } else {
+      LOG(ERROR) << absl::StrFormat(
+          "verification_metadata_write_failed artifact=%s byte_space=%s wait_ms=%.2f write_ms=%.2f cached_persist=%s error=\"%s\"",
+          artifact_ref,
+          expected_byte_space_id,
+          absl::ToDoubleMilliseconds(guard.wait_duration()),
+          absl::ToDoubleMilliseconds(persist_duration),
+          persisted_cached_metadata ? "true" : "false",
+          persist_status.message());
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status write_descriptor_if_absent(
+    const std::filesystem::path& artifact_dir,
+    std::string_view index_multihash,
+    std::string_view data_multihash,
+    uint64_t total_size_bytes,
+    std::string_view encoding) {
+  const auto descriptor_path = artifact_dir / "artifact_descriptor.json";
+  if (std::filesystem::exists(descriptor_path)) {
+    return absl::OkStatus();
+  }
+
+  try {
+    nlohmann::json j;
+    j["artifact_id"] = std::string("mi2:") + std::string(index_multihash) + ":" + std::string(data_multihash);
+    j["index_multihash"] = index_multihash;
+    j["data_multihash"] = data_multihash;
+    j["schema_version"] = "v3";
+    j["encoding"] = encoding;
+    j["total_size"] = total_size_bytes;
+    nlohmann::json hp;
+    hp["chunk_size"] = 4 * 1024 * 1024;
+    hp["fanout"] = 2;
+    hp["algorithm"] = "sha2-256";
+    j["hash_params"] = hp;
+
+    std::ofstream of(descriptor_path);
+    if (!of.is_open()) {
+      return absl::PermissionDeniedError("DESCRIPTOR_NOT_WRITABLE: cannot write artifact_descriptor.json");
+    }
+    of << j.dump(2);
+  } catch (const std::exception& e) {
+    return absl::PermissionDeniedError(std::string("DESCRIPTOR_NOT_WRITABLE: ") + e.what());
+  }
+
+  const auto index_json_path = artifact_dir / "tensor_index.json";
+  if (!std::filesystem::exists(index_json_path)) {
+    std::vector<std::filesystem::path> safetensors_files;
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(artifact_dir, ec)) {
+      if (ec) {
+        LOG(WARNING) << "Failed to enumerate artifact directory '" << artifact_dir.string()
+                     << "' while persisting canonical index: " << ec.message();
+        break;
+      }
+      if (!entry.is_regular_file()) {
+        continue;
+      }
+      const std::string name = entry.path().filename().string();
+      if (absl::EndsWith(name, ".safetensors")) {
+        safetensors_files.push_back(entry.path());
+      }
+    }
+    if (!safetensors_files.empty()) {
+      auto index_bytes_or = loader::BuildCanonicalIndexFromSafetensors(safetensors_files);
+      if (index_bytes_or.ok()) {
+        try {
+          std::ofstream oj(index_json_path);
+          if (!oj.is_open()) {
+            return absl::PermissionDeniedError("DESCRIPTOR_NOT_WRITABLE: cannot write tensor_index.json");
+          }
+          oj << index_bytes_or.value();
+          oj.close();
+        } catch (const std::exception& e) {
+          return absl::PermissionDeniedError(std::string("DESCRIPTOR_NOT_WRITABLE: ") + e.what());
+        }
+      }
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::vector<std::vector<uint8_t>>> compute_canonical_leaf_digests(
+    const MemoryView& mem,
+    absl::Span<const uint64_t> leaf_indices,
+    size_t chunk_bytes) {
+  if (leaf_indices.empty()) {
+    return std::vector<std::vector<uint8_t>>{};
+  }
+  if (chunk_bytes == 0) {
+    return absl::InvalidArgumentError("chunk_bytes must be > 0");
+  }
+  if (mem.location == common::memory::MemoryLocation::CPU) {
+    return compute_leaf_digests_from_cpu(mem, leaf_indices, chunk_bytes);
+  }
+  if (mem.location == common::memory::MemoryLocation::GPU) {
+    return compute_leaf_digests_from_gpu(mem, leaf_indices, chunk_bytes);
+  }
+  return absl::InvalidArgumentError("Unsupported memory location for canonical leaf digests");
+}
+
+} // namespace tensorcast::store::loader::verification

--- a/core/store/loader/verification_utils.h
+++ b/core/store/loader/verification_utils.h
@@ -1,0 +1,103 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "core/common/memory/memory_location.h"
+#include "core/store/loader/source.h"
+
+namespace tensorcast::store::loader::verification {
+
+class VerificationMetadataGuard {
+  struct Entry;
+
+ public:
+  class ScopedLock {
+   public:
+    ScopedLock() = default;
+    ScopedLock(ScopedLock&& other) noexcept;
+    ScopedLock& operator=(ScopedLock&& other) noexcept;
+    ScopedLock(const ScopedLock&) = delete;
+    ScopedLock& operator=(const ScopedLock&) = delete;
+    ~ScopedLock();
+
+    [[nodiscard]] absl::Duration wait_duration() const {
+      return wait_duration_;
+    }
+
+    [[nodiscard]] std::string_view artifact_id() const {
+      return artifact_id_;
+    }
+
+   private:
+    friend class VerificationMetadataGuard;
+    ScopedLock(std::string artifact_id, absl::Duration wait_duration, std::shared_ptr<Entry> entry_handle);
+
+    std::string artifact_id_;
+    absl::Duration wait_duration_{};
+    std::shared_ptr<Entry> entry_handle_;
+
+    void Reset() ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  };
+
+  static ScopedLock Acquire(std::string artifact_id) ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  static ScopedLock Acquire(std::string artifact_id, absl::Duration warn_after) ABSL_NO_THREAD_SAFETY_ANALYSIS;
+
+  using EntryPtr = std::shared_ptr<Entry>;
+
+ private:
+  VerificationMetadataGuard() = default;
+};
+
+struct MemoryView {
+  common::memory::MemoryLocation location{common::memory::MemoryLocation::CPU};
+  void* base_ptr{nullptr};
+  uint64_t size_bytes{0};
+  std::optional<int> gpu_device_id;
+};
+
+struct ViewHashResult {
+  std::string multihash;
+  std::vector<std::vector<uint8_t>> leaf_digests;
+};
+
+absl::StatusOr<std::string> compute_data_multihash(const MemoryView& mem);
+
+absl::StatusOr<ViewHashResult> compute_view_tree_hash_and_leaves(
+    loader::SeekableSource& base_source,
+    uint64_t total_size,
+    size_t leaf_chunk_bytes);
+
+absl::Status reuse_or_generate_verification_json(
+    const std::filesystem::path& artifact_dir,
+    std::string expected_byte_space_id,
+    const MemoryView& mem);
+
+// Test hook to clear in-process verification metadata cache. No-op in
+// production code paths.
+void ClearVerificationMetadataCacheForTesting();
+
+absl::Status write_descriptor_if_absent(
+    const std::filesystem::path& artifact_dir,
+    std::string_view index_multihash,
+    std::string_view data_multihash,
+    uint64_t total_size_bytes,
+    std::string_view encoding);
+
+absl::StatusOr<std::vector<std::vector<uint8_t>>> compute_canonical_leaf_digests(
+    const MemoryView& mem,
+    absl::Span<const uint64_t> leaf_indices,
+    size_t chunk_bytes);
+
+} // namespace tensorcast::store::loader::verification

--- a/core/store/loader/verification_utils_test.cc
+++ b/core/store/loader/verification_utils_test.cc
@@ -1,0 +1,380 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/store/loader/verification_utils.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <nlohmann/json.hpp>
+#include "absl/log/log.h"
+#include "absl/log/log_sink_registry.h"
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
+#include "core/common/artifact_hash.h"
+#include "core/common/artifact_verification.h"
+#include "core/common/cuda_api.h"
+#include "core/store/loader/source_hash.h"
+#include "core/testing/common.h"
+
+namespace fs = std::filesystem;
+using tensorcast::store::loader::verification::MemoryView;
+using tensorcast::store::loader::verification::ViewHashResult;
+
+namespace {
+
+MemoryView make_cpu_view(std::vector<uint8_t>& data) {
+  MemoryView view;
+  view.location = tensorcast::common::memory::MemoryLocation::CPU;
+  view.base_ptr = data.data();
+  view.size_bytes = data.size();
+  return view;
+}
+
+MemoryView make_gpu_view(void* ptr, size_t bytes, int device_id) {
+  MemoryView view;
+  view.location = tensorcast::common::memory::MemoryLocation::GPU;
+  view.base_ptr = ptr;
+  view.size_bytes = bytes;
+  view.gpu_device_id = device_id;
+  return view;
+}
+
+fs::path make_temp_dir(const std::string& prefix) {
+  fs::path dir = fs::temp_directory_path() / prefix;
+  fs::create_directories(dir);
+  return dir;
+}
+
+class VectorSource : public tensorcast::store::loader::SeekableSource {
+ public:
+  explicit VectorSource(std::vector<uint8_t> data) : data_(std::move(data)) {}
+
+  absl::StatusOr<size_t> read(void* dst, size_t max_bytes) override {
+    const size_t to_copy = std::min(max_bytes, data_.size() - cursor_);
+    std::memcpy(dst, data_.data() + cursor_, to_copy);
+    cursor_ += to_copy;
+    return to_copy;
+  }
+
+  absl::StatusOr<size_t> read_at(uint64_t offset, void* dst, size_t bytes) override {
+    if (offset >= data_.size()) {
+      return static_cast<size_t>(0);
+    }
+    const size_t to_copy = std::min<size_t>(bytes, data_.size() - static_cast<size_t>(offset));
+    std::memcpy(dst, data_.data() + offset, to_copy);
+    return to_copy;
+  }
+
+ private:
+  std::vector<uint8_t> data_;
+  size_t cursor_{0};
+};
+
+} // namespace
+
+TEST_CASE("VerificationUtils computes CPU multihash", "[verification][cpu]") {
+  std::vector<uint8_t> data(16);
+  for (size_t i = 0; i < data.size(); ++i) {
+    data[i] = static_cast<uint8_t>(i * 3);
+  }
+  MemoryView view = make_cpu_view(data);
+  auto hash_or = tensorcast::store::loader::verification::compute_data_multihash(view);
+  REQUIRE(hash_or.ok());
+
+  auto expected_or = tensorcast::store::loader::compute_data_multihash_from_cpu_memory(
+      gsl::not_null<const void*>{data.data()}, data.size());
+  REQUIRE(expected_or.ok());
+  CHECK(hash_or.value() == expected_or.value());
+}
+
+TEST_CASE("VerificationUtils computes GPU multihash when CUDA available", "[verification][gpu]") {
+  if (!tensorcast::testing::is_cuda_available()) {
+    WARN("CUDA not available – skipping GPU verification test.");
+    return;
+  }
+
+  constexpr size_t kBytes = 64;
+  std::vector<uint8_t> host_data(kBytes);
+  for (size_t i = 0; i < host_data.size(); ++i) {
+    host_data[i] = static_cast<uint8_t>(0xAA ^ i);
+  }
+
+  REQUIRE(tensorcast::cuda::set_device(0).ok());
+  void* device_ptr = nullptr;
+  REQUIRE(tensorcast::cuda::malloc(&device_ptr, kBytes).ok());
+  REQUIRE(tensorcast::cuda::memcpy(device_ptr, host_data.data(), kBytes, cudaMemcpyHostToDevice).ok());
+
+  MemoryView view = make_gpu_view(device_ptr, kBytes, /*device_id=*/0);
+  auto hash_or = tensorcast::store::loader::verification::compute_data_multihash(view);
+  REQUIRE(hash_or.ok());
+
+  auto expected_or = tensorcast::store::loader::compute_data_multihash_from_cpu_memory(
+      gsl::not_null<const void*>{host_data.data()}, host_data.size());
+  REQUIRE(expected_or.ok());
+  CHECK(hash_or.value() == expected_or.value());
+
+  REQUIRE(tensorcast::cuda::free(device_ptr).ok());
+}
+
+TEST_CASE("VerificationUtils generates and reuses verification.json", "[verification][metadata]") {
+  fs::path dir = make_temp_dir("verification_utils");
+
+  std::vector<uint8_t> data(128, 0x5A);
+  MemoryView view = make_cpu_view(data);
+
+  // When file absent, it should be generated.
+  auto status = tensorcast::store::loader::verification::reuse_or_generate_verification_json(
+      dir,
+      /*expected_byte_space_id=*/"canonical",
+      view);
+  CHECK(status.ok());
+  fs::path verification_path = dir / "verification.view_canonical.json";
+  CHECK(fs::exists(verification_path));
+
+  std::ifstream in(verification_path);
+  REQUIRE(in.is_open());
+  std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  auto info_or = tensorcast::common::ArtifactVerificationInfo::from_json(contents);
+  REQUIRE(info_or.ok());
+  CHECK(info_or->byte_space_id == "canonical");
+
+  // Reuse should succeed without rewriting when byte_space_id matches.
+  status = tensorcast::store::loader::verification::reuse_or_generate_verification_json(
+      dir,
+      /*expected_byte_space_id=*/"canonical",
+      view);
+  CHECK(status.ok());
+
+  // Mismatched byte_space_id should trigger regeneration into a new file.
+  fs::path mismatch_path = dir / "verification.view_variant.json";
+  status = tensorcast::store::loader::verification::reuse_or_generate_verification_json(
+      dir,
+      /*expected_byte_space_id=*/"variant",
+      view);
+  CHECK(status.ok());
+  CHECK(fs::exists(mismatch_path));
+
+  std::ifstream in2(mismatch_path);
+  REQUIRE(in2.is_open());
+  std::string updated((std::istreambuf_iterator<char>(in2)), std::istreambuf_iterator<char>());
+  auto updated_info = tensorcast::common::ArtifactVerificationInfo::from_json(updated);
+  REQUIRE(updated_info.ok());
+  CHECK(updated_info->byte_space_id == "variant");
+
+  fs::remove_all(dir);
+}
+
+TEST_CASE("VerificationUtils detects tampering even when metadata was cached", "[verification][metadata][tamper]") {
+  fs::path dir = make_temp_dir("verification_tamper");
+  std::vector<uint8_t> data(256, 0x7A);
+  MemoryView view = make_cpu_view(data);
+
+  auto status = tensorcast::store::loader::verification::reuse_or_generate_verification_json(
+      dir,
+      /*expected_byte_space_id=*/"",
+      view);
+  REQUIRE(status.ok());
+
+  // Warm the cache with a second successful reuse.
+  status = tensorcast::store::loader::verification::reuse_or_generate_verification_json(
+      dir,
+      /*expected_byte_space_id=*/"",
+      view);
+  REQUIRE(status.ok());
+
+  const fs::path verification_path = dir / "verification.json";
+  REQUIRE(fs::exists(verification_path));
+
+  // Tamper with key values and rewrite the file with a matching signature.
+  std::ifstream vf(verification_path);
+  REQUIRE(vf.is_open());
+  std::string payload((std::istreambuf_iterator<char>(vf)), std::istreambuf_iterator<char>());
+  vf.close();
+
+  auto info_or = tensorcast::common::ArtifactVerificationInfo::from_json(payload);
+  REQUIRE(info_or.ok());
+  tensorcast::common::ArtifactVerificationInfo tampered = *info_or;
+  tampered.key_values = {0ULL, 0ULL, 0ULL};
+  tampered.refresh_metadata_signature();
+  std::ofstream out(verification_path);
+  REQUIRE(out.is_open());
+  out << tampered.to_json();
+  out.close();
+
+  status = tensorcast::store::loader::verification::reuse_or_generate_verification_json(
+      dir,
+      /*expected_byte_space_id=*/"",
+      view);
+  REQUIRE_FALSE(status.ok());
+  CHECK(status.code() == absl::StatusCode::kDataLoss);
+
+  fs::remove_all(dir);
+}
+
+TEST_CASE("VerificationUtils writes descriptor when absent", "[verification][descriptor]") {
+  fs::path dir = make_temp_dir("verification_descriptor");
+
+  const std::string index_mh = "mindex";
+  const std::string data_mh = "mdata";
+  const uint64_t total_size = 42;
+
+  auto status =
+      tensorcast::store::loader::verification::write_descriptor_if_absent(dir, index_mh, data_mh, total_size, "json");
+  CHECK(status.ok());
+
+  fs::path descriptor = dir / "artifact_descriptor.json";
+  CHECK(fs::exists(descriptor));
+
+  std::ifstream in(descriptor);
+  REQUIRE(in.is_open());
+  nlohmann::json j;
+  in >> j;
+  CHECK(j["index_multihash"] == index_mh);
+  CHECK(j["data_multihash"] == data_mh);
+  CHECK(j["total_size"] == total_size);
+
+  // Second call should no-op.
+  status =
+      tensorcast::store::loader::verification::write_descriptor_if_absent(dir, index_mh, data_mh, total_size, "json");
+  CHECK(status.ok());
+
+  fs::remove_all(dir);
+}
+
+TEST_CASE("VerificationUtils atomic persistence prevents partial JSON reads", "[verification][atomic]") {
+  fs::path dir = make_temp_dir("verification_atomic");
+  std::vector<uint8_t> data(1024 * 32, 0x42);
+  MemoryView view = make_cpu_view(data);
+  const fs::path verification_path = dir / "verification.view_canonical.json";
+  const int iterations = 32;
+
+  std::atomic<bool> writer_done{false};
+  std::atomic<int> parse_failures{0};
+
+  std::thread reader([&]() {
+    while (!writer_done.load(std::memory_order_acquire)) {
+      if (std::filesystem::exists(verification_path)) {
+        std::ifstream in(verification_path);
+        if (!in.is_open()) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          continue;
+        }
+        std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        if (contents.empty()) {
+          // Reader may observe file absence between unlink and rename; try again.
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          continue;
+        }
+        auto info_or = tensorcast::common::ArtifactVerificationInfo::from_json(contents);
+        if (!info_or.ok()) {
+          parse_failures.fetch_add(1, std::memory_order_relaxed);
+          return;
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  });
+
+  for (int i = 0; i < iterations; ++i) {
+    std::error_code ec;
+    std::filesystem::remove(verification_path, ec);
+    auto status = tensorcast::store::loader::verification::reuse_or_generate_verification_json(
+        dir,
+        /*expected_byte_space_id=*/"canonical",
+        view);
+    REQUIRE(status.ok());
+    tensorcast::store::loader::verification::ClearVerificationMetadataCacheForTesting();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  writer_done.store(true, std::memory_order_release);
+  reader.join();
+
+  CHECK(parse_failures.load(std::memory_order_relaxed) == 0);
+  CHECK(std::filesystem::exists(verification_path));
+
+  fs::remove_all(dir);
+}
+
+class CollectingLogSink : public absl::LogSink {
+ public:
+  void Send(const absl::LogEntry& entry) override {
+    absl::MutexLock lock(&mu_);
+    messages_.push_back(std::string(entry.text_message()));
+  }
+
+  bool Contains(absl::string_view needle) const {
+    absl::MutexLock lock(&mu_);
+    for (const auto& msg : messages_) {
+      if (msg.find(needle) != std::string::npos) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  mutable absl::Mutex mu_;
+  std::vector<std::string> messages_ ABSL_GUARDED_BY(mu_);
+};
+
+TEST_CASE("VerificationUtils emits structured logs on metadata write", "[verification][logging]") {
+  fs::path dir = make_temp_dir("verification_logging");
+
+  std::vector<uint8_t> data(256, 0x11);
+  MemoryView view = make_cpu_view(data);
+  tensorcast::store::loader::verification::ClearVerificationMetadataCacheForTesting();
+
+  CollectingLogSink sink;
+  absl::AddLogSink(&sink);
+  auto status = tensorcast::store::loader::verification::reuse_or_generate_verification_json(
+      dir,
+      /*expected_byte_space_id=*/"",
+      view);
+  absl::RemoveLogSink(&sink);
+
+  REQUIRE(status.ok());
+  CHECK(sink.Contains("verification_metadata_write_succeeded"));
+
+  fs::remove_all(dir);
+}
+
+TEST_CASE("VerificationUtils computes view tree hash and leaf digests", "[verification][view]") {
+  std::vector<uint8_t> data(32);
+  for (size_t i = 0; i < data.size(); ++i) {
+    data[i] = static_cast<uint8_t>(i);
+  }
+  VectorSource source(data);
+  auto result_or = tensorcast::store::loader::verification::compute_view_tree_hash_and_leaves(
+      source,
+      /*total_size=*/data.size(),
+      /*leaf_chunk_bytes=*/8);
+  REQUIRE(result_or.ok());
+  const ViewHashResult& result = result_or.value();
+  CHECK(result.leaf_digests.size() == 4);
+  CHECK_FALSE(result.multihash.empty());
+}
+
+TEST_CASE("VerificationUtils computes canonical leaf digests for CPU", "[verification][leaf]") {
+  std::vector<uint8_t> data(32);
+  for (size_t i = 0; i < data.size(); ++i) {
+    data[i] = static_cast<uint8_t>(0x10 + i);
+  }
+  MemoryView view = make_cpu_view(data);
+  std::array<uint64_t, 2> indices = {0, 1};
+  auto digests_or = tensorcast::store::loader::verification::compute_canonical_leaf_digests(
+      view,
+      absl::MakeSpan(indices),
+      /*chunk_bytes=*/16);
+  REQUIRE(digests_or.ok());
+  CHECK(digests_or->size() == indices.size());
+}

--- a/core/store/multi_gpu_test.cc
+++ b/core/store/multi_gpu_test.cc
@@ -321,14 +321,15 @@ TEST_CASE("B5: Device-specific operations", "[store_engine][multi_gpu][b5]") {
 
   hints.disk_path = artifact_id;
   auto handle0 = store->materialize_replica(make_gpu_key(0), StoreEngine::MaterializeMode::LOAD_ONLY, hints);
+  REQUIRE(handle0.ok());
+  REQUIRE(handle0.value().wait_ready(std::chrono::milliseconds(30000)).ok());
+
   auto handle1 = store->materialize_replica(make_gpu_key(1), StoreEngine::MaterializeMode::LOAD_ONLY, hints);
 
   LOG(INFO) << "handle0: " << handle0.status().message();
   LOG(INFO) << "handle1: " << handle1.status().message();
-  REQUIRE(handle0.ok());
   REQUIRE(handle1.ok());
 
-  REQUIRE(handle0.value().wait_ready(std::chrono::milliseconds(30000)).ok());
   REQUIRE(handle1.value().wait_ready(std::chrono::milliseconds(30000)).ok());
 
   // Verify full content on both GPUs to ensure data correctness before unload

--- a/core/store/multi_gpu_verification_race_test.cc
+++ b/core/store/multi_gpu_verification_race_test.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "core/common/artifact_verification.h"
+#include "core/store/loader/verification_utils.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+tensorcast::store::loader::verification::MemoryView make_memory_view(std::vector<uint8_t>& data) {
+  tensorcast::store::loader::verification::MemoryView view;
+  view.location = tensorcast::common::memory::MemoryLocation::CPU;
+  view.base_ptr = data.data();
+  view.size_bytes = data.size();
+  return view;
+}
+
+fs::path make_temp_dir(const std::string& suffix) {
+  fs::path dir = fs::temp_directory_path() / suffix;
+  fs::create_directories(dir);
+  return dir;
+}
+
+std::string read_file(const fs::path& path) {
+  std::ifstream in(path);
+  if (!in.is_open()) {
+    return {};
+  }
+  return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+} // namespace
+
+TEST_CASE("Verification metadata guard serializes concurrent GPU loads", "[store][verification][race]") {
+  fs::path base_dir = make_temp_dir("verification_multi_gpu");
+  const int kThreads = 6;
+  const int kRounds = 5;
+
+  std::vector<uint8_t> payload(1024 * 64);
+  for (size_t i = 0; i < payload.size(); ++i) {
+    payload[i] = static_cast<uint8_t>((i * 37) & 0xFF);
+  }
+  auto view = make_memory_view(payload);
+
+  for (int round = 0; round < kRounds; ++round) {
+    fs::path artifact_dir = base_dir / ("round_" + std::to_string(round));
+    fs::create_directories(artifact_dir);
+    const fs::path verification_path = artifact_dir / "verification.json";
+
+    tensorcast::store::loader::verification::ClearVerificationMetadataCacheForTesting();
+
+    std::barrier sync_point(kThreads);
+    std::vector<std::thread> workers;
+    workers.reserve(kThreads);
+    std::atomic<int> failures{0};
+
+    for (int i = 0; i < kThreads; ++i) {
+      workers.emplace_back([&, artifact_dir]() {
+        sync_point.arrive_and_wait();
+        auto status = tensorcast::store::loader::verification::reuse_or_generate_verification_json(
+            artifact_dir,
+            /*expected_byte_space_id=*/"",
+            view);
+        if (!status.ok()) {
+          failures.fetch_add(1, std::memory_order_relaxed);
+        }
+      });
+    }
+
+    for (auto& t : workers) {
+      t.join();
+    }
+
+    REQUIRE(failures.load(std::memory_order_relaxed) == 0);
+    CHECK(fs::exists(verification_path));
+
+    const std::string contents = read_file(verification_path);
+    REQUIRE_FALSE(contents.empty());
+
+    auto info_or = tensorcast::common::ArtifactVerificationInfo::from_json(contents);
+    REQUIRE(info_or.ok());
+    CHECK(info_or->artifact_size == view.size_bytes);
+  }
+
+  fs::remove_all(base_dir);
+}

--- a/core/store/replica/replica_load_controller.cc
+++ b/core/store/replica/replica_load_controller.cc
@@ -11,6 +11,7 @@
 #include "absl/log/absl_check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/substitute.h"
 #include "absl/time/clock.h"
 
@@ -222,8 +223,9 @@ absl::Status ReplicaLoadController::allocate_gpu_memory() {
 
   absl::MutexLock lock(&mutex_);
   gpu_.cuda_mem = *gpu_alloc_result;
-  VLOG(1) << "ReplicaLoadController(" << replica_key_.artifact_id
-          << "): UMA GPU allocation successful (ptr=" << gpu_.cuda_mem->get() << ").";
+  LOG(INFO) << "ReplicaLoadController(" << replica_key_.artifact_id
+            << "): UMA GPU allocation successful (device=" << replica_key_.device.ordinal
+            << ", ptr=" << gpu_.cuda_mem->get() << ", size=" << artifact_size_ << ")";
   return set_state_locked(MemoryLocation::GPU, MemoryState::ALLOCATED);
 }
 
@@ -1276,6 +1278,25 @@ std::future<absl::Status> ReplicaLoadController::load_async_from_source(
         }
         LOG(INFO) << "ReplicaLoadController(" << replica_key_.artifact_id << "): UMA plan_load ok; launching execute";
         auto plan = std::move(*plan_or);
+        {
+          std::string range_str;
+          range_str.reserve(plan.ranges.size() * 32);
+          range_str.append("[");
+          const size_t sample = std::min<size_t>(plan.ranges.size(), 8);
+          for (size_t i = 0; i < sample; ++i) {
+            if (i > 0) {
+              range_str.append(", ");
+            }
+            const auto& r = plan.ranges[i];
+            absl::StrAppend(&range_str, "{off=", r.first, ", len=", r.second, "}");
+          }
+          if (plan.ranges.size() > sample) {
+            range_str.append(", ...");
+          }
+          range_str.append("]");
+          LOG(INFO) << "ReplicaLoadController(" << replica_key_.artifact_id << "): plan ranges device=" << device_id
+                    << " target=" << static_cast<int>(target_location) << " ranges=" << range_str;
+        }
         absl::Status exec_status =
             transfer_service_->execute(plan, target_location, *source, concurrency, gpu_ptr, gpu_allocation, device_id);
         if (!exec_status.ok()) {

--- a/core/store/replica/transfer_service.cc
+++ b/core/store/replica/transfer_service.cc
@@ -12,7 +12,9 @@
 #include "absl/log/log.h"
 #include "absl/log/vlog_is_on.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "core/common/async_copy_manager.h"
 #include "core/common/cuda_api.h"
 #include "core/store/loader/cpu_va_sink.h"
 #include "core/store/loader/file_partition_source.h"
@@ -109,6 +111,33 @@ void GpuSchedHandle::update_inflight_copies_(int device_id, int delta) {
     g_if_copies_gauge->AddCallback(&inflight_copies_callback, nullptr);
   }
 }
+} // namespace
+
+namespace {
+
+absl::Status synchronize_gpu_after_transfer(int device_id, absl::string_view context, uint64_t total_bytes) {
+  if (device_id < 0) {
+    return absl::InvalidArgumentError("GPU synchronize requested with invalid device id");
+  }
+  auto set_dev_status = tensorcast::cuda::set_device(device_id);
+  if (!set_dev_status.ok()) {
+    LOG(ERROR) << context << ": cuda set_device failed for device=" << device_id << ": " << set_dev_status;
+    return set_dev_status;
+  }
+  const auto sync_start = std::chrono::steady_clock::now();
+  auto sync_status = tensorcast::cuda::device_synchronize();
+  const auto sync_end = std::chrono::steady_clock::now();
+  const auto sync_ms = std::chrono::duration_cast<std::chrono::milliseconds>(sync_end - sync_start);
+  if (!sync_status.ok()) {
+    LOG(ERROR) << context << ": device_synchronize failed for device=" << device_id
+               << " duration_ms=" << sync_ms.count() << " status=" << sync_status;
+    return sync_status;
+  }
+  VLOG(1) << context << " cuda synchronize device=" << device_id << " bytes=" << total_bytes
+          << " duration_ms=" << sync_ms.count();
+  return absl::OkStatus();
+}
+
 } // namespace
 
 TransferService::TransferService(
@@ -369,6 +398,12 @@ absl::Status TransferService::load_from_source(
   uint64_t total_bytes = 0;
   for (const auto& r : ranges)
     total_bytes += r.second;
+  if (target_location == MemoryLocation::GPU && total_bytes > 0) {
+    auto sync_status = synchronize_gpu_after_transfer(device_id, "TransferService::load_from_source", total_bytes);
+    if (!sync_status.ok()) {
+      return sync_status;
+    }
+  }
   // Record duration metric
   try {
     auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
@@ -455,6 +490,12 @@ absl::Status TransferService::execute(
   uint64_t total_bytes = 0;
   for (const auto& r : plan.ranges)
     total_bytes += r.second;
+  if (target_location == MemoryLocation::GPU && total_bytes > 0) {
+    auto sync_status = synchronize_gpu_after_transfer(device_id, "TransferService::execute", total_bytes);
+    if (!sync_status.ok()) {
+      return sync_status;
+    }
+  }
   if (target_location == MemoryLocation::GPU && gpu_ptr_or_null != nullptr && device_id >= 0 && total_bytes > 0 &&
       VLOG_IS_ON(1)) {
     constexpr size_t kTailSampleBytes = 16;

--- a/core/store/store_engine.cc
+++ b/core/store/store_engine.cc
@@ -39,17 +39,21 @@
 #include "core/store/replica/replica_config.h"
 // RFC-0007 helpers for safetensors canonical index
 #include <nlohmann/json.hpp>
+#include "core/store/components/eviction_service.h"
 #include "core/store/loader/canonical_index.h"
+#include "core/store/loader/index_reader.h"
 #include "core/store/loader/safetensors_util.h"
 #include "core/store/loader/view_ingest_executor.h"
 #include "core/store/loader/view_plan_source.h"
 #include "core/store/loader/view_planner.h"
 // Unified hashing over SeekableSource for CPU/GPU/P2P
 #include "core/store/loader/source_hash.h"
+#include "core/store/loader/verification_utils.h"
 // SegmentPlan linearization (PAD=0 hashing)
 #include "core/store/loader/segment_plan_source.h"
 #include "core/store/loading/materialize_orchestrator.h"
 #include "core/store/loading/replica_registration_helper.h"
+#include "core/store/view_utils.h"
 #include "gsl/pointers"
 #include "opentelemetry/trace/provider.h"
 #include "opentelemetry/trace/scope.h"
@@ -73,38 +77,6 @@ using replica::Replica;
 
 namespace {
 
-std::string sanitize_view_id_for_filename(const std::string& view_id) {
-  if (view_id.empty()) {
-    return std::string("view");
-  }
-  std::string sanitized;
-  sanitized.reserve(view_id.size());
-  for (char ch : view_id) {
-    const unsigned char u = static_cast<unsigned char>(ch);
-    if ((u >= 'a' && u <= 'z') || (u >= 'A' && u <= 'Z') || (u >= '0' && u <= '9') || ch == '_' || ch == '-' ||
-        ch == '.') {
-      sanitized.push_back(ch);
-    } else {
-      sanitized.push_back('_');
-    }
-  }
-  // Truncate extremely long identifiers from the front to keep filenames manageable.
-  constexpr size_t kMaxSuffixLength = 160;
-  if (sanitized.size() > kMaxSuffixLength) {
-    sanitized.erase(0, sanitized.size() - kMaxSuffixLength);
-  }
-  return sanitized;
-}
-
-std::filesystem::path verification_path_for_view(
-    const std::filesystem::path& artifact_path,
-    const std::optional<std::string>& view_id) {
-  if (!view_id.has_value()) {
-    return artifact_path / "verification.json";
-  }
-  return artifact_path / absl::StrCat("verification.view_", sanitize_view_id_for_filename(*view_id), ".json");
-}
-
 std::optional<std::string> ComputeViewDataHash(
     replica::Replica& replica,
     MemoryLocation location,
@@ -113,6 +85,12 @@ std::optional<std::string> ComputeViewDataHash(
   if (view_size_bytes == 0) {
     return std::nullopt;
   }
+  loader::verification::MemoryView mem_view;
+  mem_view.location = location;
+  mem_view.size_bytes = view_size_bytes;
+  mem_view.gpu_device_id = gpu_device_id;
+  std::shared_ptr<common::memory::GpuDeviceMemory> gpu_guard;
+
   if (location == MemoryLocation::GPU) {
     if (!gpu_device_id.has_value()) {
       return std::nullopt;
@@ -122,168 +100,26 @@ std::optional<std::string> ComputeViewDataHash(
       VLOG(1) << "ComputeViewDataHash: GPU allocation view unavailable";
       return std::nullopt;
     }
-    auto hash_or = loader::compute_data_multihash_from_gpu_memory(
-        gsl::not_null<void*>{view_or->base_ptr}, view_size_bytes, *gpu_device_id);
-    if (!hash_or.ok()) {
-      LOG(WARNING) << "compute_data_multihash_from_gpu_memory (view) failed: " << hash_or.status();
-      return std::nullopt;
-    }
-    return *hash_or;
-  }
-
-  const auto cpu_ptrs = replica.get_memory_manager().get_pointer(MemoryLocation::CPU);
-  if (cpu_ptrs.empty() || cpu_ptrs[0] == nullptr) {
-    VLOG(1) << "ComputeViewDataHash: CPU memory unavailable for view hash";
-    return std::nullopt;
-  }
-  auto hash_or =
-      loader::compute_data_multihash_from_cpu_memory(gsl::not_null<const void*>{cpu_ptrs[0]}, view_size_bytes);
-  if (!hash_or.ok()) {
-    LOG(WARNING) << "compute_data_multihash_from_cpu_memory (view) failed: " << hash_or.status();
-    return std::nullopt;
-  }
-  return *hash_or;
-}
-
-struct TreeHashWithLeaves {
-  std::string multihash;
-  std::vector<std::vector<uint8_t>> leaf_digests;
-};
-
-absl::StatusOr<TreeHashWithLeaves> compute_tree_hash_and_leaves(
-    loader::SeekableSource& source,
-    uint64_t total_size,
-    size_t leaf_chunk_bytes) {
-  if (total_size == 0) {
-    return absl::InvalidArgumentError("total_size must be > 0");
-  }
-  if (leaf_chunk_bytes == 0) {
-    return absl::InvalidArgumentError("leaf_chunk_bytes must be > 0");
-  }
-  std::vector<std::vector<uint8_t>> leaves;
-  leaves.reserve(static_cast<size_t>((total_size + leaf_chunk_bytes - 1) / leaf_chunk_bytes));
-  std::vector<uint8_t> buffer(leaf_chunk_bytes);
-  uint64_t processed = 0;
-  while (processed < total_size) {
-    const size_t to_read = static_cast<size_t>(std::min<uint64_t>(leaf_chunk_bytes, total_size - processed));
-    auto read_or = source.read_at(processed, buffer.data(), to_read);
-    if (!read_or.ok()) {
-      return read_or.status();
-    }
-    const size_t got = read_or.value();
-    if (got == 0) {
-      return absl::DataLossError("short read while computing tree hash");
-    }
-    leaves.push_back(common::sha256_digest_bytes(absl::Span<const uint8_t>(buffer.data(), got)));
-    processed += got;
-  }
-  TreeHashWithLeaves out;
-  out.multihash = common::multibase_multihash_sha256(common::compute_tree_hash_root_sha256(leaves));
-  out.leaf_digests = std::move(leaves);
-  return out;
-}
-
-uint64_t align_up(uint64_t value, uint64_t align) {
-  if (align == 0) {
-    return value;
-  }
-  const uint64_t remainder = value % align;
-  return remainder == 0 ? value : value + (align - remainder);
-}
-
-uint64_t align_down(uint64_t value, uint64_t align) {
-  if (align == 0) {
-    return value;
-  }
-  return value - (value % align);
-}
-
-std::vector<uint64_t> compute_fully_covered_canonical_leaf_indices(
-    absl::Span<const StoreEngine::CanonicalRange> ranges,
-    uint64_t chunk_bytes) {
-  if (chunk_bytes == 0) {
-    return {};
-  }
-  absl::flat_hash_set<uint64_t> indices;
-  for (const auto& range : ranges) {
-    if (range.length == 0) {
-      continue;
-    }
-    const uint64_t range_start = range.offset;
-    const uint64_t range_end = range.offset + range.length;
-    const uint64_t first_full = align_up(range_start, chunk_bytes);
-    const uint64_t last_full = align_down(range_end, chunk_bytes);
-    if (first_full >= last_full) {
-      continue;
-    }
-    for (uint64_t pos = first_full; pos < last_full; pos += chunk_bytes) {
-      indices.insert(pos / chunk_bytes);
-    }
-  }
-  std::vector<uint64_t> sorted(indices.begin(), indices.end());
-  std::sort(sorted.begin(), sorted.end());
-  return sorted;
-}
-
-absl::StatusOr<std::vector<std::vector<uint8_t>>> compute_canonical_leaf_digests(
-    const replica::Replica& replica,
-    bool use_cpu_memory,
-    void* gpu_ptr_hint,
-    int device_id,
-    uint64_t total_size_bytes,
-    absl::Span<const uint64_t> leaf_indices,
-    size_t chunk_bytes) {
-  std::vector<std::vector<uint8_t>> digests;
-  if (leaf_indices.empty()) {
-    return digests;
-  }
-  if (use_cpu_memory) {
+    gpu_guard = view_or->allocation;
+    mem_view.base_ptr = view_or->base_ptr;
+  } else {
     const auto cpu_ptrs = replica.get_memory_manager().get_pointer(MemoryLocation::CPU);
     if (cpu_ptrs.empty() || cpu_ptrs[0] == nullptr) {
-      return absl::FailedPreconditionError("CPU pointer unavailable for canonical leaf digests");
+      VLOG(1) << "ComputeViewDataHash: CPU memory unavailable for view hash";
+      return std::nullopt;
     }
-    const auto* base = static_cast<const uint8_t*>(cpu_ptrs[0]);
-    digests.reserve(leaf_indices.size());
-    for (uint64_t idx : leaf_indices) {
-      const uint64_t offset = idx * chunk_bytes;
-      if (offset + chunk_bytes > total_size_bytes) {
-        continue;
-      }
-      digests.push_back(common::sha256_digest_bytes(absl::Span<const uint8_t>(base + offset, chunk_bytes)));
-    }
-    return digests;
+    mem_view.base_ptr = const_cast<void*>(cpu_ptrs[0]);
   }
-  void* gpu_ptr = gpu_ptr_hint;
-  if (gpu_ptr == nullptr) {
-    const auto gpu_ptrs = replica.get_memory_manager().get_pointer(MemoryLocation::GPU);
-    if (!gpu_ptrs.empty()) {
-      gpu_ptr = gpu_ptrs[0];
+
+  auto hash_or = loader::verification::compute_data_multihash(mem_view);
+  if (!hash_or.ok()) {
+    if (!absl::IsNotFound(hash_or.status())) {
+      LOG(WARNING) << "compute_data_multihash (view) failed: " << hash_or.status();
     }
+    return std::nullopt;
   }
-  if (gpu_ptr == nullptr) {
-    return absl::FailedPreconditionError("GPU pointer unavailable for canonical leaf digests");
-  }
-  std::vector<uint8_t> buffer(chunk_bytes);
-  digests.reserve(leaf_indices.size());
-  for (uint64_t idx : leaf_indices) {
-    const uint64_t offset = idx * chunk_bytes;
-    if (offset + chunk_bytes > total_size_bytes) {
-      continue;
-    }
-    if (auto st = tensorcast::cuda::set_device(device_id); !st.ok()) {
-      return st;
-    }
-    auto copy_status = tensorcast::cuda::memcpy(
-        buffer.data(), static_cast<uint8_t*>(gpu_ptr) + offset, chunk_bytes, cudaMemcpyDeviceToHost);
-    if (!copy_status.ok()) {
-      return copy_status;
-    }
-    if (auto sync_status = tensorcast::cuda::device_synchronize(); !sync_status.ok()) {
-      return sync_status;
-    }
-    digests.push_back(common::sha256_digest_bytes(absl::Span<const uint8_t>(buffer.data(), chunk_bytes)));
-  }
-  return digests;
+  (void)gpu_guard;
+  return *hash_or;
 }
 
 uint64_t sum_view_write_bytes(const loader::ViewWritePlan& write_plan) {
@@ -329,97 +165,10 @@ std::vector<StoreEngine::CanonicalRange> canonical_ranges_from_write_plan(const 
   return merged;
 }
 
-std::string build_view_spec_json(const loader::ViewSpec& spec) {
-  nlohmann::json tensors = nlohmann::json::object();
-  for (const auto& [tensor_name, ops] : spec.tensors) {
-    nlohmann::json tensor_json;
-    nlohmann::json ops_array = nlohmann::json::array();
-    for (const auto& op : ops.ops) {
-      nlohmann::json op_json;
-      switch (op.kind) {
-        case loader::ViewOp::Kind::kNarrow:
-          op_json["type"] = "narrow";
-          op_json["dim"] = op.narrow.dim;
-          op_json["start"] = op.narrow.start;
-          op_json["length"] = op.narrow.length;
-          break;
-        case loader::ViewOp::Kind::kTranspose:
-          op_json["type"] = "transpose";
-          op_json["dim0"] = op.transpose.dim0;
-          op_json["dim1"] = op.transpose.dim1;
-          break;
-      }
-      ops_array.push_back(std::move(op_json));
-    }
-    tensor_json["ops"] = std::move(ops_array);
-    tensors[tensor_name] = std::move(tensor_json);
-  }
-  nlohmann::json root;
-  root["tensors"] = std::move(tensors);
-  return root.dump();
-}
-
 } // namespace
 
 // (hashing utilities moved to core/common/artifact_hash.*)
 // GPU eviction helper kept internal to this translation unit.
-absl::Status try_evict_gpu_memory_impl(
-    ReplicaRegistry& registry,
-    DeviceManager& device_manager,
-    MetricsCollector& metrics,
-    int device_id,
-    size_t required_bytes) {
-  // Query initial free memory so we can track progress.
-  auto free_before_or = device_manager.get_free_memory(device_id);
-  if (!free_before_or.ok()) {
-    return free_before_or.status();
-  }
-  size_t free_before = free_before_or.value();
-
-  // Helper to check whether we have reclaimed enough GPU memory.
-  auto has_freed_enough = [&](size_t free_now) { return (free_now - free_before) >= required_bytes; };
-
-  // Iterate LRU instances – GPU only.
-  auto lru_instances = registry.get_lru_instances();
-  for (const auto& key : lru_instances) {
-    if (key.device.type != DeviceType::GPU || key.device.ordinal != device_id) {
-      continue; // Different device or CPU instance.
-    }
-
-    auto replica_or = registry.find(key);
-    if (!replica_or.ok()) {
-      continue;
-    }
-    const auto& replica = replica_or.value();
-
-    if (replica->get_memory_state(MemoryLocation::GPU) != MemoryState::LOADED) {
-      continue; // Nothing to free.
-    }
-
-    // Attempt to release GPU memory (safe mode to avoid mid-transfer memory).
-    auto st = replica->release_memory(MemoryLocation::GPU);
-    if (!st.ok()) {
-      continue; // Couldn't free – maybe busy.
-    }
-
-    metrics.record_memory_eviction();
-
-    // Update free memory reading.
-    auto free_now_or = device_manager.get_free_memory(device_id);
-    if (!free_now_or.ok()) {
-      // Non-fatal – continue trying.
-      continue;
-    }
-    size_t free_now = free_now_or.value();
-
-    if (has_freed_enough(free_now)) {
-      return absl::OkStatus();
-    }
-  }
-
-  return absl::ResourceExhaustedError("Could not free enough GPU memory for device " + std::to_string(device_id));
-}
-
 // ═══════════════════════════════════════════════════════════════════════════
 // Construction and Destruction
 // ═══════════════════════════════════════════════════════════════════════════
@@ -436,14 +185,18 @@ StoreEngine::StoreEngine(const StoreEngineOptions& opts)
           gsl::not_null<std::unique_ptr<components::DeviceManager>>(std::make_unique<components::DeviceManager>())),
       replica_registry_(
           gsl::not_null<std::unique_ptr<components::ReplicaRegistry>>(std::make_unique<components::ReplicaRegistry>())),
-      metrics_collector_(gsl::not_null<std::unique_ptr<components::MetricsCollector>>(
-          std::make_unique<components::MetricsCollector>())),
-      comm_manager_(gsl::not_null<std::shared_ptr<components::CommunicationManager>>(
-          std::make_shared<components::CommunicationManager>())),
-      memory_pool_(gsl::not_null<std::shared_ptr<common::memory::PinnedBufferPool>>(
-          std::make_shared<common::memory::PinnedBufferPool>(memory_pool_size_, tx_slice_bytes_))),
-      va_space_(gsl::not_null<std::shared_ptr<common::memory::VirtualAddressSpace>>(
-          std::make_shared<common::memory::VirtualAddressSpace>(opts.artifact_chunk_bytes))) {
+      metrics_collector_(
+          gsl::not_null<std::unique_ptr<components::MetricsCollector>>(
+              std::make_unique<components::MetricsCollector>())),
+      comm_manager_(
+          gsl::not_null<std::shared_ptr<components::CommunicationManager>>(
+              std::make_shared<components::CommunicationManager>())),
+      memory_pool_(
+          gsl::not_null<std::shared_ptr<common::memory::PinnedBufferPool>>(
+              std::make_shared<common::memory::PinnedBufferPool>(memory_pool_size_, tx_slice_bytes_))),
+      va_space_(
+          gsl::not_null<std::shared_ptr<common::memory::VirtualAddressSpace>>(
+              std::make_shared<common::memory::VirtualAddressSpace>(opts.artifact_chunk_bytes))) {
   LOG(INFO) << "Initializing StoreEngine with unified Options constructor";
   LOG(INFO) << "Storage path: "
             << (storage_path_.empty() ? "<empty - artifact_identifier will be full path>" : storage_path_.string());
@@ -731,93 +484,43 @@ absl::StatusOr<loading::ReplicaHandle> StoreEngine::ingest_from_disk_internal(
         "artifact_descriptor.json missing schema_version; canonical index v3 required");
   }
   if (descriptor_schema_version.has_value() && *descriptor_schema_version != "v3") {
-    return absl::FailedPreconditionError(absl::StrCat(
-        "Unsupported artifact descriptor schema_version='",
-        *descriptor_schema_version,
-        "'; canonical index v3 is required"));
+    return absl::FailedPreconditionError(
+        absl::StrCat(
+            "Unsupported artifact descriptor schema_version='",
+            *descriptor_schema_version,
+            "'; canonical index v3 is required"));
   }
 
   if (!canonical_index_json.has_value()) {
-    if (is_safetensors) {
-      if (existing_index_mh.has_value()) {
-        computed_index_mh = existing_index_mh;
+    auto index_info_or = loader::read_from_artifact_dir(artifact_path, target_device_id);
+    if (index_info_or.ok()) {
+      const loader::IndexInfo& info = *index_info_or;
+      canonical_index_json = info.canonical_index_json;
+      if (!info.index_multihash.empty()) {
+        computed_index_mh = info.index_multihash;
       }
-      std::vector<std::filesystem::path> st_files;
-      for (const auto& entry : std::filesystem::directory_iterator(artifact_path)) {
-        if (entry.is_regular_file()) {
-          const auto name = entry.path().filename().string();
-          if (name.ends_with(".safetensors")) {
-            st_files.push_back(entry.path());
-          }
-        }
-      }
-      auto index_bytes_or = loader::BuildCanonicalIndexFromSafetensors(st_files);
-      if (index_bytes_or.ok()) {
-        canonical_index_json = index_bytes_or.value();
-        if (!computed_index_mh.has_value()) {
-          auto index_mh_or = common::compute_index_multihash(std::optional<std::string>(*canonical_index_json), "");
-          if (index_mh_or.ok()) {
-            computed_index_mh = *index_mh_or;
-          } else {
-            LOG(WARNING) << "Index multihash computation failed: " << index_mh_or.status();
-          }
-        }
-        try {
-          nlohmann::json idx_json = nlohmann::json::parse(*canonical_index_json, nullptr, true);
-          for (auto it = idx_json.begin(); it != idx_json.end(); ++it) {
-            const auto& arr = it.value();
-            if (!arr.is_array() || arr.size() < 2) {
-              continue;
-            }
-            uint64_t off = arr[0].get<uint64_t>();
-            uint64_t sz = arr[1].get<uint64_t>();
-            logical_total_size = std::max<uint64_t>(logical_total_size, off + sz);
-          }
-        } catch (const std::exception& e) {
-          LOG(WARNING) << "Failed to parse canonical index for total_size: " << e.what();
-        }
-      } else {
-        LOG(WARNING) << "Failed to build canonical index from safetensors: " << index_bytes_or.status();
-      }
-    } else {
-      const auto index_json_path = artifact_path / "tensor_index.json";
-      try {
-        std::string raw_json;
-        if (std::filesystem::exists(index_json_path)) {
-          std::ifstream f(index_json_path);
-          nlohmann::json j;
-          f >> j;
-          raw_json = j.dump();
-        }
-        if (!raw_json.empty()) {
-          auto rebuilt_or = loader::rebuild_stable_canonical_index(raw_json, target_device_id);
-          const std::string& canonical_json = rebuilt_or.ok() ? *rebuilt_or : raw_json;
-          canonical_index_json = canonical_json;
-          auto index_mh_or = common::compute_index_multihash(std::optional<std::string>(canonical_json), "");
-          if (index_mh_or.ok()) {
-            computed_index_mh = *index_mh_or;
-          } else {
-            LOG(WARNING) << "Index multihash computation failed: " << index_mh_or.status();
-          }
-          try {
-            nlohmann::json idx_json = nlohmann::json::parse(canonical_json);
-            for (auto it = idx_json.begin(); it != idx_json.end(); ++it) {
-              const auto& arr = it.value();
-              if (!arr.is_array() || arr.size() < 2) {
-                continue;
-              }
-              uint64_t off = arr[0].get<uint64_t>();
-              uint64_t sz = arr[1].get<uint64_t>();
-              logical_total_size = std::max<uint64_t>(logical_total_size, off + sz);
-            }
-          } catch (const std::exception& e) {
-            LOG(WARNING) << "Failed to parse canonical index JSON for total_size: " << e.what();
-          }
-        }
-      } catch (const std::exception& e) {
-        LOG(WARNING) << "Failed to read/parse tensor_index.json: " << e.what();
-      }
+      logical_total_size = std::max<uint64_t>(logical_total_size, info.total_size_bytes);
+      is_safetensors = info.is_safetensors;
+    } else if (!absl::IsNotFound(index_info_or.status())) {
+      LOG(WARNING) << "Failed to resolve canonical index for '" << artifact_path.string()
+                   << "': " << index_info_or.status();
     }
+  } else {
+    auto info_or = loader::canonicalize_from_raw_json(*canonical_index_json, target_device_id);
+    if (info_or.ok()) {
+      const loader::IndexInfo& info = *info_or;
+      canonical_index_json = info.canonical_index_json;
+      if (!computed_index_mh.has_value() && !info.index_multihash.empty()) {
+        computed_index_mh = info.index_multihash;
+      }
+      logical_total_size = std::max<uint64_t>(logical_total_size, info.total_size_bytes);
+    } else if (!absl::IsNotFound(info_or.status())) {
+      LOG(WARNING) << "Failed to canonicalize index JSON: " << info_or.status();
+    }
+  }
+
+  if (!computed_index_mh.has_value() && existing_index_mh.has_value()) {
+    computed_index_mh = existing_index_mh;
   }
 
   if (!resolved_view_plan.has_value() && hints.variant.has_value()) {
@@ -898,7 +601,7 @@ absl::StatusOr<loading::ReplicaHandle> StoreEngine::ingest_from_disk_internal(
                  << "). Attempting GPU eviction on device " << target_device_id << " for ~" << required_bytes
                  << " bytes.";
 
-    auto evict_st = try_evict_gpu_memory_impl(
+    auto evict_st = components::evict_for_gpu(
         *replica_registry_, *device_manager_, *metrics_collector_, target_device_id, required_bytes);
 
     if (evict_st.ok()) {
@@ -980,89 +683,16 @@ absl::StatusOr<loading::ReplicaHandle> StoreEngine::ingest_from_disk_internal(
     }
   }
 
-  // Compute or obtain index multihash
-  if (is_safetensors) {
-    if (existing_index_mh.has_value()) {
-      computed_index_mh = existing_index_mh; // trust descriptor when present
-    }
-    std::vector<std::filesystem::path> st_files;
-    for (const auto& entry : std::filesystem::directory_iterator(artifact_path)) {
-      if (entry.is_regular_file()) {
-        const auto name = entry.path().filename().string();
-        if (name.ends_with(".safetensors")) {
-          st_files.push_back(entry.path());
-        }
+  // Compute or obtain index multihash if still missing
+  if (!computed_index_mh.has_value() && canonical_index_json.has_value()) {
+    auto meta_or = loader::canonicalize_from_raw_json(*canonical_index_json, target_device_id);
+    if (meta_or.ok()) {
+      if (!meta_or->index_multihash.empty()) {
+        computed_index_mh = meta_or->index_multihash;
       }
-    }
-    auto index_bytes_or = loader::BuildCanonicalIndexFromSafetensors(st_files);
-    if (index_bytes_or.ok()) {
-      canonical_index_json = index_bytes_or.value();
-      if (!computed_index_mh.has_value()) {
-        auto index_mh_or = common::compute_index_multihash(std::optional<std::string>(*canonical_index_json), "");
-        if (index_mh_or.ok()) {
-          computed_index_mh = *index_mh_or;
-        } else {
-          LOG(WARNING) << "Index multihash computation failed: " << index_mh_or.status();
-        }
-      }
-      try {
-        nlohmann::json idx_json = nlohmann::json::parse(*canonical_index_json, nullptr, true);
-        for (auto it = idx_json.begin(); it != idx_json.end(); ++it) {
-          const auto& arr = it.value();
-          if (!arr.is_array() || arr.size() < 2) {
-            continue;
-          }
-          uint64_t off = arr[0].get<uint64_t>();
-          uint64_t sz = arr[1].get<uint64_t>();
-          logical_total_size = std::max<uint64_t>(logical_total_size, off + sz);
-        }
-      } catch (const std::exception& e) {
-        LOG(WARNING) << "Failed to parse canonical index for total_size: " << e.what();
-      }
-    } else {
-      LOG(WARNING) << "Failed to build canonical index from safetensors: " << index_bytes_or.status();
-    }
-  } else {
-    // Standard partition format – read tensor_index.json and canonicalize bytes via nlohmann::json
-    const auto index_json_path = artifact_path / "tensor_index.json";
-    try {
-      // Read canonical index (JSON), then rebuild with stable grouping
-      std::string raw_json;
-      if (std::filesystem::exists(index_json_path)) {
-        std::ifstream f(index_json_path);
-        nlohmann::json j;
-        f >> j;
-        raw_json = j.dump();
-      }
-      if (!raw_json.empty()) {
-        // Apply stable canonicalization using C++ authority
-        auto rebuilt_or = loader::rebuild_stable_canonical_index(raw_json, target_device_id);
-        const std::string& canonical_json = rebuilt_or.ok() ? *rebuilt_or : raw_json;
-        canonical_index_json = canonical_json;
-        auto index_mh_or = common::compute_index_multihash(std::optional<std::string>(canonical_json), "");
-        if (index_mh_or.ok()) {
-          computed_index_mh = *index_mh_or;
-        } else {
-          LOG(WARNING) << "Index multihash computation failed: " << index_mh_or.status();
-        }
-        // Determine logical total size from canonical index JSON
-        try {
-          nlohmann::json idx_json = nlohmann::json::parse(canonical_json);
-          for (auto it = idx_json.begin(); it != idx_json.end(); ++it) {
-            const auto& arr = it.value();
-            if (!arr.is_array() || arr.size() < 2) {
-              continue;
-            }
-            uint64_t off = arr[0].get<uint64_t>();
-            uint64_t sz = arr[1].get<uint64_t>();
-            logical_total_size = std::max<uint64_t>(logical_total_size, off + sz);
-          }
-        } catch (const std::exception& e) {
-          LOG(WARNING) << "Failed to parse canonical index JSON for total_size: " << e.what();
-        }
-      }
-    } catch (const std::exception& e) {
-      LOG(WARNING) << "Failed to read/parse tensor_index.json: " << e.what();
+      logical_total_size = std::max<uint64_t>(logical_total_size, meta_or->total_size_bytes);
+    } else if (!absl::IsNotFound(meta_or.status())) {
+      LOG(WARNING) << "Failed to recompute canonical index metadata: " << meta_or.status();
     }
   }
 
@@ -1190,109 +820,39 @@ absl::StatusOr<loading::ReplicaHandle> StoreEngine::ingest_from_disk_internal(
 
   // Default post-load lightweight verification when descriptor is present
   if (std::filesystem::exists(descriptor_path) && allow_verification_metadata) {
-    try {
-      struct VerificationBuffers {
-        std::vector<void*> ptrs;
-        std::vector<size_t> sizes;
-        int device_id{-1};
-        uint64_t total_size{0};
-        std::shared_ptr<common::memory::GpuDeviceMemory> gpu_guard;
-      };
-
-      auto prepare_buffers = [&]() -> VerificationBuffers {
-        VerificationBuffers buffers;
-        uint64_t resolved_size = 0;
-        if (auto sz_or = replica->get_artifact_size(); sz_or.ok()) {
-          resolved_size = *sz_or;
-        } else {
-          resolved_size = logical_total_size;
-        }
-        buffers.total_size = resolved_size;
-        if (target_location == MemoryLocation::GPU && buffers.total_size > 0) {
-          auto view_or = replica->get_memory_manager().get_gpu_allocation_view();
-          if (view_or.ok()) {
-            buffers.ptrs.push_back(view_or->base_ptr);
-            buffers.sizes.push_back(static_cast<size_t>(buffers.total_size));
-            buffers.device_id = target_device_id;
-            buffers.gpu_guard = view_or->allocation;
-          }
-        } else {
-          const auto cpu_ptrs = replica->get_memory_manager().get_pointer(MemoryLocation::CPU);
-          if (!cpu_ptrs.empty() && cpu_ptrs[0] != nullptr && buffers.total_size > 0) {
-            buffers.ptrs.push_back(cpu_ptrs[0]);
-            buffers.sizes.push_back(static_cast<size_t>(buffers.total_size));
-          }
-        }
-        return buffers;
-      };
-
-      const auto verification_path = verification_path_for_view(artifact_path, requested_view_id);
-      bool regenerate_metadata = !std::filesystem::exists(verification_path);
-      bool metadata_verified = false;
-
-      if (!regenerate_metadata) {
-        std::ifstream vf(verification_path);
-        if (vf.is_open()) {
-          std::stringstream vbuf;
-          vbuf << vf.rdbuf();
-          vf.close();
-          auto ver_or = common::ArtifactVerificationInfo::from_json(vbuf.str());
-          if (ver_or.ok()) {
-            const common::ArtifactVerificationInfo& info = *ver_or;
-            if ((!expected_byte_space_id.empty() || !info.byte_space_id.empty()) &&
-                info.byte_space_id != expected_byte_space_id) {
-              LOG(WARNING) << "Verification metadata at '" << verification_path.string()
-                           << "' was recorded for byte_space_id='" << info.byte_space_id << "', expected '"
-                           << expected_byte_space_id << "'; regenerating.";
-              regenerate_metadata = true;
-            } else {
-              auto buffers = prepare_buffers();
-              if (!buffers.ptrs.empty()) {
-                absl::Status vstatus = common::ArtifactVerifier::verify_artifact_data(
-                    buffers.ptrs, buffers.sizes, info, common::VerificationLevel::SEGMENT_HASHES, buffers.device_id);
-                if (!vstatus.ok()) {
-                  return absl::DataLossError(
-                      absl::StrCat("ARTIFACT_ID_MISMATCH: verification failed: ", vstatus.message()));
-                }
-                metadata_verified = true;
-              } else {
-                metadata_verified = true; // Nothing to verify (empty replica)
-              }
-            }
-          } else {
-            LOG(WARNING) << "Failed to parse verification metadata at '" << verification_path.string()
-                         << "': " << ver_or.status();
-            regenerate_metadata = true;
-          }
-        } else {
-          regenerate_metadata = true;
-        }
-      }
-
-      if (!metadata_verified && regenerate_metadata) {
-        auto buffers = prepare_buffers();
-        if (!buffers.ptrs.empty()) {
-          auto gen_or = common::ArtifactVerifier::generate_verification_info(
-              buffers.ptrs, buffers.sizes, buffers.device_id, common::VerificationLevel::SEGMENT_HASHES);
-          if (gen_or.ok()) {
-            auto info = *gen_or;
-            info.byte_space_id = expected_byte_space_id;
-            try {
-              std::ofstream vf(verification_path, std::ios::trunc);
-              if (vf.is_open()) {
-                vf << info.to_json();
-                vf.close();
-              }
-            } catch (const std::exception& e) {
-              LOG(WARNING) << "Failed to persist verification metadata at '" << verification_path.string()
-                           << "': " << e.what();
-            }
-          }
-        }
-      }
-    } catch (const std::exception& e) {
-      LOG(WARNING) << "Post-load verification skipped due to error: " << e.what();
+    uint64_t resolved_size = 0;
+    if (auto sz_or = replica->get_artifact_size(); sz_or.ok()) {
+      resolved_size = *sz_or;
+    } else {
+      resolved_size = logical_total_size;
     }
+
+    loader::verification::MemoryView verification_view;
+    verification_view.location = target_location;
+    verification_view.size_bytes = resolved_size;
+    verification_view.gpu_device_id =
+        (target_location == MemoryLocation::GPU) ? std::optional<int>(target_device_id) : std::nullopt;
+    std::shared_ptr<common::memory::GpuDeviceMemory> metadata_gpu_guard;
+
+    if (target_location == MemoryLocation::GPU && verification_view.size_bytes > 0) {
+      auto view_or = replica->get_memory_manager().get_gpu_allocation_view();
+      if (view_or.ok()) {
+        metadata_gpu_guard = view_or->allocation;
+        verification_view.base_ptr = view_or->base_ptr;
+      }
+    } else if (target_location == MemoryLocation::CPU && verification_view.size_bytes > 0) {
+      const auto cpu_ptrs = replica->get_memory_manager().get_pointer(MemoryLocation::CPU);
+      if (!cpu_ptrs.empty() && cpu_ptrs[0] != nullptr) {
+        verification_view.base_ptr = const_cast<void*>(cpu_ptrs[0]);
+      }
+    }
+
+    auto verification_status = loader::verification::reuse_or_generate_verification_json(
+        artifact_path, expected_byte_space_id, verification_view);
+    if (!verification_status.ok()) {
+      return verification_status;
+    }
+    (void)metadata_gpu_guard;
   } else if (std::filesystem::exists(descriptor_path) && !allow_verification_metadata) {
     VLOG(1) << "Skipping verification metadata reuse for unnamed view variant (no view_id provided).";
   }
@@ -1308,82 +868,43 @@ absl::StatusOr<loading::ReplicaHandle> StoreEngine::ingest_from_disk_internal(
         }
       }
       if (total > 0) {
+        loader::verification::MemoryView data_view;
+        data_view.location = target_location;
+        data_view.size_bytes = total;
+        data_view.gpu_device_id =
+            (target_location == MemoryLocation::GPU) ? std::optional<int>(target_device_id) : std::nullopt;
+        std::shared_ptr<common::memory::GpuDeviceMemory> data_gpu_guard;
         if (target_location == MemoryLocation::GPU) {
           auto view_or = replica->get_memory_manager().get_gpu_allocation_view();
           if (view_or.ok()) {
-            [[maybe_unused]] auto keep_gpu_allocation = view_or->allocation;
-            auto mh_or = loader::compute_data_multihash_from_gpu_memory(
-                gsl::not_null<void*>{view_or->base_ptr}, total, target_device_id);
-            if (mh_or.ok()) {
-              computed_data_mh = *mh_or;
-            }
+            data_gpu_guard = view_or->allocation;
+            data_view.base_ptr = view_or->base_ptr;
           }
         } else {
           const auto cpu_ptrs = replica->get_memory_manager().get_pointer(MemoryLocation::CPU);
           if (!cpu_ptrs.empty() && cpu_ptrs[0] != nullptr) {
-            auto mh_or = loader::compute_data_multihash_from_cpu_memory(gsl::not_null<const void*>{cpu_ptrs[0]}, total);
-            if (mh_or.ok()) {
-              computed_data_mh = *mh_or;
-            }
+            data_view.base_ptr = const_cast<void*>(cpu_ptrs[0]);
           }
         }
+        auto mh_or = loader::verification::compute_data_multihash(data_view);
+        if (mh_or.ok()) {
+          computed_data_mh = mh_or.value();
+        }
+        (void)data_gpu_guard;
       }
     }
 
     if (computed_index_mh.has_value() && computed_data_mh.has_value()) {
-      try {
-        // 1) Persist artifact_descriptor.json
-        nlohmann::json j;
-        j["artifact_id"] = std::string("mi2:") + *computed_index_mh + ":" + *computed_data_mh;
-        j["index_multihash"] = *computed_index_mh;
-        j["data_multihash"] = *computed_data_mh;
-        j["schema_version"] = "v3";
-        // Encoding is JSON only per project decision
-        const auto index_json_path = artifact_path / "tensor_index.json";
-        j["encoding"] = "json";
-        uint64_t total_for_desc = logical_total_size;
-        if (total_for_desc == 0) {
-          if (auto sz_or = replica->get_artifact_size(); sz_or.ok()) {
-            total_for_desc = *sz_or;
-          }
+      uint64_t total_for_desc = logical_total_size;
+      if (total_for_desc == 0) {
+        if (auto sz_or = replica->get_artifact_size(); sz_or.ok()) {
+          total_for_desc = *sz_or;
         }
-        j["total_size"] = total_for_desc;
-        nlohmann::json hp;
-        hp["chunk_size"] = 4 * 1024 * 1024;
-        hp["fanout"] = 2;
-        hp["algorithm"] = "sha2-256";
-        j["hash_params"] = hp;
-        std::ofstream of(descriptor_path);
-        if (!of.is_open()) {
-          return absl::PermissionDeniedError("DESCRIPTOR_NOT_WRITABLE: cannot write artifact_descriptor.json");
-        }
-        of << j.dump(2);
-
-        // 2) Optionally persist canonical index (JSON) if not already present
-        if (!std::filesystem::exists(index_json_path)) {
-          // Rebuild canonical index bytes from safetensors headers
-          std::vector<std::filesystem::path> st_files;
-          for (const auto& entry : std::filesystem::directory_iterator(artifact_path)) {
-            if (entry.is_regular_file()) {
-              const auto name = entry.path().filename().string();
-              if (name.ends_with(".safetensors")) {
-                st_files.push_back(entry.path());
-              }
-            }
-          }
-          auto index_bytes_or = loader::BuildCanonicalIndexFromSafetensors(st_files);
-          if (index_bytes_or.ok()) {
-            // Write JSON index directly
-            std::ofstream oj(index_json_path);
-            if (!oj.is_open()) {
-              return absl::PermissionDeniedError("DESCRIPTOR_NOT_WRITABLE: cannot write tensor_index.json");
-            }
-            oj << index_bytes_or.value();
-            oj.close();
-          }
-        }
-      } catch (const std::exception& e) {
-        return absl::PermissionDeniedError(std::string("DESCRIPTOR_NOT_WRITABLE: ") + e.what());
+      }
+      auto desc_status = loader::verification::write_descriptor_if_absent(
+          artifact_path, *computed_index_mh, *computed_data_mh, total_for_desc, "json");
+      if (!desc_status.ok()) {
+        return desc_status;
       }
     }
   }
@@ -1703,38 +1224,7 @@ std::shared_ptr<replica::Replica> StoreEngine::get_or_create_replica(
 }
 
 absl::Status StoreEngine::try_evict_memory_for_replica(size_t required_size) {
-  // Prefer the new multi-device LRU ordering.
-  auto lru_instances = replica_registry_->get_lru_instances();
-
-  for (const auto& inst_key : lru_instances) {
-    auto replica_or = replica_registry_->find(inst_key);
-    if (!replica_or.ok()) {
-      continue;
-    }
-
-    const auto& replica = replica_or.value();
-
-    // Only attempt to free CPU memory for now – GPU eviction will be handled
-    // in a future iteration.
-    auto free_status = replica->release_memory(common::memory::MemoryLocation::CPU);
-    if (free_status.ok()) {
-      metrics_collector_->record_memory_eviction();
-      LOG(INFO) << "Evicted replica " << inst_key.artifact_id
-                << " (device=" << (inst_key.device.type == DeviceType::CPU ? "CPU" : "GPU") << ":"
-                << inst_key.device.ordinal << ") from CPU memory";
-
-      // Check if we have freed enough memory.
-      if (memory_pool_->get_available_size() >= required_size) {
-        return absl::OkStatus();
-      }
-    }
-  }
-
-  // No further legacy fallbacks – the new multi-device registry covers all
-  // cases.  If eviction above fails to free enough memory, report resource
-  // exhaustion.
-
-  return absl::ResourceExhaustedError("Could not free enough memory");
+  return components::evict_for_cpu(*replica_registry_, *memory_pool_, *metrics_collector_, required_size);
 }
 
 size_t StoreEngine::get_num_chunk_from_tensor_size(size_t tensor_size) const {
@@ -1906,7 +1396,7 @@ absl::StatusOr<ReplicaHandle> StoreEngine::materialize_replica(
       // Require an explicit artifact identifier so we can locate a source instance.
       // This avoids implicit coupling to disk_path or other hints and keeps COPY_ONLY semantics clear.
       if (canonical_artifact_id.empty()) {
-        return absl::InvalidArgumentError("COPY_ONLY requires a canonical artifact identifier");
+        return absl::InvalidArgumentError("COPY_ONLY requires hints.artifact_id (canonical artifact identifier)");
       }
 
       const auto candidates = replica_registry_->find_by_artifact(canonical_artifact_id);
@@ -1998,12 +1488,13 @@ absl::StatusOr<ReplicaHandle> StoreEngine::materialize_replica(
         }
         return handle;
       }
-      return absl::FailedPreconditionError(absl::StrCat(
-          "No suitable source instance for COPY_ONLY mode (artifact_id=",
-          canonical_artifact_id,
-          ", view_id=",
-          requested_view_id.has_value() ? *requested_view_id : std::string("<none>"),
-          ")"));
+      return absl::FailedPreconditionError(
+          absl::StrCat(
+              "No suitable source instance for COPY_ONLY mode (artifact_id=",
+              canonical_artifact_id,
+              ", view_id=",
+              requested_view_id.has_value() ? *requested_view_id : std::string("<none>"),
+              ")"));
     }
 
     case MaterializeMode::LOAD_ONLY: {
@@ -2448,12 +1939,13 @@ absl::StatusOr<StoreEngine::RegistrationBeginResult> StoreEngine::begin_register
     if (view_opts.placement == ViewPlacement::kServer && view_plan->inverse_transform.requires_materialization) {
       auto info_or = device_manager_->get_gpu_info(reg.device_id);
       if (!info_or.ok()) {
-        return absl::FailedPreconditionError(absl::StrCat(
-            "SERVER placement for view registration requires GPU transpose support on device ",
-            reg.device_id,
-            "; retry with placement=CLIENT (",
-            info_or.status().message(),
-            ")"));
+        return absl::FailedPreconditionError(
+            absl::StrCat(
+                "SERVER placement for view registration requires GPU transpose support on device ",
+                reg.device_id,
+                "; retry with placement=CLIENT (",
+                info_or.status().message(),
+                ")"));
       }
     }
   }
@@ -2480,20 +1972,21 @@ absl::StatusOr<StoreEngine::RegistrationBeginResult> StoreEngine::begin_register
       size_t free_bytes = free_or.value();
       if (reg.total_size_bytes > free_bytes) {
         // Try to evict unused GPU memory first on the specific device
-        auto evict_status = try_evict_gpu_memory_impl(
+        auto evict_status = components::evict_for_gpu(
             *replica_registry_,
             *device_manager_,
             *metrics_collector_,
             reg.device_id,
             reg.total_size_bytes - free_bytes);
         if (!evict_status.ok()) {
-          return absl::ResourceExhaustedError(absl::StrCat(
-              "Insufficient GPU memory available. Requested: ",
-              reg.total_size_bytes,
-              " bytes, Free: ",
-              free_bytes,
-              ". ",
-              evict_status.message()));
+          return absl::ResourceExhaustedError(
+              absl::StrCat(
+                  "Insufficient GPU memory available. Requested: ",
+                  reg.total_size_bytes,
+                  " bytes, Free: ",
+                  free_bytes,
+                  ". ",
+                  evict_status.message()));
         }
       }
     }
@@ -2630,11 +2123,12 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
       return absl::FailedPreconditionError("view executor missing for server placement registration");
     }
     if (!view_state.executor->is_complete()) {
-      return absl::FailedPreconditionError(absl::StrCat(
-          "view bytes incomplete; expected ",
-          view_state.expected_view_bytes,
-          " received ",
-          view_state.executor->ingested_bytes()));
+      return absl::FailedPreconditionError(
+          absl::StrCat(
+              "view bytes incomplete; expected ",
+              view_state.expected_view_bytes,
+              " received ",
+              view_state.executor->ingested_bytes()));
     }
     auto finalize_status = view_state.executor->finalize(MemoryLocation::GPU, entry->gpu_ptr, entry->device_id);
     if (!finalize_status.ok()) {
@@ -2898,7 +2392,7 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
         LOG(WARNING) << "Failed to rebuild segment plan for view hash: " << plan_or.status();
       }
     }
-    view_spec_json = build_view_spec_json(entry->view_state->options.spec);
+    view_spec_json = view::build_view_spec_json(entry->view_state->options.spec);
     leaf_chunk_bytes =
         options_.artifact_chunk_bytes == 0 ? static_cast<size_t>(4ULL * 1024 * 1024) : options_.artifact_chunk_bytes;
 
@@ -2914,7 +2408,7 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
             gsl::not_null<void*>{gpu_ptr}, entry->device_id, absl::MakeSpan(segment_plan), entry->size_bytes);
         loader::ViewPlanSource view_source(
             gsl::not_null<loader::SeekableSource*>{&canonical_source}, entry->view_state->plan.forward.selection);
-        auto view_hash_or = compute_tree_hash_and_leaves(
+        auto view_hash_or = loader::verification::compute_view_tree_hash_and_leaves(
             view_source, entry->view_state->plan.forward.selection.total_bytes, *leaf_chunk_bytes);
         if (view_hash_or.ok()) {
           view_data_hash = view_hash_or->multihash;
@@ -2934,19 +2428,32 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
         }
       }
     }
-    canonical_leaf_indices = compute_fully_covered_canonical_leaf_indices(
+    canonical_leaf_indices = view::compute_fully_covered_canonical_leaf_indices(
         entry->view_state->options.canonical_ranges, leaf_chunk_bytes.value_or(0));
   }
 
   if (entry->view_state && leaf_chunk_bytes.has_value() && !canonical_leaf_indices.empty()) {
-    auto canonical_digest_or = compute_canonical_leaf_digests(
-        *entry->replica,
-        entry->plan == PendingRegistrationEntry::Plan::CPU,
-        entry->gpu_ptr,
-        entry->device_id,
-        entry->size_bytes,
-        canonical_leaf_indices,
-        *leaf_chunk_bytes);
+    loader::verification::MemoryView canonical_view;
+    canonical_view.size_bytes = entry->size_bytes;
+    if (entry->plan == PendingRegistrationEntry::Plan::CPU) {
+      canonical_view.location = MemoryLocation::CPU;
+      const auto cpu_ptrs = entry->replica->get_memory_manager().get_pointer(MemoryLocation::CPU);
+      if (!cpu_ptrs.empty() && cpu_ptrs[0] != nullptr) {
+        canonical_view.base_ptr = const_cast<void*>(cpu_ptrs[0]);
+      }
+    } else {
+      canonical_view.location = MemoryLocation::GPU;
+      canonical_view.gpu_device_id = entry->device_id;
+      void* gpu_ptr = entry->gpu_ptr;
+      if (gpu_ptr == nullptr) {
+        const auto ptrs = entry->replica->get_memory_manager().get_pointer(MemoryLocation::GPU);
+        gpu_ptr = (!ptrs.empty() ? ptrs[0] : nullptr);
+      }
+      canonical_view.base_ptr = gpu_ptr;
+    }
+
+    auto canonical_digest_or = loader::verification::compute_canonical_leaf_digests(
+        canonical_view, absl::Span<const uint64_t>(canonical_leaf_indices), *leaf_chunk_bytes);
     if (!canonical_digest_or.ok()) {
       LOG(WARNING) << "Failed to compute canonical leaf digests for view registration: "
                    << canonical_digest_or.status();
@@ -3006,7 +2513,7 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
     components::VariantViewUpdate update;
     update.artifact_id = entry->artifact_id;
     update.view_id = entry->view_state->options.view_id;
-    update.view_spec_json = view_spec_json.value_or(build_view_spec_json(entry->view_state->options.spec));
+    update.view_spec_json = view_spec_json.value_or(view::build_view_spec_json(entry->view_state->options.spec));
     update.view_size_bytes = entry->view_state->plan.forward.view_size_bytes;
     update.view_data_hash = view_data_hash;
     update.mark_verified = true;
@@ -3114,7 +2621,12 @@ absl::StatusOr<std::string> StoreEngine::compute_view_data_hash_from_source(
     return absl::InvalidArgumentError("view plan selection has zero length");
   }
   loader::ViewPlanSource view_source(gsl::not_null<loader::SeekableSource*>{&base_source}, plan.selection);
-  return loader::compute_data_multihash_from_seekable_source(view_source, plan.selection.total_bytes, leaf_chunk_bytes);
+  auto hash_or = loader::verification::compute_view_tree_hash_and_leaves(
+      view_source, plan.selection.total_bytes, leaf_chunk_bytes);
+  if (!hash_or.ok()) {
+    return hash_or.status();
+  }
+  return hash_or->multihash;
 }
 
 absl::Status StoreEngine::abort_registered_artifact(std::string_view registration_id) {

--- a/core/store/store_engine.h
+++ b/core/store/store_engine.h
@@ -26,6 +26,7 @@
 #include "core/store/replica/memory_state.h"
 #include "core/store/replica/replica.h"
 #include "core/store/store_engine_options.h"
+#include "core/store/view_utils.h"
 #include "gsl/pointers"
 
 namespace tensorcast::store {
@@ -110,10 +111,7 @@ class StoreEngine {
 
   enum class ViewPlacement : uint8_t { kUnspecified = 0, kServer = 1, kClient = 2 };
 
-  struct CanonicalRange {
-    uint64_t offset{0};
-    uint64_t length{0};
-  };
+  using CanonicalRange = view::CanonicalRange;
 
   struct ViewRegistration {
     std::string view_id;

--- a/core/store/store_engine_verification_default_test.cc
+++ b/core/store/store_engine_verification_default_test.cc
@@ -9,6 +9,7 @@
 #include <nlohmann/json.hpp>
 
 #include "absl/status/status.h"
+#include "core/common/artifact_verification.h"
 #include "core/store/store_engine.h"
 #include "core/store/store_engine_options.h"
 #include "core/testing/common.h"
@@ -76,16 +77,16 @@ TEST_CASE("Post-load verification generation and enforcement", "[store_engine][v
   REQUIRE(tensorcast::testing::write_rfc0007_descriptor_for_standard_artifact_dir(artifact_dir2).ok());
 
   // Write a bad verification.json (wrong key_values ensures failure)
-  nlohmann::json bad;
-  bad["version"] = "1.0";
-  bad["artifact_size"] = artifact_size;
-  bad["full_hash"] = 0ULL;
-  bad["segment_hashes"] = std::vector<uint64_t>(8, 0ULL);
-  bad["sample_values"] = std::vector<uint64_t>(16, 0ULL);
-  bad["key_values"] = std::vector<uint64_t>{1ULL, 2ULL, 3ULL};
+  tensorcast::common::ArtifactVerificationInfo bad_info;
+  bad_info.artifact_size = artifact_size;
+  bad_info.full_hash = 0ULL;
+  bad_info.segment_hashes.fill(0ULL);
+  bad_info.sample_values.fill(0ULL);
+  bad_info.key_values = {1ULL, 2ULL, 3ULL};
+  bad_info.refresh_metadata_signature();
   std::ofstream out(artifact_dir2 / "verification.json");
   REQUIRE(out.is_open());
-  out << bad.dump(2);
+  out << bad_info.to_json();
   out.close();
 
   tensorcast::store::loading::MaterializeHints hints2;

--- a/core/store/view_utils.cc
+++ b/core/store/view_utils.cc
@@ -1,0 +1,84 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/store/view_utils.h"
+
+#include <algorithm>
+
+#include "absl/container/flat_hash_set.h"
+#include "nlohmann/json.hpp"
+
+namespace tensorcast::store::view {
+
+std::string build_view_spec_json(const loader::ViewSpec& spec) {
+  nlohmann::json tensors = nlohmann::json::object();
+  for (const auto& [tensor_name, ops] : spec.tensors) {
+    nlohmann::json tensor_json;
+    nlohmann::json ops_array = nlohmann::json::array();
+    for (const auto& op : ops.ops) {
+      nlohmann::json op_json;
+      switch (op.kind) {
+        case loader::ViewOp::Kind::kNarrow:
+          op_json["type"] = "narrow";
+          op_json["dim"] = op.narrow.dim;
+          op_json["start"] = op.narrow.start;
+          op_json["length"] = op.narrow.length;
+          break;
+        case loader::ViewOp::Kind::kTranspose:
+          op_json["type"] = "transpose";
+          op_json["dim0"] = op.transpose.dim0;
+          op_json["dim1"] = op.transpose.dim1;
+          break;
+      }
+      ops_array.push_back(std::move(op_json));
+    }
+    tensor_json["ops"] = std::move(ops_array);
+    tensors[tensor_name] = std::move(tensor_json);
+  }
+  nlohmann::json root;
+  root["tensors"] = std::move(tensors);
+  return root.dump();
+}
+
+uint64_t align_up(uint64_t value, uint64_t align) {
+  if (align == 0) {
+    return value;
+  }
+  const uint64_t remainder = value % align;
+  return remainder == 0 ? value : value + (align - remainder);
+}
+
+uint64_t align_down(uint64_t value, uint64_t align) {
+  if (align == 0) {
+    return value;
+  }
+  return value - (value % align);
+}
+
+std::vector<uint64_t> compute_fully_covered_canonical_leaf_indices(
+    absl::Span<const CanonicalRange> ranges,
+    uint64_t chunk_bytes) {
+  if (chunk_bytes == 0) {
+    return {};
+  }
+  absl::flat_hash_set<uint64_t> indices;
+  for (const auto& range : ranges) {
+    if (range.length == 0) {
+      continue;
+    }
+    const uint64_t range_start = range.offset;
+    const uint64_t range_end = range.offset + range.length;
+    const uint64_t first_full = align_up(range_start, chunk_bytes);
+    const uint64_t last_full = align_down(range_end, chunk_bytes);
+    if (first_full >= last_full) {
+      continue;
+    }
+    for (uint64_t pos = first_full; pos < last_full; pos += chunk_bytes) {
+      indices.insert(pos / chunk_bytes);
+    }
+  }
+  std::vector<uint64_t> sorted(indices.begin(), indices.end());
+  std::sort(sorted.begin(), sorted.end());
+  return sorted;
+}
+
+} // namespace tensorcast::store::view

--- a/core/store/view_utils.h
+++ b/core/store/view_utils.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/types/span.h"
+#include "core/store/loader/view_planner.h"
+
+namespace tensorcast::store::view {
+
+struct CanonicalRange {
+  uint64_t offset{0};
+  uint64_t length{0};
+};
+
+std::string build_view_spec_json(const loader::ViewSpec& spec);
+
+uint64_t align_up(uint64_t value, uint64_t align);
+uint64_t align_down(uint64_t value, uint64_t align);
+
+std::vector<uint64_t> compute_fully_covered_canonical_leaf_indices(
+    absl::Span<const CanonicalRange> ranges,
+    uint64_t chunk_bytes);
+
+} // namespace tensorcast::store::view

--- a/docs/designs/0020-verification-metadata-coordination.md
+++ b/docs/designs/0020-verification-metadata-coordination.md
@@ -1,0 +1,122 @@
+---
+slug: 0020-verification-metadata-coordination
+title: Deterministic Verification Metadata for Multi-GPU Loads
+status: implemented
+areas: ["core"]
+related_code:
+  - core/store/loader/**
+  - core/store/replica/**
+  - core/common/artifact_verification.cc
+links:
+  plan: ../plans/0020-verification-metadata-coordination.md
+created: 2025-10-20
+last_updated: 2025-10-21
+---
+
+# Summary
+
+Concurrent GPU materialisations used to race when persisting or consuming `verification.json`: one replica could emit a partially written file while another parsed it immediately and raised `DataLoss` despite identical device memory. This change introduces a per-artifact guard, atomic persistence helper, and explicit GPU completion barrier so verification metadata becomes deterministic, atomic, and contention-safe across the Store Engine. Regression tests exercise the guard under concurrent workloads and ensure logs expose the relevant coordination signals.
+
+# Problem Statement
+
+- `reuse_or_generate_verification_json()` writes JSON directly to the canonical path with no guard or atomic rename.
+- Parallel `materialize_replica(..., LOAD_ONLY)` calls targeting different GPUs for the same artifact reuse the helper without coordination.
+- A second load can open the file mid-write, parse incomplete payloads, and compare against hashes computed before the first load drains its CUDA stream, yielding false `DataLoss`.
+- Disk + P2P fan-in and daemon-driven rebalances trigger the same race because all flows converge on the shared metadata file.
+
+# Goals / Non-Goals
+
+**Goals**
+- Guarantee that readers observe only complete, finalised verification blobs.
+- Prevent metadata verification from running before the producing transfer finishes on the GPU.
+- Make metadata generation idempotent and shareable across replicas to avoid redundant hashing.
+- Provide regression coverage and structured logging for concurrent load scenarios.
+
+**Non-Goals**
+- Changing the verification format or hash algorithm (xxHash64 segment rolling hash remains).
+- Replacing RFC-0007 descriptor semantics or Global Store propagation contracts.
+- Broader Store Engine modularisation (tracked in `0019-store-engine-modularization`).
+
+# Architecture & Interfaces
+
+## Guarded Metadata Pipeline
+
+```mermaid
+flowchart LR
+    subgraph Load Path
+        A["ReplicaLoadController<br>async execute()"] --> B["GPU stream<br>synchronise"]
+        B --> C["VerificationMetadataGuard<br>(per artifact)"]
+        C --> D["reuse_or_generate_verification_json"]
+    end
+    D --> E["Atomic write<br>verification.json.tmp"]
+    E --> F["fsync + rename<br>→ verification.json"]
+    F --> G["Consumers<br>(subsequent loads / P2P)"]
+```
+
+- `VerificationMetadataGuard` in `core/store/loader/verification_utils.{h,cc}` provides `ScopedLock` backed by an `absl::Mutex` keyed on canonical artifact identifiers (recovered from `artifact_descriptor.json` when present, otherwise the canonicalised artifact path). Guard instances warn once when wait time exceeds 100 ms.
+- `reuse_or_generate_verification_json` acquires the guard before reads/writes so only one load manipulates metadata at a time. In-process cache entries (keyed by artifact + byte_space) eliminate redundant hashing inside a single process; `ClearVerificationMetadataCacheForTesting()` resets the cache for stress tests.
+- Atomic persistence uses a deterministic temp path `<name>.tmp.<pid>.<nonce>`, writes via POSIX `open`/`write`, flushes with `fsync`, closes the descriptor, and atomically renames to the final target. The parent directory is `fsync`-ed to guarantee durability. Guard RAII ensures readers either see the previous valid file or block until the new blob commits.
+
+## GPU Completion Barrier
+
+- `TransferService::{load_from_source,execute}` now synchronise the per-device H2D stream by calling `AsyncCopyManager::synchronize_h2d_stream(device_id)` followed by `cuda::device_synchronize()`. Synchronisation failures abort the transfer and propagate upstream.
+- `ReplicaLoadController::load_async_from_source` continues to run post-load hooks only after `TransferService` reports success, which now implies GPU completion. Any sync failure aborts UMA commit and metadata generation, preserving on-disk state.
+
+## Metadata Determinism & Caching
+
+- The loader caches the most recent `ArtifactVerificationInfo` payload per artifact+byte-space in-process to cut guard hold time for repeat loads.
+- Cache entries are invalidated automatically when the on-disk file is incompatible (byte-space mismatch) or verification fails; tests can clear the cache explicitly to force regeneration.
+- Metadata structure remains unchanged; atomically persisted files always contain a full `ArtifactVerificationInfo` JSON blob associated with the expected `byte_space_id`.
+
+## Logging
+
+- Structured logs expose guard wait duration, write latency, artifact identifier (or path fallback), and byte space under the `verification_metadata_write_{succeeded,failed}` events.
+- Guard wait warnings are emitted once per artifact when the wait threshold is exceeded, avoiding noisy log streams.
+- File persistence failures fall back to the cached payload in memory and emit an `ERROR` log with the captured status for observability.
+
+# Invariants & Error Model
+
+- Metadata transitions are atomic: consumers either read the previously committed blob or the latest fully written blob; temp files are never visible.
+- Metadata generation only commences once GPU transfers are confirmed complete; any CUDA failure aborts the entire load and leaves metadata untouched.
+- Guard acquisition order is scoped per artifact, preventing cross-artifact deadlocks and ensuring liveness under high fan-in.
+- Filesystem failures (`open`, `write`, `fsync`, `rename`, directory `fsync`) return `Status` to callers and surface via structured logs, never silently downgrading guarantees.
+
+# Alternatives Considered
+
+- **File-system advisory locks only:** Relying solely on `flock`/`fcntl` was rejected because we need in-process coordination even when metadata stays on object storage or non-POSIX filesystems; keyed mutexes give deterministic behaviour regardless of backend.
+- **Global Store–mediated coordination:** Leveraging Global Store leases would have introduced cross-service round trips on every load and tightened coupling between runtime and control plane. The chosen guard is local, cheap, and keeps the Global Store uninvolved in data-path mutexing.
+- **Eager metadata precomputation per device:** Precomputing verification JSON during artifact ingest would avoid runtime contention but multiplies write amplification and diverges the store from actual on-device bytes. Keeping generation near the replica ensures hashes reflect the loaded buffers and works for on-demand replicas.
+
+# Trade-offs & Risks
+
+- **Throughput hit:** Serialising metadata access introduces brief critical sections. Mitigated by the short hashing window plus in-process caching.
+- **Atomic rename portability:** Linux `rename(2)` suffices; for exotic filesystems, failures log warnings and fall back to cached payloads to avoid serving partial files.
+- **Deadlock potential:** Keyed mutexes must only lock per artifact; guard implementation rejects nested lock attempts and reports programming errors.
+- **Cache staleness:** In-process caching must be invalidated on mismatched byte space or verification failure; explicit test hook ensures deterministic stress coverage.
+
+# Compatibility & Acceptance Criteria
+
+- Concurrent loads (disk or P2P) to multiple GPUs complete without false `DataLoss`.
+- `verification.json` remains valid JSON with deterministic content for a given artifact; no consumer observes truncated or stale hashes.
+- Single-threaded load latency regression remains within ±5% of baseline.
+- Structured logs capture guard wait time, byte-space identifier, artifact reference, and metadata write latency without overwhelming output volume.
+
+# Testing
+
+- `bazel test //core/store/loader:verification_utils_test` — adds atomic persistence stress, logging assertions, and cache-clear hooks.
+- `bazel test //core/store:multi_gpu_verification_race_test` — multi-threaded guard contention regression that mirrors concurrent GPU loads.
+
+# References
+
+- `core/store/loader/verification_utils.cc`
+- `core/store/replica/transfer_service.cc`
+- `core/store/loader:verification_utils_test`
+- `core/store:multi_gpu_verification_race_test`
+- `core/common/artifact_verification.cc`
+
+# References
+
+- `core/store/loader/verification_utils.cc`
+- `core/store/replica/replica.cc`
+- `core/common/artifact_verification.cc`
+- `docs/designs/0019-store-engine-modularization.md`

--- a/docs/plans/0019-store-engine-modularization.md
+++ b/docs/plans/0019-store-engine-modularization.md
@@ -17,28 +17,30 @@ Modularize `StoreEngine` by introducing `IndexService` (loader/), `VerificationS
 # Phases & Milestones
 
 - [ ] Phase 1: Mechanical Extraction (no behavior changes)
-  - [ ] Create `core/store/loader/index_reader.{h,cc}` with APIs from the design; move canonical index reading and total size derivation.
-  - [ ] Create `core/store/loader/verification_utils.{h,cc}`; move data/view hash, verification.json reuse/generation, descriptor writeback.
-  - [ ] Create `core/store/components/eviction_service.{h,cc}`; move GPU/CPU eviction logic.
-  - [ ] Update Bazel BUILD rules for new libraries using `sc_cc_library`.
-  - [ ] Refactor `store_engine.cc` to call services without changing external behavior or logs.
+  - [x] Create `core/store/loader/index_reader.{h,cc}` with APIs from the design; move canonical index reading and total size derivation.
+  - [x] Create `core/store/loader/verification_utils.{h,cc}`; move data/view hash, verification.json reuse/generation, descriptor writeback.
+  - [x] Create `core/store/components/eviction_service.{h,cc}`; move GPU/CPU eviction logic.
+  - [x] Update Bazel BUILD rules for new libraries using `sc_cc_library`.
+  - [x] Refactor `store_engine.cc` to call services without changing external behavior or logs.
 
-- [ ] Phase 2: Dedup and Simplify Orchestration
-  - [ ] Replace repeated index canonicalization blocks in disk/P2P paths with `IndexService`.
-  - [ ] Replace repeated verification/descriptor blocks with `VerificationService`.
-  - [ ] Consolidate GPU retry-after-eviction to a single callsite using `EvictionService`.
-  - [ ] Move `build_view_spec_json` and small helpers (align/filename sanitize) into appropriate utils.
+- [x] Phase 2: Dedup and Simplify Orchestration
+  - [x] Replace repeated index canonicalization blocks in disk/P2P paths with `IndexService`.
+  - [x] Replace repeated verification/descriptor blocks with `VerificationService`.
+  - [x] Consolidate GPU retry-after-eviction to a single callsite using `EvictionService`.
+  - [x] Move `build_view_spec_json` and small helpers (align/filename sanitize) into appropriate utils.
 
 - [ ] Phase 3: Copy & Variant Path Refinements
   - [ ] Optional: extract COPY_ONLY path into a `CopyService` (GPU→GPU) wrapping `Replica::copy_from`.
-  - [ ] Ensure variant `view_data_hash` generation routes through `VerificationService` helpers.
+  - [x] Ensure variant `view_data_hash` generation routes through `VerificationService` helpers.
 
-- [ ] Phase 4: Tests & Docs
-  - [ ] Unit tests for `IndexService` (safetensors/partition, malformed descriptors, size derivation).
-  - [ ] Unit tests for `VerificationService` (CPU/GPU digest, verification.json reuse/mismatch, descriptor writeback, leaf digests).
-  - [ ] Unit tests for `EvictionService` (GPU required bytes reclaimed; CPU pinned pool logic; metrics increments).
-  - [ ] Update `core/store/README.md` and any linked docs per Doc Sync Rule.
+- [x] Phase 4: Tests & Docs
+  - [x] Unit tests for `IndexService` (safetensors/partition, malformed descriptors, size derivation).
+  - [x] Unit tests for `VerificationService` (CPU/GPU digest, verification.json reuse/mismatch, descriptor writeback, leaf digests).
+  - [x] Unit tests for `EvictionService` (GPU required bytes reclaimed; CPU pinned pool logic; metrics increments).
+  - [x] Update `core/store/README.md` and any linked docs per Doc Sync Rule.
   - [ ] Ensure existing tests (loader/components/daemon) pass in fake and real CUDA modes.
+    - [x] Targeted unit suites executed: `bazel test //core/store:eviction_service_test //core/store/loader:index_reader_test //core/store/loader:verification_utils_test`
+    - [ ] Full loader/components/daemon matrix still pending (fake + real CUDA)
 
 # Tasks
 
@@ -85,5 +87,3 @@ Success Criteria
 - `store_engine.cc` reduced substantially (by >30%).
 - All tests pass in fake CUDA; no regressions in real CUDA paths.
 - Code ownership clear: services are independently testable and documented.
-
-

--- a/docs/plans/0020-verification-metadata-coordination.md
+++ b/docs/plans/0020-verification-metadata-coordination.md
@@ -1,0 +1,63 @@
+---
+slug: 0020-verification-metadata-coordination
+title: Plan — Deterministic Verification Metadata Coordination
+status: completed
+links:
+  design: ../designs/0020-verification-metadata-coordination.md
+areas: ["core"]
+related_code:
+  - core/store/loader/**
+  - core/store/replica/**
+  - core/common/artifact_verification.cc
+created: 2025-10-20
+last_updated: 2025-10-21
+---
+
+# Objective
+
+Sequence the changes that introduce guarded verification metadata, atomic file persistence, guaranteed GPU completion, and regression coverage so multi-GPU loads no longer surface false `DataLoss` during concurrent materialisation.
+
+# Phases & Milestones
+
+- [x] **Phase 1 — Guard Infrastructure**
+  - [x] Implement `VerificationMetadataGuard` keyed by canonical artifact id with RAII acquisition (`core/store/loader/verification_utils.cc`).
+  - [x] Integrate guard acquisition into `reuse_or_generate_verification_json` and add in-process metadata cache (cache + guard reuse with descriptor validation).
+  - [x] Emit warn-once logs when guard acquisition waits exceed the configured threshold (threshold: 100 ms default).
+- [x] **Phase 2 — Atomic Persistence**
+  - [x] Replace direct writes with temp-file + flush + `fsync` + atomic `rename` helper (`atomic_write_file` helper).
+  - [x] Extend unit coverage to ensure readers never observe partial JSON (injectable reader hook via new stress test in `verification_utils_test.cc`).
+  - [x] Emit structured logs when filesystem operations fail, falling back to cached payload (`verification_metadata_write_{succeeded,failed}` events).
+- [x] **Phase 3 — GPU Completion Barrier**
+  - [x] Add explicit stream/device synchronization in `TransferService::execute` and `load_from_source` (via `AsyncCopyManager::synchronize_h2d_stream` + `cuda::device_synchronize`).
+  - [x] Gate metadata generation on sync success in `ReplicaLoadController::load_async_from_source` (metadata hook runs only after synchronised execute success).
+  - [x] Ensure CUDA failures propagate without touching on-disk metadata (sync failures bubble to callers before persistence).
+- [x] **Phase 4 — Regression & Stress Tests**
+  - [x] Author `core/store/multi_gpu_verification_race_test.cc` covering concurrent LOAD_ONLY flows.
+  - [x] Add a stress harness that spawns parallel futures to hammer metadata generation (multi-threaded barriers in new test and cache-reset helper).
+  - [x] Capture guard contention behaviour via deterministic assertions (ensures no DataLoss and final metadata parses in concurrent rounds).
+  - [x] Verify structured logs emit expected fields without excessive verbosity (log sink assertion in `verification_utils_test.cc`).
+
+# Tasks
+
+- Update Bazel (and tests) to include guard implementations and new regression suites (`core/store/loader:verification_utils_test`, `core/store:multi_gpu_verification_race_test`). No CMake changes required.
+- Document guard usage expectations in `core/store/README.md` and loader docs per doc-sync rule. **Done** — README and architecture guide describe guard, atomic writes, and logging.
+- Audit existing callers for potential nested guard attempts; add debug assertions. **Done** — guard prevents re-entry via per-artifact map.
+- Ensure fake-CUDA path covers the new synchronization calls and mirrors real CUDA behaviour in tests. **Done** — synchronisation funnels through shared `cuda::device_synchronize()`.
+- Add portable atomic-write helper under `common/filesystem/` if reuse emerges; otherwise scope it to loader implementation. **Implemented** within loader for now.
+- Emit structured logs (artifact id, generator version, guard wait duration) when metadata writes complete and on failure paths. **Done** — VLOG + structured INFO/ERROR entries with guard wait/write durations.
+
+# Test / Rollout / Backout
+
+- `uv run pytest tests/python/store/test_multi_gpu_verification.py` (new or extended) for Python-level regression.
+- `bazel test //core/store:multi_gpu_verification_race_test` under fake CUDA and real CUDA gates.
+- `bazel test //core/store:all` smoke to catch integration regressions.
+- Rollout via staged canary: enable guard and atomic writes behind runtime flag; once validated, flip flag to mandatory and remove fallback.
+- Backout plan: toggle runtime flag to disable guard usage (reverts to cached metadata only) while keeping atomic write helper available; if necessary, roll back to previous release tag.
+
+# Risks & Tracking
+
+- **Deadlock risk:** Monitor guard wait duration via structured log sampling; add thresholds for manual investigation if waits exceed 100 ms.
+- **Performance regression:** Benchmark load latency before and after; set guard-critical-section budget (<5 ms per artifact).
+- **Filesystem incompatibility:** Validate atomic rename on supported filesystems in staging; document fallback behaviour for unsupported cases.
+- **Debug visibility gaps:** Validate that log sampling thresholds and message contents are sufficient to detect prolonged waits without additional telemetry.
+- **Logging coverage:** Confirm structured logs surface enough context (artifact id, generator version, wait duration, status) to debug regressions quickly.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds signed verification metadata with guarded atomic persistence, refactors StoreEngine into modular services, synchronizes GPU transfers, improves async pump error handling, and introduces eviction/index/verification utilities with tests and docs.
> 
> - **Verification metadata (core/common + loader)**:
>   - Add `metadata_signature` (SHA-256) to `ArtifactVerificationInfo`, canonicalize JSON, and validate on read; expose `compute_metadata_signature()` and `refresh_metadata_signature()`.
>   - New `verification_utils` with per-artifact `VerificationMetadataGuard`, atomic write (`open`→`fsync`→`rename`), in-process cache, and helpers for data/view hashing and leaf digests.
> - **StoreEngine refactor (core/store)**:
>   - Extract index loading to `loader/index_reader` and view helpers to `view_utils`.
>   - Introduce `components/eviction_service` (GPU/CPU) and wire it into load/registration paths.
>   - Replace inline verification/descriptor logic with `verification_utils`; add structured logs and reuse/regenerate per-view `verification.json`.
> - **Transfer and pump hardening**:
>   - `TransferService`: synchronize GPU after loads (per-device stream + device sync); add tail-byte diagnostics.
>   - `pump`: robust async slot lifetime management, drain-on-error, detailed mismatch logging; regression for delayed post-pump failures.
> - **Async copy manager**:
>   - Expose `synchronize_h2d_stream(device_id)` for per-device stream sync.
> - **Tests and docs**:
>   - New unit tests: `index_reader_test`, `verification_utils_test`, `eviction_service_test`, `multi_gpu_verification_race_test`, enhanced pump async tests; update verification JSON tests for signature.
>   - Update README and add design/plan docs for verification metadata coordination and modularization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7550a0084a62691bb1e1f4ba04356746e9f6d32. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->