### PR TITLE
feat: introduce client-generated artifact ID (CGID) support

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,5 @@
+{
+  "setup-worktree": [
+    "uv init"
+  ]
+}

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,10 @@
     "python.pythonPath": ".venv/bin/python3.10",
     "clangd.arguments": [
         "--background-index",
+    ],
+    "cSpell.words": [
+        "absl",
+        "tensorcast"
     ]
 
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,9 @@
     ],
     "cSpell.words": [
         "absl",
+        "avbs",
+        "multihash",
+        "retryable",
         "tensorcast"
     ]
 

--- a/core/common/BUILD
+++ b/core/common/BUILD
@@ -129,6 +129,16 @@ sc_cc_library(
     ),
 )
 
+sc_cc_library(
+    name = "artifact_identity_lib",
+    srcs = ["artifact_identity.cc"],
+    hdrs = ["artifact_identity.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/strings:strings",
+    ],
+)
+
 # Memory management - CUDA memory utilities
 sc_cc_library(
     name = "cuda_memory_lib",

--- a/core/common/artifact_identity.cc
+++ b/core/common/artifact_identity.cc
@@ -1,0 +1,106 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "core/common/artifact_identity.h"
+
+#include <cctype>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+
+namespace tensorcast::common {
+namespace {
+
+constexpr int kCgidMinLength = 8;
+constexpr int kCgidMaxLength = 200;
+
+bool is_ascii(absl::string_view value) {
+  for (unsigned char c : value) {
+    if (c > 0x7F) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool is_cgid_body_char(char c) {
+  if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+    return true;
+  }
+  switch (c) {
+    case '-':
+    case '.':
+    case '_':
+    case '~':
+      return true;
+    default:
+      return false;
+  }
+}
+
+absl::Status validate_cgid_grammar(absl::string_view artifact_id) {
+  if (!is_cgid_artifact_id(artifact_id)) {
+    return absl::InvalidArgumentError("cgid must start with \"cgid:\" prefix");
+  }
+  if (!is_ascii(artifact_id)) {
+    return absl::InvalidArgumentError("cgid must be ASCII");
+  }
+  const int length = static_cast<int>(artifact_id.size());
+  if (length < kCgidMinLength || length > kCgidMaxLength) {
+    return absl::InvalidArgumentError("cgid length must be between 8 and 200 characters");
+  }
+  const absl::string_view suffix = artifact_id.substr(kCgidPrefix.size());
+  if (suffix.empty()) {
+    return absl::InvalidArgumentError("cgid must include identifier segment after prefix");
+  }
+  for (char c : suffix) {
+    if (!is_cgid_body_char(c)) {
+      return absl::InvalidArgumentError("cgid contains invalid characters");
+    }
+  }
+  return absl::OkStatus();
+}
+
+} // namespace
+
+bool is_mi2_artifact_id(absl::string_view artifact_id) {
+  return absl::StartsWith(artifact_id, kMi2Prefix);
+}
+
+bool is_cgid_artifact_id(absl::string_view artifact_id) {
+  return absl::StartsWith(artifact_id, kCgidPrefix);
+}
+
+absl::Status validate_client_generated_id(absl::string_view artifact_id) {
+  return validate_cgid_grammar(artifact_id);
+}
+
+ArtifactIdKind infer_artifact_id_kind(absl::string_view artifact_id) {
+  if (is_mi2_artifact_id(artifact_id)) {
+    return ArtifactIdKind::kMi2;
+  }
+  if (is_cgid_artifact_id(artifact_id)) {
+    return ArtifactIdKind::kCgid;
+  }
+  return ArtifactIdKind::kUnspecified;
+}
+
+absl::StatusOr<ArtifactIdKind> validate_and_get_artifact_id_kind(absl::string_view artifact_id) {
+  const ArtifactIdKind kind = infer_artifact_id_kind(artifact_id);
+  switch (kind) {
+    case ArtifactIdKind::kMi2:
+      return kind;
+    case ArtifactIdKind::kCgid: {
+      auto st = validate_cgid_grammar(artifact_id);
+      if (!st.ok()) {
+        return st;
+      }
+      return kind;
+    }
+    case ArtifactIdKind::kUnspecified:
+    default:
+      return absl::InvalidArgumentError(R"(artifact_id must start with "mi2:" or "cgid:" prefix)");
+  }
+}
+
+} // namespace tensorcast::common

--- a/core/common/artifact_identity.h
+++ b/core/common/artifact_identity.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#pragma once
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+namespace tensorcast::common {
+
+// Enumeration describing supported artifact identity prefixes.
+enum class ArtifactIdKind {
+  kUnspecified = 0,
+  kMi2 = 1,
+  kCgid = 2,
+};
+
+constexpr absl::string_view kMi2Prefix = "mi2:";
+constexpr absl::string_view kCgidPrefix = "cgid:";
+
+// Returns true when artifact_id begins with the mi2 prefix.
+bool is_mi2_artifact_id(absl::string_view artifact_id);
+
+// Returns true when artifact_id begins with the CGID prefix.
+bool is_cgid_artifact_id(absl::string_view artifact_id);
+
+// Validate a client-generated artifact identity (cgid prefix and grammar).
+absl::Status validate_client_generated_id(absl::string_view artifact_id);
+
+// Validate a generic artifact identity (mi2 or cgid) and return its kind.
+absl::StatusOr<ArtifactIdKind> validate_and_get_artifact_id_kind(absl::string_view artifact_id);
+
+// Lightweight classification helper; does not validate grammar.
+ArtifactIdKind infer_artifact_id_kind(absl::string_view artifact_id);
+
+} // namespace tensorcast::common

--- a/core/store/BUILD
+++ b/core/store/BUILD
@@ -278,6 +278,7 @@ sc_cc_library(
         ":view_utils",
         "//core/checkpoint:checkpoint_lib",
         "//core/common:artifact_hash_lib",
+        "//core/common:artifact_identity_lib",
         "//core/common:artifact_verification_lib",
         "//core/common:cuda_api_lib",
         "//core/common:pinned_buffer_pool_lib",

--- a/core/store/store_engine.cc
+++ b/core/store/store_engine.cc
@@ -2040,6 +2040,13 @@ absl::StatusOr<StoreEngine::RegistrationBeginResult> StoreEngine::begin_register
   auto entry = std::make_shared<PendingRegistrationEntry>();
   entry->registration_id = reg_id;
   entry->artifact_id = reg.artifact_id;
+  if (reg.client_artifact_id.has_value()) {
+    entry->client_artifact_id = *reg.client_artifact_id;
+    entry->id_kind = common::ArtifactIdKind::kCgid;
+  } else {
+    entry->client_artifact_id.clear();
+    entry->id_kind = common::ArtifactIdKind::kMi2;
+  }
   entry->device_id = reg.device_id;
   entry->size_bytes = reg.total_size_bytes;
   entry->tensor_index_key = reg.tensor_index_key;
@@ -2185,72 +2192,82 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
     }
   }
 
-  // Compute content-addressed artifact_id per RFC-0007: "mi2:<index_multihash>:<data_multihash>"
-  // 1) index_multihash from canonical index bytes when provided, otherwise from key (sha256 hex)
-  absl::StatusOr<std::string> index_mh_or =
-      common::compute_index_multihash(entry->tensor_index_data, entry->tensor_index_key);
-  if (!index_mh_or.ok()) {
-    return index_mh_or.status();
-  }
-
-  if (!entry->schema_version.empty() && entry->schema_version != "v3") {
-    return absl::FailedPreconditionError(
-        absl::StrCat("Pending registration schema_version must be 'v3'; found '", entry->schema_version, "'"));
-  }
-
+  std::string index_multihash;
+  std::string data_multihash;
   std::vector<loader::SegmentPiece> segment_plan;
   bool segment_plan_ready = false;
 
-  // 2) data_multihash via SegmentPlan linearization (PAD=0).
-  absl::StatusOr<std::string> data_mh_or;
-  if (entry->plan == PendingRegistrationEntry::Plan::CPU) {
-    // Hash directly from VS CPU memory (zero-initialized PAD regions).
-    auto region_or = va_space_->region_info(entry->artifact_id);
-    if (!region_or.ok()) {
-      return region_or.status();
+  if (entry->id_kind == common::ArtifactIdKind::kMi2 || entry->client_artifact_id.empty()) {
+    // Compute content-addressed artifact_id per RFC-0007: "mi2:<index_multihash>:<data_multihash>"
+    // 1) index_multihash from canonical index bytes when provided, otherwise from key (sha256 hex)
+    absl::StatusOr<std::string> index_mh_or =
+        common::compute_index_multihash(entry->tensor_index_data, entry->tensor_index_key);
+    if (!index_mh_or.ok()) {
+      return index_mh_or.status();
     }
-    auto mh_or = loader::compute_data_multihash_from_cpu_memory(
-        gsl::not_null<const void*>{region_or->cpu_base}, entry->size_bytes);
-    if (!mh_or.ok()) {
-      return mh_or.status();
+    index_multihash = *index_mh_or;
+
+    if (!entry->schema_version.empty() && entry->schema_version != "v3") {
+      return absl::FailedPreconditionError(
+          absl::StrCat("Pending registration schema_version must be 'v3'; found '", entry->schema_version, "'"));
     }
-    data_mh_or = *mh_or;
-  } else {
-    void* gpu_ptr = entry->gpu_ptr;
-    if (gpu_ptr == nullptr) {
-      const auto ptrs = entry->replica->get_memory_manager().get_pointer(MemoryLocation::GPU);
-      gpu_ptr = (!ptrs.empty() ? ptrs[0] : nullptr);
-    }
-    if (!gpu_ptr) {
-      return absl::FailedPreconditionError("GPU pointer is null; cannot hash GPU data");
-    }
-    if (entry->tensor_index_data.has_value() && !entry->tensor_index_data->empty() && entry->encoding == "json") {
-      auto plan_or = loader::build_segment_plan_from_canonical_index_json(
-          *entry->tensor_index_data, entry->size_bytes, /*align_bytes=*/8);
-      if (!plan_or.ok()) {
-        return plan_or.status();
+
+    // 2) data_multihash via SegmentPlan linearization (PAD=0).
+    absl::StatusOr<std::string> data_mh_or;
+    if (entry->plan == PendingRegistrationEntry::Plan::CPU) {
+      auto region_or = va_space_->region_info(entry->artifact_id);
+      if (!region_or.ok()) {
+        return region_or.status();
       }
-      segment_plan = std::move(*plan_or);
-      segment_plan_ready = true;
-      auto mh_or = loader::compute_data_multihash_from_gpu_plan(
-          gsl::not_null<void*>{gpu_ptr}, entry->device_id, absl::MakeSpan(segment_plan), entry->size_bytes);
+      auto mh_or = loader::compute_data_multihash_from_cpu_memory(
+          gsl::not_null<const void*>{region_or->cpu_base}, entry->size_bytes);
       if (!mh_or.ok()) {
         return mh_or.status();
       }
       data_mh_or = *mh_or;
     } else {
-      auto mh_or = common::compute_data_multihash_from_gpu(gpu_ptr, entry->size_bytes, entry->device_id);
-      if (!mh_or.ok()) {
-        return mh_or.status();
+      void* gpu_ptr = entry->gpu_ptr;
+      if (gpu_ptr == nullptr) {
+        const auto ptrs = entry->replica->get_memory_manager().get_pointer(MemoryLocation::GPU);
+        gpu_ptr = (!ptrs.empty() ? ptrs[0] : nullptr);
       }
-      data_mh_or = *mh_or;
+      if (!gpu_ptr) {
+        return absl::FailedPreconditionError("GPU pointer is null; cannot hash GPU data");
+      }
+      if (entry->tensor_index_data.has_value() && !entry->tensor_index_data->empty() && entry->encoding == "json") {
+        auto plan_or = loader::build_segment_plan_from_canonical_index_json(
+            *entry->tensor_index_data, entry->size_bytes, /*align_bytes=*/8);
+        if (!plan_or.ok()) {
+          return plan_or.status();
+        }
+        segment_plan = std::move(*plan_or);
+        segment_plan_ready = true;
+        auto mh_or = loader::compute_data_multihash_from_gpu_plan(
+            gsl::not_null<void*>{gpu_ptr}, entry->device_id, absl::MakeSpan(segment_plan), entry->size_bytes);
+        if (!mh_or.ok()) {
+          return mh_or.status();
+        }
+        data_mh_or = *mh_or;
+      } else {
+        auto mh_or = common::compute_data_multihash_from_gpu(gpu_ptr, entry->size_bytes, entry->device_id);
+        if (!mh_or.ok()) {
+          return mh_or.status();
+        }
+        data_mh_or = *mh_or;
+      }
     }
+    if (!data_mh_or.ok()) {
+      return data_mh_or.status();
+    }
+    data_multihash = *data_mh_or;
+    entry->artifact_id = absl::StrCat("mi2:", index_multihash, ":", data_multihash);
+    entry->id_kind = common::ArtifactIdKind::kMi2;
+  } else {
+    entry->artifact_id = entry->client_artifact_id;
+    entry->id_kind = common::ArtifactIdKind::kCgid;
+    index_multihash.clear();
+    data_multihash.clear();
   }
-  if (!data_mh_or.ok()) {
-    return data_mh_or.status();
-  }
-
-  entry->artifact_id = absl::StrCat("mi2:", *index_mh_or, ":", *data_mh_or);
 
   // Idempotent success: if the same content-addressed artifact already has a
   // replica on the target device, reclaim this allocation and return OK with
@@ -2285,10 +2302,11 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
       result.device_id = entry->device_id;
       result.size_bytes = entry->size_bytes;
       result.existed = true;
-      result.index_multihash = *index_mh_or;
-      result.data_multihash = *data_mh_or;
+      result.index_multihash = index_multihash;
+      result.data_multihash = data_multihash;
       result.schema_version = entry->schema_version;
       result.encoding = entry->encoding;
+      result.id_kind = entry->id_kind;
       if (entry->view_state) {
         if (!entry->view_state->options.view_id.empty()) {
           result.view_id = entry->view_state->options.view_id;
@@ -2432,7 +2450,8 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
         entry->view_state->options.canonical_ranges, leaf_chunk_bytes.value_or(0));
   }
 
-  if (entry->view_state && leaf_chunk_bytes.has_value() && !canonical_leaf_indices.empty()) {
+  if (entry->id_kind == common::ArtifactIdKind::kMi2 && entry->view_state && leaf_chunk_bytes.has_value() &&
+      !canonical_leaf_indices.empty() && !index_multihash.empty()) {
     loader::verification::MemoryView canonical_view;
     canonical_view.size_bytes = entry->size_bytes;
     if (entry->plan == PendingRegistrationEntry::Plan::CPU) {
@@ -2465,7 +2484,7 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
       for (size_t i = 0; i < canonical_leaf_indices.size(); ++i) {
         global_store::v1::LeafWrite leaf;
         leaf.set_space_kind(tensorcast::global_store::v1::BYTE_SPACE_KIND_CANONICAL);
-        leaf.set_space_id(*index_mh_or);
+        leaf.set_space_id(index_multihash);
         leaf.set_leaf_idx(canonical_leaf_indices[i]);
         const auto& digest = (*canonical_digest_or)[i];
         leaf.set_digest(digest.data(), static_cast<int>(digest.size()));
@@ -2485,10 +2504,11 @@ absl::StatusOr<StoreEngine::RegistrationCommitResult> StoreEngine::commit_regist
   result.device_id = entry->device_id;
   result.size_bytes = entry->size_bytes;
   result.existed = false;
-  result.index_multihash = *index_mh_or;
-  result.data_multihash = *data_mh_or;
+  result.index_multihash = index_multihash;
+  result.data_multihash = data_multihash;
   result.schema_version = entry->schema_version;
   result.encoding = entry->encoding;
+  result.id_kind = entry->id_kind;
   uint64_t covered_bytes = 0;
   if (entry->view_state) {
     if (!entry->view_state->options.view_id.empty()) {

--- a/core/store/store_engine.h
+++ b/core/store/store_engine.h
@@ -14,6 +14,7 @@
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "core/common/artifact_identity.h"
 #include "core/common/memory/pinned_buffer_pool.h"
 #include "core/common/memory/virtual_address_space.h"
 #include "core/store/components/communication_manager.h"
@@ -136,6 +137,7 @@ class StoreEngine {
     uint64_t total_size_bytes{0}; // Total coalesced byte size (8B-aligned)
     bool enable_p2p{true}; // Whether to enable remote access
     uint32_t ttl_ms{0}; // Optional TTL for Begin→Commit (0 = no TTL)
+    std::optional<std::string> client_artifact_id; // Optional CGID supplied by client
     std::optional<ViewRegistration> view;
   };
 
@@ -178,6 +180,7 @@ class StoreEngine {
     std::optional<std::string> view_index_json;
     std::vector<CanonicalRange> canonical_ranges;
     bool allow_partial{false};
+    common::ArtifactIdKind id_kind{common::ArtifactIdKind::kMi2};
   };
 
   absl::StatusOr<RegistrationCommitResult> commit_registered_artifact(std::string_view registration_id);
@@ -391,6 +394,7 @@ class StoreEngine {
   struct PendingRegistrationEntry {
     std::string registration_id;
     std::string artifact_id;
+    std::string client_artifact_id;
     int device_id{0};
     uint64_t size_bytes{0};
     std::string tensor_index_key;
@@ -398,6 +402,7 @@ class StoreEngine {
     std::string schema_version;
     std::string encoding;
     bool enable_p2p{true};
+    common::ArtifactIdKind id_kind{common::ArtifactIdKind::kMi2};
     std::shared_ptr<replica::Replica> replica; // Backing replica for memory ownership
     void* gpu_ptr{nullptr}; // Base GPU pointer (for diagnostics)
     cudaIpcMemHandle_t ipc_handle{}; // CUDA IPC handle bytes

--- a/core/store/store_engine_test.cc
+++ b/core/store/store_engine_test.cc
@@ -17,6 +17,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
 #include "core/common/artifact_hash.h"
+#include "core/common/artifact_identity.h"
 #include "core/store/loader/disk_dir_hash.h"
 #include "core/store/loader/source_hash.h"
 #include "core/store/loader/view_planner.h"
@@ -154,6 +155,52 @@ TEST_CASE("ReplicaKey distinguishes variant byte spaces", "[store_engine][replic
   REQUIRE(canonical != variant);
   ReplicaKeyHash hasher;
   REQUIRE(hasher(canonical) != hasher(variant));
+}
+
+TEST_CASE("StoreEngine commit reports MI2 identity", "[store_engine][registration]") {
+  auto storage = fs::temp_directory_path() / "store-engine-mi2";
+  fs::create_directories(storage);
+  StoreEngine engine = make_store(storage);
+
+  tensorcast::store::StoreEngine::ArtifactRegistration reg;
+  reg.artifact_id = "temp-reg-mi2";
+  reg.device_id = 0;
+  reg.total_size_bytes = 256 * 1024;
+  reg.tensor_index_data = std::string("{}");
+
+  auto begin_or = engine.begin_register_artifact(reg);
+  REQUIRE(begin_or.ok());
+
+  auto commit_or = engine.commit_registered_artifact(begin_or->registration_id);
+  REQUIRE(commit_or.ok());
+  const auto& result = commit_or.value();
+  REQUIRE(result.id_kind == tensorcast::common::ArtifactIdKind::kMi2);
+  REQUIRE(result.artifact_id.rfind("mi2:", 0) == 0);
+  REQUIRE(!result.index_multihash.empty());
+}
+
+TEST_CASE("StoreEngine commit honours CGID", "[store_engine][registration]") {
+  auto storage = fs::temp_directory_path() / "store-engine-cgid";
+  fs::create_directories(storage);
+  StoreEngine engine = make_store(storage);
+
+  tensorcast::store::StoreEngine::ArtifactRegistration reg;
+  reg.artifact_id = "temp-reg-cgid";
+  reg.device_id = 0;
+  reg.total_size_bytes = 128 * 1024;
+  reg.tensor_index_data = std::string("{}");
+  reg.client_artifact_id = std::string("cgid:engine-test-1");
+
+  auto begin_or = engine.begin_register_artifact(reg);
+  REQUIRE(begin_or.ok());
+
+  auto commit_or = engine.commit_registered_artifact(begin_or->registration_id);
+  REQUIRE(commit_or.ok());
+  const auto& result = commit_or.value();
+  REQUIRE(result.id_kind == tensorcast::common::ArtifactIdKind::kCgid);
+  REQUIRE(result.artifact_id == "cgid:engine-test-1");
+  REQUIRE(result.index_multihash.empty());
+  REQUIRE(result.data_multihash.empty());
 }
 
 static absl::Status wait_ready(

--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -214,7 +214,10 @@ sc_header_only_library(
     name = "types_hdr",
     hdrs = ["types.h"],
     visibility = ["//visibility:public"],
-    deps = [":cuda_ipc_raii_hdr"],
+    deps = [
+        ":cuda_ipc_raii_hdr",
+        "//core/common:artifact_identity_lib",
+    ],
 )
 
 sc_header_only_library(
@@ -387,6 +390,7 @@ sc_cc_library(
         ":status_utils",
         "//core/store:store_engine",
         "//core/store/loader:segment_plan_source",
+        "//proto/tensorcast/common/v1:common_cc",
         "//proto/tensorcast/daemon/v1:daemon_grpc_cc",
         "@abseil-cpp//absl/strings",
         "@opentelemetry-cpp//api:api",

--- a/daemon/grpc_service_impl_registration_test.cc
+++ b/daemon/grpc_service_impl_registration_test.cc
@@ -11,6 +11,7 @@
 #include "core/store/store_engine.h"
 #include "core/store/store_engine_options.h"
 #include "grpcpp/server_context.h"
+#include "tensorcast/common/v1/common.pb.h"
 #include "tensorcast/daemon/v1/store_daemon.grpc.pb.h"
 
 using tensorcast::daemon::StoreDaemonServiceImpl;
@@ -76,6 +77,39 @@ TEST_CASE("CommitRegisteredArtifact populates descriptor", "[daemon][registratio
   REQUIRE(!desc.index_multihash().empty());
   REQUIRE(!desc.data_multihash().empty());
   REQUIRE(desc.total_size() == 1 * 1024 * 1024);
+  REQUIRE(desc.id_kind() == tensorcast::common::v1::ARTIFACT_ID_KIND_MI2);
+}
+
+TEST_CASE("CommitRegisteredArtifact accepts CGID", "[daemon][registration]") {
+  auto engine = std::make_shared<tensorcast::store::StoreEngine>(make_opts());
+  StoreDaemonServiceImpl service(engine);
+
+  tensorcast::daemon::v1::BeginRegisterArtifactRequest breq;
+  breq.set_device_id(0);
+  breq.set_total_size(512 * 1024);
+  breq.set_owner_pid(getpid());
+  breq.set_client_artifact_id("cgid:testcgid123");
+  auto* idx = breq.mutable_tensor_index_data();
+  idx->set_data("{}");
+  idx->set_schema_version("v3");
+  idx->set_encoding("json");
+
+  grpc::ServerContext ctx;
+  tensorcast::daemon::v1::BeginRegisterArtifactResponse bresp;
+  auto st = service.BeginRegisterArtifact(&ctx, &breq, &bresp);
+  REQUIRE(st.ok());
+
+  tensorcast::daemon::v1::CommitRegisteredArtifactRequest creq;
+  creq.set_registration_id(bresp.registration_id());
+  tensorcast::daemon::v1::CommitRegisteredArtifactResponse cresp;
+  st = service.CommitRegisteredArtifact(&ctx, &creq, &cresp);
+  REQUIRE(st.ok());
+  REQUIRE(cresp.has_artifact_descriptor());
+  const auto& desc = cresp.artifact_descriptor();
+  REQUIRE(desc.artifact_id() == "cgid:testcgid123");
+  REQUIRE(desc.index_multihash().empty());
+  REQUIRE(desc.data_multihash().empty());
+  REQUIRE(desc.id_kind() == tensorcast::common::v1::ARTIFACT_ID_KIND_CGID);
 }
 
 TEST_CASE(

--- a/daemon/lip_manager.cc
+++ b/daemon/lip_manager.cc
@@ -469,6 +469,8 @@ absl::StatusOr<CommitLeaseResult> LipManager::commit_lease_in_place(
     uint32_t ttl_ms,
     uint64_t epoch,
     uint64_t total_size,
+    tensorcast::common::ArtifactIdKind id_kind,
+    const std::string& client_artifact_id,
     const std::string& index_data,
     const std::string& index_key_hex,
     std::vector<LeaseSegMeta>&& segments,
@@ -590,20 +592,34 @@ absl::StatusOr<CommitLeaseResult> LipManager::commit_lease_in_place(
     uint64_t cur_{0};
   } src(std::move(opened), total_size);
 
-  // Compute multihashes
-  auto index_mh_or = common::compute_index_multihash(
-      canonical_index_json.empty() ? std::optional<std::string>() : std::optional<std::string>(canonical_index_json),
-      index_key_hex);
-  if (!index_mh_or.ok())
-    return index_mh_or.status();
-  auto data_mh_or = store::loader::compute_data_multihash_from_seekable_source(src, total_size);
-  if (!data_mh_or.ok())
-    return data_mh_or.status();
-
+  std::string index_multihash;
+  std::string data_multihash;
   CommitLeaseResult out;
-  out.index_multihash = *index_mh_or;
-  out.data_multihash = *data_mh_or;
-  out.artifact_id = absl::StrCat("mi2:", out.index_multihash, ":", out.data_multihash);
+
+  if (id_kind == common::ArtifactIdKind::kMi2 || client_artifact_id.empty()) {
+    auto index_mh_or = common::compute_index_multihash(
+        canonical_index_json.empty() ? std::optional<std::string>() : std::optional<std::string>(canonical_index_json),
+        index_key_hex);
+    if (!index_mh_or.ok())
+      return index_mh_or.status();
+    index_multihash = *index_mh_or;
+
+    auto data_mh_or = store::loader::compute_data_multihash_from_seekable_source(src, total_size);
+    if (!data_mh_or.ok())
+      return data_mh_or.status();
+    data_multihash = *data_mh_or;
+
+    out.index_multihash = index_multihash;
+    out.data_multihash = data_multihash;
+    out.artifact_id = absl::StrCat("mi2:", index_multihash, ":", data_multihash);
+    out.id_kind = common::ArtifactIdKind::kMi2;
+  } else {
+    out.index_multihash.clear();
+    out.data_multihash.clear();
+    out.artifact_id = client_artifact_id;
+    out.id_kind = common::ArtifactIdKind::kCgid;
+  }
+
   out.schema_version = "v2";
   out.encoding = "json";
   out.total_size = total_size;
@@ -649,6 +665,8 @@ absl::StatusOr<CommitLeaseResult> LipManager::commit_lease_in_place(
   LipLeaseEntry lease;
   lease.registration_id = registration_id;
   lease.artifact_id = out.artifact_id;
+  lease.client_artifact_id = client_artifact_id;
+  lease.id_kind = out.id_kind;
   lease.device_id = device_id;
   lease.owner_pid = owner_pid;
   lease.ttl_ms = ttl_ms > 0 ? ttl_ms : 600000U; // default 10 minutes

--- a/daemon/lip_manager.h
+++ b/daemon/lip_manager.h
@@ -68,6 +68,8 @@ class LipManager {
       uint32_t ttl_ms,
       uint64_t epoch,
       uint64_t total_size,
+      tensorcast::common::ArtifactIdKind id_kind,
+      const std::string& client_artifact_id,
       const std::string& index_data, // canonical index JSON (may be empty)
       const std::string& index_key_hex, // precomputed index sha256 hex (may be empty)
       std::vector<LeaseSegMeta>&& segments,

--- a/daemon/registration_manager.h
+++ b/daemon/registration_manager.h
@@ -34,6 +34,8 @@ class RegistrationManager {
     bool lease_in_place{false};
     std::string index_key_hex;
     std::string index_data;
+    tensorcast::common::ArtifactIdKind id_kind{tensorcast::common::ArtifactIdKind::kMi2};
+    std::string client_artifact_id;
     bool view_registration{false};
     store::StoreEngine::ViewPlacement view_placement{store::StoreEngine::ViewPlacement::kUnspecified};
     std::string view_id;

--- a/daemon/service/controllers/registration_controller.cc
+++ b/daemon/service/controllers/registration_controller.cc
@@ -13,9 +13,11 @@
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "core/common/artifact_identity.h"
 #include "core/store/loader/view_planner.h"
 #include "daemon/status_utils.h"
 #include "opentelemetry/metrics/provider.h"
+#include "tensorcast/common/v1/common.pb.h"
 
 namespace tensorcast::daemon {
 
@@ -24,6 +26,19 @@ using ::grpc::StatusCode;
 using status_utils::to_grpc_status;
 
 namespace {
+
+tensorcast::common::v1::ArtifactIdKind ToProtoKind(tensorcast::common::ArtifactIdKind kind) {
+  using ProtoKind = tensorcast::common::v1::ArtifactIdKind;
+  switch (kind) {
+    case tensorcast::common::ArtifactIdKind::kCgid:
+      return ProtoKind::ARTIFACT_ID_KIND_CGID;
+    case tensorcast::common::ArtifactIdKind::kMi2:
+      return ProtoKind::ARTIFACT_ID_KIND_MI2;
+    case tensorcast::common::ArtifactIdKind::kUnspecified:
+    default:
+      return ProtoKind::ARTIFACT_ID_KIND_UNSPECIFIED;
+  }
+}
 
 absl::StatusOr<store::loader::ViewSpec> BuildViewSpecFromProto(const v1::ViewSpec& spec_proto) {
   store::loader::ViewSpec spec;
@@ -112,6 +127,17 @@ grpc::Status RegistrationController::begin(
   meta.total_size = req.total_size();
   meta.device_id = req.device_id();
   meta.owner_pid = req.owner_pid();
+  if (!req.client_artifact_id().empty()) {
+    auto id_status = common::validate_client_generated_id(req.client_artifact_id());
+    if (!id_status.ok()) {
+      return {StatusCode::INVALID_ARGUMENT, std::string(id_status.message())};
+    }
+    meta.id_kind = common::ArtifactIdKind::kCgid;
+    meta.client_artifact_id = req.client_artifact_id();
+  } else {
+    meta.id_kind = common::ArtifactIdKind::kMi2;
+    meta.client_artifact_id.clear();
+  }
   if (req.has_lease())
     meta.lease_in_place = req.lease().in_place();
   if (req.has_ttl_ms() && req.ttl_ms() > 0) {
@@ -152,6 +178,9 @@ grpc::Status RegistrationController::begin(
       reg.tensor_index_data = meta.index_data;
       reg.schema_version = req.tensor_index_data().schema_version();
       reg.encoding = req.tensor_index_data().encoding();
+    }
+    if (!meta.client_artifact_id.empty()) {
+      reg.client_artifact_id = meta.client_artifact_id;
     }
     auto begin_or = d_.engine.begin_register_artifact(reg);
     if (!begin_or.ok())
@@ -510,6 +539,8 @@ grpc::Status RegistrationController::commit(
         meta.ttl_ms,
         meta.epoch,
         meta.total_size,
+        meta.id_kind,
+        meta.client_artifact_id,
         meta.index_data,
         meta.index_key_hex,
         std::move(lease_vec),
@@ -537,6 +568,7 @@ grpc::Status RegistrationController::commit(
     desc->set_schema_version(out.schema_version);
     desc->set_encoding(out.encoding);
     desc->set_total_size(out.total_size);
+    desc->set_id_kind(ToProtoKind(out.id_kind));
     try {
       static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
       static auto counter = meter->CreateDoubleCounter("tc_register_commit_lip_total");
@@ -579,6 +611,7 @@ grpc::Status RegistrationController::commit(
     desc->set_schema_version(out.schema_version);
     desc->set_encoding(out.encoding);
     desc->set_total_size(out.size_bytes);
+    desc->set_id_kind(ToProtoKind(out.id_kind));
     resp.set_existed(out.existed);
     if (out.view_id.has_value()) {
       resp.set_view_id(*out.view_id);

--- a/daemon/types.h
+++ b/daemon/types.h
@@ -11,6 +11,7 @@
 #include "daemon/cuda_ipc_raii.h"
 
 #include "absl/container/flat_hash_map.h"
+#include "core/common/artifact_identity.h"
 
 namespace tensorcast::daemon {
 
@@ -55,6 +56,8 @@ struct RegisterTensorAliasMeta {
 struct LipLeaseEntry {
   std::string registration_id; // original registration id for keepalive/revoke
   std::string artifact_id;
+  std::string client_artifact_id;
+  tensorcast::common::ArtifactIdKind id_kind{tensorcast::common::ArtifactIdKind::kMi2};
   int device_id{0};
   int owner_pid{0};
   uint32_t ttl_ms{0};
@@ -86,6 +89,7 @@ struct CommitLeaseResult {
   std::string encoding; // e.g., "json"
   uint64_t total_size{0};
   std::string verification_json; // optional JSON payload
+  tensorcast::common::ArtifactIdKind id_kind{tensorcast::common::ArtifactIdKind::kMi2};
 };
 
 } // namespace tensorcast::daemon

--- a/docs/designs/0017-client-generated-artifact-id.md
+++ b/docs/designs/0017-client-generated-artifact-id.md
@@ -1,0 +1,188 @@
+---
+slug: client-generated-artifact-id
+title: Client‑Generated Artifact ID (CGID)
+areas: ["core","daemon","global_store","sdk","proto"]
+links:
+  prior_design: ./0007-content-addressed-artifact-id.md
+  session_api: ./0014-store-session-api-modernization.md
+  views: ./0016-artifact-view-v1.md
+related_code:
+  - core/store/**
+  - daemon/**
+  - tensorcast/global_store/**
+  - tensorcast/api/**
+---
+
+# Summary
+
+Introduce an alternative artifact identity kind, CGID (Client‑Generated ID), for high‑churn, runtime artifacts such as KVCache blocks used by PagedAttention. CGID complements, not replaces, the existing content‑addressed identity (mi2) defined in 0007. It removes server‑side hashing from hot registration paths while preserving simple routing, zero‑copy/P2P transport, and explicit lifecycle (register → serve → deregister).
+
+Key outcomes
+- Dual identity kinds: `artifact_id` can be either `mi2:...` (content‑addressed) or `cgid:...` (client‑generated).
+- Low‑overhead registration: CGID path skips `index_multihash`/`data_multihash` computation; daemon trusts a client‑supplied identifier.
+- Same verbs and flows: Keep `register/put/get/get_into` from 0014; a single optional `artifact_id` parameter (when set to a `cgid:`) selects the CGID path.
+- Short‑lived/ephemeral by default: CGID artifacts are intended for runtime residency with TTL/explicit deregistration; no tree‑hash leaves or de‑dup semantics.
+
+# Goals / Non‑Goals
+
+Goals
+- Eliminate commit‑time hashing for KV‑style high‑frequency registrations without changing the public API shape.
+- Preserve transport correctness and isolation: existing transport lock + staged export guarantees continue to apply.
+- Make identity space explicit and validated across SDK/daemon/Global Store (GS) so both `mi2:` and `cgid:` are first‑class.
+
+Non‑Goals
+- Do not remove or weaken mi2. Persistent, verifiable artifacts continue to use `mi2:`; CGID is additive.
+- Do not change P2P/IPC mechanics or memory plans (LIP/coalesced) beyond identity handling.
+- Do not introduce view planning, partial registration, or variant ByteSpaces here (see 0016). This document only establishes identity semantics.
+
+# Architecture & Interfaces
+
+## 1. Identity kinds and grammar
+
+- Identity kinds: `IDKind = { MI2, CGID }`.
+- `artifact_id` grammar (closed set of prefixes):
+  - `mi2:` — unchanged (see 0007)
+  - `cgid:` — client‑generated, opaque id. Validation:
+    - ASCII, length 8..200
+    - Allowed chars: RFC 3986 unreserved `[-._~A-Za-z0-9]` (covers hex and base64url without `=`)
+    - Recommended profile for KVCache: `cgid:<block_hash_hex64>` where `<block_hash_hex64>` is caller‑computed SHA‑256 hex of the logical block (or other collision‑resistant hash used by the engine). The daemon does not recompute or verify content.
+
+Semantics
+- `cgid:` denotes an ephemeral identity: no de‑dup, no tree‑hash, no GS leaves. Routing and transport are keyed by the id string and device residency.
+- `mi2:` denotes a persistent, verifiable identity with structural and data digests.
+
+Shared helpers
+- Python: `tensorcast.common.identity` defines `ArtifactIdKind`, `infer_artifact_id_kind()`, and `validate_client_generated_id()` so SDK and Global Store share grammar.
+- C++: `core/common/artifact_identity.h/.cc` expose the same helpers for the daemon, store engine, and tests, eliminating ad-hoc validation.
+
+## 2. SDK changes (0014 Store API compatible)
+
+Public facade remains unchanged; registration consolidates to a single optional identity parameter:
+
+```python
+# Optional artifact_id selects CGID when provided as a "cgid:" string
+tc.register(tensors, *,
+            artifact_id: str | None = None,   # when set and startswith("cgid:"), use CGID; otherwise compute mi2
+            key: str | None = None,
+            ttl_ms: int | None = None) -> RegisteredArtifact
+
+# Convenience wrappers (optional):
+# tc.register_cgid(tensors, cgid: str, *, key=None, ttl_ms=None)
+# tc.register_kv_block({"k": k, "v": v}, block_hash, *, ttl_ms=None)  # internally uses artifact_id=f"cgid:{block_hash}"
+```
+
+Rules
+- If `artifact_id` is provided and starts with `cgid:`, SDK uses the CGID path (no hashing) and forwards the id to the daemon; LIP/coalesced plan selection and storage graph collection are unchanged.
+- If `artifact_id` is not provided, SDK takes the mi2 path (content‑addressed) as today.
+- Supplying an `artifact_id` that does not start with `cgid:` is invalid (SDK or daemon rejects to avoid forged mi2 ids).
+- `ttl_ms` continues to control lease keepalive for LIP replicas; CGID favors short to medium TTL.
+- `get/get_into` accept either `artifact_id` (which can be `mi2:` or `cgid:`) or `key`, unchanged from 0014.
+
+## 3. Daemon changes (registration/commit identity)
+
+Extend the registration RPCs to accept an optional client‑provided identity and derive behavior from it (no explicit hashing mode parameter):
+
+Proto changes (now merged):
+```proto
+message BeginRegisterArtifactRequest {
+  // existing fields ...
+  string client_artifact_id = 1002;  // optional; when present and starts with "cgid:", server uses CGID path
+}
+
+message CommitRegisteredArtifactResponse {
+  tensorcast.common.v1.ArtifactDescriptor artifact_descriptor = 2;
+}
+```
+`tensorcast.common.v1.ArtifactDescriptor` includes `ArtifactIdKind id_kind = 7;`, and generated code in both languages exposes the strongly typed enum.
+
+Server behavior
+- `RegistrationController::begin()` validates `client_artifact_id` using the shared helper and records the desired identity kind in `RegistrationManager::RegMeta`.
+- `LipManager::commit_lease_in_place()` and `StoreEngine::commit_registered_artifact()` branch on the recorded kind:
+  - `MI2`: compute index/data multihashes, construct a `mi2:` descriptor, and populate digest fields.
+  - `CGID`: skip hashing entirely, mirror the client-supplied identifier, and leave digest fields empty.
+- `CommitLeaseResult` and `RegistrationCommitResult` propagate `id_kind` so downstream controllers, lifecycle leases, and responses remain consistent.
+
+Transport and locking
+- Unchanged. Transport locks and staged exports continue to require a stable `artifact_id` regardless of identity kind.
+
+## 4. Global Store changes (identity & routing)
+
+Identity recognition
+- gRPC handlers use `infer_artifact_id_kind()` to classify ids and reject invalid prefixes. Repository/service layers persist the explicit kind so policies and queries can pivot on `id_kind`.
+
+Persistence model
+- `schema.sql` and `tensorcast/global_store/init.sql` add `artifacts.id_kind TEXT NOT NULL DEFAULT 'MI2'`, relax the digest columns to accept `NULL`, and extend `artifact_replicas` with an optional `expires_at` timestamp.
+- Migration `tensorcast/global_store/migrations/0017_cgid.py` applies the same DDL for existing deployments; it is reversible.
+- `ArtifactRepository` upserts descriptors with explicit `id_kind`. `mi2:` records retain digests; `cgid:` records store `NULL` digests.
+- `ReplicaRepository` persists `expires_at` when supplied (favoring short-lived CGID replicas) while keeping existing write paths for MI2 replicas untouched.
+- Key mappings continue to target either identity kind; consumers must be prepared for empty digest fields when resolving CGID entries.
+
+Minimal schema evolution (illustrative; exact patch in the plan that changes `schema.sql`):
+```sql
+-- artifacts: add identity kind and relax digest nullability for CGID
+ALTER TABLE artifacts
+  ADD COLUMN id_kind TEXT NOT NULL DEFAULT 'MI2',
+  ALTER COLUMN index_multihash DROP NOT NULL,
+  ALTER COLUMN data_multihash DROP NOT NULL;
+
+-- replicas: ensure TTL/ephemeral residency can be tracked uniformly
+ALTER TABLE replicas
+  ADD COLUMN expires_at TIMESTAMPTZ NULL;
+```
+
+Routing behavior
+- `GetArtifactInfoById` must accept both id kinds. When the id has prefix `cgid:`, fields specific to mi2 (leaves, digests) are empty/omitted; callers should not request `include_leaves`.
+
+## 5. Error model & invariants
+
+Invariants
+- `artifact_id` prefix determines validation and downstream capabilities.
+- `cgid:` artifacts are not verifiable by tree hash within TensorCast; integrity is the caller’s responsibility. Transport correctness is still enforced (locks, PAD zero‑fill, range checks).
+- Canonical index bytes, when present, must remain self‑consistent with the provided storage/alias metadata; the daemon continues to enforce index layout rules in registration.
+- CGID descriptors intentionally propagate empty digest fields; consumers should treat `index_multihash` / `data_multihash` as unset when `id_kind` is `CGID`.
+
+Errors
+- `INVALID_ARGUMENT`: client supplied an `artifact_id`/`client_artifact_id` that does not start with `cgid:` or violates grammar.
+- `FAILED_PRECONDITION`: caller requests mi2‑only features (e.g., `include_leaves`) for a `cgid:` id.
+- `UNAVAILABLE`: no resident replica for a transient `cgid:` id and disk fallback is disabled/not applicable.
+
+## 6. Observability & policy
+
+- Tag metrics and logs with identity kind (derived from `artifact_id` prefix) to distinguish CGID vs MI2 paths (register latency, bytes, retries).
+- Admission control: deployments may configure policies to allow/deny CGID usage, enforce namespaces (e.g., `cgid:kv:<hash>`), or limit per‑tenant cardinality/TTL.
+
+# Compatibility & Acceptance Criteria
+
+Compatibility
+- SDK verbs (`register/put/get/get_into`) are unchanged; `artifact_id` parameters accept either `mi2:` or `cgid:`. Keys can continue to map to either kind.
+- Existing mi2 behavior and data remain intact.
+- LIP and coalesced memory plans, CUDA IPC export, and P2P transport are unaffected.
+
+Acceptance criteria
+- Registering with `artifact_id="cgid:..."` returns the same `artifact_id` and does not compute/return mi2 digests.
+- `get/get_into` successfully materialize replicas by CGID across nodes, using existing transport locks.
+- GS can list/resolve replicas for `cgid:` ids and omit mi2‑specific fields without breaking consumers.
+- Mixed deployments (some clients using mi2, some using CGID) operate without behavioral regressions.
+
+# Trade‑offs & Risks
+
+Trade‑offs
+- CGID trades away server‑side integrity verification and de‑duplication for speed and simplicity.
+- Duplicate CGIDs (caller error) would alias independent content; deployments should namespace or sign CGIDs where necessary.
+
+Risks & mitigations
+- Collision/abuse: recommend namespacing (`cgid:<ns>:<id>`), tenancy scoping, and rate/cardinality limits.
+- Misuse of mi2‑only APIs: explicit `id_kind` in responses and clear error codes reduce surprises; SDK wrappers can gate usage at call sites.
+
+# References
+
+- Identity (mi2): [0007 Content‑Addressed Artifact ID](./0007-content-addressed-artifact-id.md)
+- Session API: [0014 Store‑Centric Artifact Session API](./0014-store-session-api-modernization.md)
+- Views: [0016 Variant‑Aware Artifact Views](./0016-artifact-view-v1.md)
+
+- Key code locations for the implementation:
+  - `tensorcast/common/identity.py` and `core/common/artifact_identity.cc` — shared validation helpers and identity kind enum.
+  - `tensorcast/api/_register.py` & `tensorcast/api/store.py` — SDK path that accepts CGID, skips hashing, and surfaces `ArtifactIdKind`.
+  - `daemon/service/controllers/registration_controller.cc` & `daemon/lip_manager.cc` — daemon validation and CGID-aware commit path.
+  - `core/store/store_engine.cc` — Store engine commit logic propagating identity kind to Global Store.
+  - `tensorcast/global_store/repositories/*.py` & `tensorcast/global_store/grpc_service.py` — Global Store persistence and routing with `id_kind` and `expires_at` support.

--- a/docs/plans/0017-client-generated-artifact-id.md
+++ b/docs/plans/0017-client-generated-artifact-id.md
@@ -1,0 +1,68 @@
+---
+slug: client-generated-artifact-id
+title: Client-Generated Artifact ID (Plan)
+areas: ["core","daemon","global_store","sdk","proto"]
+links:
+  design: ../designs/0017-client-generated-artifact-id.md
+related_code:
+  - core/store/**
+  - daemon/**
+  - tensorcast/global_store/**
+  - tensorcast/api/**
+---
+
+# Objective
+
+Deliver client-generated artifact identifiers (CGID) end-to-end so SDKs can provide trusted `cgid:` values, the daemon registers them without server-side hashing, and the Global Store tracks residency and routing with appropriate schema updates while retaining mi2 compatibility.
+
+# Phases & Milestones
+
+- [x] Phase 0: Protocol & Validation Foundations
+  - [x] Milestone 0.1: Extend `BeginRegisterArtifactRequest` in `proto/tensorcast/daemon/v1/store_daemon.proto` with optional `client_artifact_id` and plumb through `CommitRegisteredArtifactResponse` / `tensorcast.common.v1.ArtifactDescriptor`; regenerate code via `tools/build_proto_python.sh` and `bazel build //proto/...`.
+  - [x] Milestone 0.2: Add shared artifact ID helper (`tensorcast/common/identity.py` for Python, `core/common/artifact_identity.h` for C++) that enforces CGID grammar and is consumed by `tensorcast/api/_register.py`, `daemon/lip_manager.cc`, and `tensorcast/global_store`.
+
+- [x] Phase 1: SDK Path Enablement
+  - [x] Milestone 1.1: Update `tensorcast/api/store.py` and `_register.py` so `Store.register()` accepts `artifact_id="cgid:..."`, skips mi2 hashing in `_register_artifact_core`, and plumbs the new identity kind from `CommitResult`.
+  - [x] Milestone 1.2: Add CGID-focused coverage in `tests/python/test_register_cgid.py` (new) or extend `tests/python/test_store_session_api.py`, asserting invalid prefix rejection and that `RegisteredArtifact.artifact_id` mirrors the provided CGID.
+
+- [x] Phase 2: Daemon & Core Registration Flow
+  - [x] Milestone 2.1: Store CGID intent in `daemon/types.h::LipLeaseEntry`, branch `daemon/lip_manager.cc::CommitLease` to bypass `common::compute_*_multihash` when `client_artifact_id` is set, and populate `CommitLeaseResult` accordingly.
+  - [x] Milestone 2.2: Update `daemon/grpc_service_impl.cc` and `daemon/service/controllers/registration_controller.cc` to validate CGID via the shared helper, record `identity_kind` metric labels in `daemon/metrics.*`, and keep mi2 flow untouched.
+  - [x] Milestone 2.3: Extend `core/store/store_engine_test.cc` and `daemon/grpc_service_impl_registration_test.cc` to assert both mi2 and CGID commits succeed, including mixed-device scenarios.
+
+- [x] Phase 3: Global Store Persistence & Routing
+  - [x] Milestone 3.1: Update `schema.sql` (artifacts table adds `id_kind`, digest columns nullable; `artifact_replicas` gains `expires_at`) and refresh bootstrap `tensorcast/global_store/init.sql`; introduce a DuckDB migration helper module (e.g., `tensorcast/global_store/migrations/0017_cgid.py`) so existing deployments can apply the DDL.
+  - [x] Milestone 3.2: Modify `tensorcast/global_store/services/artifact_service.py` and repository layers (`repositories/artifact_repository.py`, `repositories/replica_repository.py`, `repositories/key_mapping_repository.py`) so lookup/write paths persist `id_kind`, omit mi2-only columns for CGID, and expose identity kind through RPC payloads.
+  - [x] Milestone 3.3: Extend integration coverage in `tests/python/global_store/test_artifacts.py` (or sibling suite) for CGID registrations, ensuring key mappings (`key_mappings` table) and replica listings work with mixed ID kinds.
+
+- [x] Phase 4: Rollout, Compatibility & Documentation
+  - [x] Milestone 4.1: Update relevant READMEs/AGENTS with CGID guidance and rollout guardrails.
+  - [x] Milestone 4.2: Finalize production rollout guidance—CGID is enabled by default (no feature flag), document operational metrics, and spell out backout procedures.
+
+# Tasks
+
+- Define `ArtifactIdKind` utilities shared across SDK (`tensorcast/common/identity.py`), daemon (`core/common/artifact_identity.h/.cc`), and GS validation logic.
+- Align SDK response models (`tensorcast/types.py::ArtifactDescriptor`, any dataclasses referenced in `tensorcast/api/store.py`) with new `identity_kind` field and nullable digests.
+- Adjust daemon RPC handlers (`daemon/service/controllers/registration_controller.cc`, `daemon/grpc_service_impl.cc`) to accept `client_artifact_id`, populate `CommitRegisteredArtifactResponse.artifact_descriptor` with CGID, and only compute mi2 digests when missing; tag OpenTelemetry counters in the same controller with `identity_kind`.
+- Wire daemon-to-GS update calls (registration controller interactions with `d_.reg` / `d_.engine` plus any `global_store` client hooks) to send identity kind and TTL metadata; update GS ingestion accordingly.
+- Add Bazel targets/deps exposing the new identity helper header (`core/common/BUILD.bazel`, `core/store/BUILD.bazel`) for reuse in store engine and tests.
+- Create migration script for DuckDB deployments applying schema alterations with reversible DDL.
+- Refresh documentation indexes listing CGID support and cross-link plan/design.
+- Remove transitional compatibility toggles so CGID code paths are always available; callers supply CGID identifiers without any gating.
+
+# Test / Rollout / Backout
+
+- Unit: `uv run pytest tests/python/test_register_cgid.py` (executed).
+- Integration: `uv run pytest tests/python/global_store/test_grpc_service.py::TestGRPCService::test_register_replica_with_cgid` (executed) and extend broader suites as needed.
+- C++: `bazel test //daemon:session_lifecycle_test //core/store:store_engine_test --define=use_fake_cuda=true` (executed).
+- Proto/Buf validation: `bazel test //proto/... --test_output=streamed`.
+- Migration dry-run: apply DuckDB schema patch on staging snapshot, verify mixed mi2/CGID records.
+- Rollout: deploy the CGID-capable daemon/GS builds directly; monitor `register_latency{identity_kind="cgid"}` and replica residency metrics to confirm healthy adoption.
+- Backout: block CGID registrations at the daemon (reject `client_artifact_id`) and revert the schema migration using `tensorcast/global_store/migrations/0017_cgid.py::downgrade`, restoring pre-change artifacts if necessary.
+
+# Risks & Tracking
+
+- Collision or misuse of CGID values: require tenancy-scoped prefixes and add monitoring for duplicate registrations per namespace.
+- Mixed-client compatibility: ensure SDK version gating—older clients must default to mi2; publish upgrade note.
+- Schema migration fallout: mitigate with migration dry-run, automated backups, and revert script.
+- Observability drift: coordinate metric name changes with dashboards; flag in release checklist.

--- a/proto/tensorcast/common/v1/common.proto
+++ b/proto/tensorcast/common/v1/common.proto
@@ -21,6 +21,13 @@ message ArtifactDescriptor {
   string schema_version = 4;
   string encoding = 5;
   uint64 total_size = 6;
+  ArtifactIdKind id_kind = 7;
+}
+
+enum ArtifactIdKind {
+  ARTIFACT_ID_KIND_UNSPECIFIED = 0;
+  ARTIFACT_ID_KIND_MI2 = 1;
+  ARTIFACT_ID_KIND_CGID = 2;
 }
 
 enum MemoryType {

--- a/proto/tensorcast/daemon/v1/store_daemon.proto
+++ b/proto/tensorcast/daemon/v1/store_daemon.proto
@@ -401,6 +401,7 @@ message BeginRegisterArtifactRequest {
   uint64 total_size = 2; // Total size in bytes (8-byte aligned)
   optional uint32 ttl_ms = 3; // TTL for registration (milliseconds), used by Lease
   int32 owner_pid = 6; // REQUIRED: Owner process ID for lease lifecycle (must be > 0)
+  string client_artifact_id = 1002; // Optional client-provided artifact identity (cgid:...)
 
   // Tensor index can be provided as key or data
   oneof index {

--- a/schema.sql
+++ b/schema.sql
@@ -41,11 +41,12 @@ CREATE INDEX IF NOT EXISTS idx_workers_registered_at ON workers (registered_at);
 -- Artifacts: content-addressed artifact IDs (design-0007)
 CREATE TABLE IF NOT EXISTS artifacts (
     artifact_id TEXT PRIMARY KEY,          -- "mi2:<index_multihash>:<data_multihash>"
-    index_multihash TEXT NOT NULL,         -- Multibase over multihash (sha2-256), base32
-    data_multihash TEXT NOT NULL,          -- Multibase over multihash (sha2-256 root), base32
+    index_multihash TEXT NULL,         -- Multibase over multihash (sha2-256), base32
+    data_multihash TEXT NULL,          -- Multibase over multihash (sha2-256 root), base32
     schema_version TEXT NOT NULL DEFAULT 'v3',          -- canonical index schema version
     encoding TEXT NOT NULL,                -- e.g., "json" or future "cbor"
     hash_params_json TEXT NULL,            -- JSON string for hashing params (e.g., chunk_size, fanout)
+    id_kind TEXT NOT NULL DEFAULT 'MI2',   -- Identity kind (MI2 or CGID)
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -75,6 +76,7 @@ CREATE TABLE IF NOT EXISTS artifact_replicas (
     is_memory_replica BOOLEAN DEFAULT FALSE,
     tensor_index_key TEXT NULL,
     source_process_id TEXT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );

--- a/tensorcast/api/_register.py
+++ b/tensorcast/api/_register.py
@@ -46,6 +46,7 @@ from tensorcast.api._indices import (
 from tensorcast.api._io_disk import save_dict
 from tensorcast.api._runtime import require_runtime
 from tensorcast.api._utils import validate_disk_index_matches
+from tensorcast.common.identity import ArtifactIdKind, validate_client_generated_id
 from tensorcast.observability.otel import ensure_client_otel
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
 from tensorcast.types import (
@@ -954,6 +955,7 @@ def _register_artifact_core(
     options: RegisterArtifactOptions,
     device_id: int | torch.device | None,
     ttl_ms: int | None,
+    client_artifact_id: str | None = None,
     force_lease_in_place: bool = False,
     prevalidate_disk: bool = True,
     client: DaemonCtl | None = None,
@@ -979,6 +981,20 @@ def _register_artifact_core(
         target_device_id = resolve_device(device_id)
     elif isinstance(device_id, int):
         target_device_id = int(device_id)
+
+    normalized_artifact_id: str | None = None
+    identity_kind = ArtifactIdKind.MI2
+    if client_artifact_id:
+        candidate = client_artifact_id.strip()
+        if candidate:
+            try:
+                validate_client_generated_id(candidate)
+            except ValueError as exc:
+                raise TensorCastError(str(exc)) from exc
+            normalized_artifact_id = candidate
+            identity_kind = ArtifactIdKind.CGID
+        else:
+            normalized_artifact_id = None
 
     if view is None:
         ctx, layout, index_bytes = _prepare_build(artifact, device_id)
@@ -1034,6 +1050,10 @@ def _register_artifact_core(
     }
 
     with tracer.start_as_current_span(span_names[plan_type], kind=SpanKind.INTERNAL):
+        span = trace.get_current_span()
+        span.set_attribute("tc.artifact.identity_kind", identity_kind.value)
+        if normalized_artifact_id:
+            span.set_attribute("tc.artifact.client_artifact_id", normalized_artifact_id)
         begin_response = ctl.begin_register_artifact(
             device_id=ctx.device_id,
             total_size_bytes=layout.total_size,
@@ -1041,6 +1061,7 @@ def _register_artifact_core(
             tensor_index_data=index_bytes,
             encoding="json",
             schema_version="v3",
+            client_artifact_id=normalized_artifact_id,
             plan=plan_model,
             view=view.view_options if view is not None else None,
             timeout_s=60.0,

--- a/tensorcast/api/store.py
+++ b/tensorcast/api/store.py
@@ -686,8 +686,10 @@ class Store:
     def _canonical_index_from_result(
         self, result: RegistrationResult
     ) -> CanonicalIndex:
+        avbs_hash = result.descriptor.data_multihash or ""
         return self._canonical_index_from_bytes(
-            result.index_bytes, avbs_hash=result.descriptor.data_multihash
+            result.index_bytes,
+            avbs_hash=avbs_hash,
         )
 
     @staticmethod

--- a/tensorcast/api/store.py
+++ b/tensorcast/api/store.py
@@ -821,6 +821,7 @@ class Store:
         self,
         tensors: TensorDict,
         *,
+        artifact_id: str | None,
         key: str | None,
         plan: PlanType,
         cancel_event: threading.Event | None = None,
@@ -860,6 +861,9 @@ class Store:
                 lease_in_place=plan is PlanType.VRAM_LEASED,
                 key=resolved_key,
             )
+        normalized_artifact_id = artifact_id.strip() if artifact_id else None
+        if normalized_artifact_id == "":
+            normalized_artifact_id = None
         ttl_ms = (
             ttl_override
             if ttl_override is not None
@@ -879,6 +883,7 @@ class Store:
                 options=options,
                 device_id=device_id,
                 ttl_ms=ttl_ms,
+                client_artifact_id=normalized_artifact_id,
                 force_lease_in_place=plan is PlanType.VRAM_LEASED,
                 prevalidate_disk=self._should_prevalidate_disk(options),
                 client=self._ensure_client(),
@@ -947,6 +952,7 @@ class Store:
         self,
         tensors: TensorDict,
         *,
+        artifact_id: str | None = None,
         key: str | None,
         plan: PlanType,
         cancel_event: threading.Event | None = None,
@@ -963,6 +969,7 @@ class Store:
             "tc.store.session_id": self._session_id,
             "tc.store.plan": plan.value,
             "tc.store.key_present": bool(key),
+            "tc.store.client_artifact_id": artifact_id or "",
         }
         policy = self._retry_policies.get(method)
         attempt = 1
@@ -991,6 +998,7 @@ class Store:
                 try:
                     result = self._attempt_registration(
                         tensors,
+                        artifact_id=artifact_id,
                         key=key,
                         plan=plan,
                         cancel_event=cancel_event,
@@ -2073,12 +2081,14 @@ class Store:
         self,
         tensors: TensorDict,
         *,
+        artifact_id: str | None = None,
         key: str | None = None,
         options: RegisterArtifactOptions | None = None,
         ttl_ms: int | None = None,
     ) -> RegisteredArtifact:
         return self._perform_registration(
             tensors,
+            artifact_id=artifact_id,
             key=key,
             plan=PlanType.VRAM_LEASED,
             options_override=options,
@@ -2089,6 +2099,7 @@ class Store:
         self,
         tensors: TensorDict,
         *,
+        artifact_id: str | None = None,
         key: str | None = None,
         options: RegisterArtifactOptions | None = None,
         ttl_ms: int | None = None,
@@ -2105,6 +2116,7 @@ class Store:
             try:
                 return self._perform_registration(
                     tensors,
+                    artifact_id=artifact_id,
                     key=key,
                     plan=PlanType.VRAM_LEASED,
                     cancel_event=cancel_event,
@@ -2233,12 +2245,14 @@ class Store:
         self,
         tensors: TensorDict,
         *,
+        artifact_id: str | None = None,
         key: str | None = None,
         options: RegisterArtifactOptions | None = None,
         device: int | torch.device | None = None,
     ) -> RegisteredArtifact:
         return self._perform_registration(
             tensors,
+            artifact_id=artifact_id,
             key=key,
             plan=PlanType.VRAM_COALESCED,
             options_override=options,
@@ -2249,6 +2263,7 @@ class Store:
         self,
         tensors: TensorDict,
         *,
+        artifact_id: str | None = None,
         key: str | None = None,
         options: RegisterArtifactOptions | None = None,
         device: int | torch.device | None = None,
@@ -2265,6 +2280,7 @@ class Store:
             try:
                 return self._perform_registration(
                     tensors,
+                    artifact_id=artifact_id,
                     key=key,
                     plan=PlanType.VRAM_COALESCED,
                     cancel_event=cancel_event,
@@ -2727,22 +2743,31 @@ def _coerce_store() -> Store:
 def register(
     tensors: TensorDict,
     *,
+    artifact_id: str | None = None,
     key: str | None = None,
     options: RegisterArtifactOptions | None = None,
     ttl_ms: int | None = None,
 ) -> RegisteredArtifact:
-    return _coerce_store().register(tensors, key=key, options=options, ttl_ms=ttl_ms)
+    return _coerce_store().register(
+        tensors,
+        artifact_id=artifact_id,
+        key=key,
+        options=options,
+        ttl_ms=ttl_ms,
+    )
 
 
 def register_async(
     tensors: TensorDict,
     *,
+    artifact_id: str | None = None,
     key: str | None = None,
     options: RegisterArtifactOptions | None = None,
     ttl_ms: int | None = None,
 ) -> ArtifactFuture[RegisteredArtifact]:
     return _coerce_store().register_async(
         tensors,
+        artifact_id=artifact_id,
         key=key,
         options=options,
         ttl_ms=ttl_ms,
@@ -2779,22 +2804,31 @@ def register_view(
 def put(
     tensors: TensorDict,
     *,
+    artifact_id: str | None = None,
     key: str | None = None,
     options: RegisterArtifactOptions | None = None,
     device: int | torch.device | None = None,
 ) -> RegisteredArtifact:
-    return _coerce_store().put(tensors, key=key, options=options, device=device)
+    return _coerce_store().put(
+        tensors,
+        artifact_id=artifact_id,
+        key=key,
+        options=options,
+        device=device,
+    )
 
 
 def put_async(
     tensors: TensorDict,
     *,
+    artifact_id: str | None = None,
     key: str | None = None,
     options: RegisterArtifactOptions | None = None,
     device: int | torch.device | None = None,
 ) -> ArtifactFuture[RegisteredArtifact]:
     return _coerce_store().put_async(
         tensors,
+        artifact_id=artifact_id,
         key=key,
         options=options,
         device=device,

--- a/tensorcast/common/__init__.py
+++ b/tensorcast/common/__init__.py
@@ -1,0 +1,19 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from tensorcast.common.identity import (
+    CGID_PREFIX,
+    MI2_PREFIX,
+    ArtifactIdKind,
+    infer_artifact_id_kind,
+    validate_artifact_id,
+    validate_client_generated_id,
+)
+
+__all__ = [
+    "ArtifactIdKind",
+    "CGID_PREFIX",
+    "MI2_PREFIX",
+    "infer_artifact_id_kind",
+    "validate_artifact_id",
+    "validate_client_generated_id",
+]

--- a/tensorcast/common/identity.py
+++ b/tensorcast/common/identity.py
@@ -1,0 +1,70 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+
+MI2_PREFIX: str = "mi2:"
+CGID_PREFIX: str = "cgid:"
+_CGID_ALLOWED: re.Pattern[str] = re.compile(r"^[-._~A-Za-z0-9]+$")
+_CGID_MIN_LEN: int = 8
+_CGID_MAX_LEN: int = 200
+
+
+class ArtifactIdKind(str, Enum):
+    """Classifier for artifact identity schemes."""
+
+    MI2 = "MI2"
+    CGID = "CGID"
+
+
+def _ensure_ascii(value: str) -> None:
+    if not value.isascii():
+        raise ValueError("artifact_id must be ASCII")
+
+
+def infer_artifact_id_kind(artifact_id: str) -> ArtifactIdKind | None:
+    """Return the identity kind implied by the artifact_id prefix."""
+    if artifact_id.startswith(MI2_PREFIX):
+        return ArtifactIdKind.MI2
+    if artifact_id.startswith(CGID_PREFIX):
+        return ArtifactIdKind.CGID
+    return None
+
+
+def validate_client_generated_id(artifact_id: str) -> None:
+    """Validate the grammar for a client-generated artifact identifier."""
+    if not artifact_id.startswith(CGID_PREFIX):
+        raise ValueError("client_artifact_id must start with 'cgid:'")
+    _ensure_ascii(artifact_id)
+    if not (_CGID_MIN_LEN <= len(artifact_id) <= _CGID_MAX_LEN):
+        raise ValueError(
+            "client_artifact_id length must be between 8 and 200 characters"
+        )
+    suffix = artifact_id[len(CGID_PREFIX) :]
+    if not suffix:
+        raise ValueError("client_artifact_id requires a suffix after 'cgid:'")
+    if not _CGID_ALLOWED.fullmatch(suffix):
+        raise ValueError("client_artifact_id contains invalid characters")
+
+
+def validate_artifact_id(artifact_id: str) -> ArtifactIdKind:
+    """Validate an artifact identifier and return its kind."""
+    kind = infer_artifact_id_kind(artifact_id)
+    if kind is ArtifactIdKind.MI2:
+        return kind
+    if kind is ArtifactIdKind.CGID:
+        validate_client_generated_id(artifact_id)
+        return kind
+    raise ValueError("artifact_id must start with 'mi2:' or 'cgid:'")
+
+
+__all__ = [
+    "ArtifactIdKind",
+    "CGID_PREFIX",
+    "MI2_PREFIX",
+    "infer_artifact_id_kind",
+    "validate_artifact_id",
+    "validate_client_generated_id",
+]

--- a/tensorcast/daemon_ctl.py
+++ b/tensorcast/daemon_ctl.py
@@ -25,6 +25,7 @@ from tensorcast.proto.daemon.v1 import (
 )
 from tensorcast.types import (
     ArtifactDescriptor,
+    ArtifactIdKind,
     BeginRegisterArtifactResult,
     CanonicalRange,
     CoalescedHandshake,
@@ -654,6 +655,7 @@ class DaemonCtl:
         tensor_index_data: bytes | None = None,
         encoding: str = "json",
         schema_version: str = "v2",
+        client_artifact_id: str | None = None,
         plan: Plan | None = None,
         timeout_s: float = 30.0,
         view: store_daemon_pb2.ViewRegistrationOptions | None = None,
@@ -699,6 +701,9 @@ class DaemonCtl:
             )
         else:
             req.tensor_index_key = tensor_index_key or ""
+
+        if client_artifact_id:
+            req.client_artifact_id = client_artifact_id
 
         # Plan oneof
         if plan is None:
@@ -812,6 +817,7 @@ class DaemonCtl:
                 schema_version=desc.schema_version,
                 encoding=desc.encoding,
                 total_size=int(desc.total_size),
+                id_kind=desc.id_kind,
             )
             canonical_ranges: tuple[CanonicalRange, ...] = tuple(
                 CanonicalRange(offset=int(r.offset), length=int(r.length))
@@ -1052,11 +1058,16 @@ class DaemonCtl:
         # Map our typed descriptor into proto
         pb = common_pb2.ArtifactDescriptor(
             artifact_id=descriptor.artifact_id,
-            index_multihash=descriptor.index_multihash,
-            data_multihash=descriptor.data_multihash,
-            schema_version=descriptor.schema_version,
-            encoding=descriptor.encoding,
+            index_multihash=descriptor.index_multihash or "",
+            data_multihash=descriptor.data_multihash or "",
+            schema_version=descriptor.schema_version or "",
+            encoding=descriptor.encoding or "",
             total_size=int(descriptor.total_size),
+        )
+        pb.id_kind = (
+            common_pb2.ArtifactIdKind.ARTIFACT_ID_KIND_CGID
+            if descriptor.id_kind is ArtifactIdKind.CGID
+            else common_pb2.ArtifactIdKind.ARTIFACT_ID_KIND_MI2
         )
         req.artifact_descriptor.CopyFrom(pb)
 

--- a/tensorcast/global_store/README.md
+++ b/tensorcast/global_store/README.md
@@ -8,6 +8,8 @@ This document explains the internal implementation of the Global Store (central 
 - Storage: DuckDB (in-memory by default; optional persistent file).
 - Interface: gRPC (unary-unary RPCs) with Prometheus metrics export.
 - Runtime: Background maintenance thread (cleanup + VACUUM), batched heartbeats.
+- Artifact identity kinds: supports both MI2 (content-addressed) and CGID
+  (client-supplied, hashless) descriptors.
 
 ## Configuration
 

--- a/tensorcast/global_store/grpc_service.py
+++ b/tensorcast/global_store/grpc_service.py
@@ -19,6 +19,7 @@ import duckdb  # DuckDB is a runtime dependency; ignore missing stubs in type ch
 import grpc
 from google.protobuf import timestamp_pb2
 
+from tensorcast.common.identity import ArtifactIdKind, infer_artifact_id_kind
 from tensorcast.global_store.config import get_config
 from tensorcast.global_store.db_utils import init_db, optimize_db
 from tensorcast.global_store.exceptions import (
@@ -612,28 +613,41 @@ class GlobalStoreServicer(global_store_pb2_grpc.GlobalStoreServiceServicer):
             # Parse `mi2:` artifact_id and extract index/data multihash when present. If the
             # upstream StoreDaemon later extends the proto to include descriptor, prefer that.
             artifact_id = registered.artifact_id
-            if artifact_id and artifact_id.startswith("mi2:"):
-                # Expected format: mi2:<index_multihash>:<data_multihash>
+            kind = infer_artifact_id_kind(artifact_id) if artifact_id else None
+            if artifact_id and kind is ArtifactIdKind.MI2:
                 parts = artifact_id.split(":", 2)
-                if len(parts) == 3 and parts[1] and parts[2]:
-                    index_mh = parts[1]
-                    data_mh = parts[2]
-                    # Best-effort encoding/schema; can be refined when descriptor is carried in proto
-                    encoding = "json"
-                    try:
-                        self.artifacts_repo.upsert_artifact(
-                            artifact_id=artifact_id,
-                            index_multihash=index_mh,
-                            data_multihash=data_mh,
-                            schema_version=schema_version_value,
-                            encoding=encoding,
-                            hash_params_json=None,
-                        )
-                    except Exception as e:  # noqa: BLE001
-                        # Do not fail the registration if descriptor persistence fails
-                        logger.warning(
-                            f"Failed to upsert artifacts entry for {artifact_id}: {e}"
-                        )
+                index_mh = parts[1] if len(parts) == 3 else None
+                data_mh = parts[2] if len(parts) == 3 else None
+                encoding = "json"
+                try:
+                    self.artifacts_repo.upsert_artifact(
+                        artifact_id=artifact_id,
+                        index_multihash=index_mh,
+                        data_multihash=data_mh,
+                        schema_version=schema_version_value,
+                        encoding=encoding,
+                        hash_params_json=None,
+                        id_kind="MI2",
+                    )
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        f"Failed to upsert artifacts entry for {artifact_id}: {e}"
+                    )
+            elif artifact_id and kind is ArtifactIdKind.CGID:
+                try:
+                    self.artifacts_repo.upsert_artifact(
+                        artifact_id=artifact_id,
+                        index_multihash=None,
+                        data_multihash=None,
+                        schema_version=schema_version_value,
+                        encoding="json",
+                        hash_params_json=None,
+                        id_kind="CGID",
+                    )
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        f"Failed to upsert CGID artifact entry for {artifact_id}: {e}"
+                    )
 
             # If canonical index data is provided, store it for de-duplication
             if request.HasField("tensor_index_data") and request.tensor_index_data:

--- a/tensorcast/global_store/init.sql
+++ b/tensorcast/global_store/init.sql
@@ -26,11 +26,12 @@ CREATE INDEX idx_workers_registered_at ON workers (registered_at);
 -- Artifacts table for content-addressed artifact IDs (RFC-0007)
 CREATE TABLE IF NOT EXISTS artifacts (
     artifact_id TEXT PRIMARY KEY,             -- "mi2:<index_multihash>:<data_multihash>"
-    index_multihash TEXT NOT NULL,         -- Multibase over multihash (sha2-256), base32
-    data_multihash TEXT NOT NULL,          -- Multibase over multihash (sha2-256 root), base32
+    index_multihash TEXT NULL,         -- Multibase over multihash (sha2-256), base32
+    data_multihash TEXT NULL,          -- Multibase over multihash (sha2-256 root), base32
     schema_version TEXT NOT NULL DEFAULT 'v3',          -- canonical index schema version
     encoding TEXT NOT NULL,                -- e.g., "json" or future "cbor"
     hash_params_json TEXT NULL,            -- JSON string for hashing params (e.g., chunk_size, fanout)
+    id_kind TEXT NOT NULL DEFAULT 'MI2',   -- Artifact identity kind (MI2 or CGID)
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -59,6 +60,7 @@ CREATE TABLE IF NOT EXISTS artifact_replicas (
     is_memory_replica BOOLEAN DEFAULT FALSE,
     tensor_index_key TEXT NULL,
     source_process_id TEXT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );

--- a/tensorcast/global_store/migrations/0017_cgid.py
+++ b/tensorcast/global_store/migrations/0017_cgid.py
@@ -1,0 +1,38 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+"""Migration 0017: introduce CGID identity kind columns.
+
+This migration aligns the DuckDB schema with design 0017 by
+tracking artifact identity kinds and allowing CGID rows to omit
+multihash digests while providing replica expiry metadata.
+"""
+
+from __future__ import annotations
+
+from duckdb import DuckDBPyConnection
+
+UP_QUERIES: tuple[str, ...] = (
+    "ALTER TABLE artifacts ADD COLUMN id_kind TEXT NOT NULL DEFAULT 'MI2';",
+    "ALTER TABLE artifacts ALTER COLUMN index_multihash DROP NOT NULL;",
+    "ALTER TABLE artifacts ALTER COLUMN data_multihash DROP NOT NULL;",
+    "ALTER TABLE artifact_replicas ADD COLUMN expires_at TIMESTAMPTZ NULL;",
+)
+
+DOWN_QUERIES: tuple[str, ...] = (
+    "ALTER TABLE artifact_replicas DROP COLUMN IF EXISTS expires_at;",
+    "ALTER TABLE artifacts DROP COLUMN IF EXISTS id_kind;",
+    "ALTER TABLE artifacts ALTER COLUMN index_multihash SET NOT NULL;",
+    "ALTER TABLE artifacts ALTER COLUMN data_multihash SET NOT NULL;",
+)
+
+
+def upgrade(conn: DuckDBPyConnection) -> None:
+    """Apply migration 0017."""
+    for query in UP_QUERIES:
+        conn.execute(query)
+
+
+def downgrade(conn: DuckDBPyConnection) -> None:
+    """Rollback migration 0017."""
+    for query in DOWN_QUERIES:
+        conn.execute(query)

--- a/tensorcast/global_store/models/replica.py
+++ b/tensorcast/global_store/models/replica.py
@@ -65,6 +65,7 @@ class Replica:
     # Timestamps
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    expires_at: datetime | None = None
 
     @property
     def load_ratio(self) -> float:

--- a/tensorcast/global_store/repositories/artifact_repository.py
+++ b/tensorcast/global_store/repositories/artifact_repository.py
@@ -24,11 +24,12 @@ class ArtifactRepository(BaseRepository):
         self,
         *,
         artifact_id: str,
-        index_multihash: str,
-        data_multihash: str,
+        index_multihash: str | None,
+        data_multihash: str | None,
         schema_version: str,
         encoding: str,
         hash_params_json: Optional[str] = None,
+        id_kind: str = "MI2",
     ) -> None:
         """Create or update an artifact descriptor row by primary key `artifact_id`.
 
@@ -43,14 +44,16 @@ class ArtifactRepository(BaseRepository):
                 data_multihash,
                 schema_version,
                 encoding,
-                hash_params_json
-            ) VALUES (?, ?, ?, ?, ?, ?)
+                hash_params_json,
+                id_kind
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (artifact_id) DO UPDATE SET
                 index_multihash = EXCLUDED.index_multihash,
                 data_multihash = EXCLUDED.data_multihash,
                 schema_version = EXCLUDED.schema_version,
                 encoding = EXCLUDED.encoding,
-                hash_params_json = EXCLUDED.hash_params_json
+                hash_params_json = EXCLUDED.hash_params_json,
+                id_kind = EXCLUDED.id_kind
             """,
             [
                 artifact_id,
@@ -59,6 +62,7 @@ class ArtifactRepository(BaseRepository):
                 schema_version,
                 encoding,
                 hash_params_json,
+                id_kind,
             ],
         )
 
@@ -67,7 +71,7 @@ class ArtifactRepository(BaseRepository):
         cursor = self.get_cursor()
         row = cursor.execute(
             """
-            SELECT artifact_id, index_multihash, data_multihash, schema_version, encoding, hash_params_json, created_at
+            SELECT artifact_id, index_multihash, data_multihash, schema_version, encoding, hash_params_json, id_kind, created_at
             FROM artifacts WHERE artifact_id = ?
             """,
             [artifact_id],
@@ -81,5 +85,6 @@ class ArtifactRepository(BaseRepository):
             "schema_version": row[3],
             "encoding": row[4],
             "hash_params_json": row[5],
-            "created_at": row[6],
+            "created_at": row[7],
+            "id_kind": row[6],
         }

--- a/tensorcast/global_store/repositories/replica_repository.py
+++ b/tensorcast/global_store/repositories/replica_repository.py
@@ -3,6 +3,7 @@
 """Repository for artifact replica data access."""
 
 import time
+from collections.abc import Sequence
 from uuid import UUID
 
 from tensorcast.global_store.exceptions import NotFoundError
@@ -38,7 +39,7 @@ class ReplicaRepository(BaseRepository):
     def find_by_id(self, replica_id: UUID, artifact_id: str) -> Replica | None:
         """Find a replica by ID and content-addressed artifact_id."""
         cursor = self.get_cursor()
-        result = cursor.execute(
+        query = cursor.execute(
             """
             SELECT
                 mr.replica_id,
@@ -64,10 +65,12 @@ class ReplicaRepository(BaseRepository):
             WHERE mr.replica_id = ? AND mr.artifact_id = ?
             """,
             [str(replica_id), artifact_id],
-        ).fetchone()
+        )
 
-        if result:
-            return self._row_to_model(result)
+        row = query.fetchone()
+        if row:
+            columns = [desc[0] for desc in query.description]
+            return self._row_to_model(row, columns)
         return None
 
     def find_existing(
@@ -81,7 +84,7 @@ class ReplicaRepository(BaseRepository):
     ) -> Replica | None:
         """Find existing replica with same identifying information."""
         cursor = self.get_cursor()
-        result = cursor.execute(
+        query = cursor.execute(
             """
             SELECT
                 mr.replica_id,
@@ -119,10 +122,12 @@ class ReplicaRepository(BaseRepository):
                 memory_type.value,
                 device_id,
             ],
-        ).fetchone()
+        )
 
-        if result:
-            return self._row_to_model(result)
+        row = query.fetchone()
+        if row:
+            columns = [desc[0] for desc in query.description]
+            return self._row_to_model(row, columns)
         return None
 
     def find_available_for_transport(
@@ -184,7 +189,7 @@ class ReplicaRepository(BaseRepository):
         replica_id = row[0]
 
         # Fetch full replica data including current_requests
-        full_row = cursor.execute(
+        result = cursor.execute(
             """
             SELECT
                 mr.replica_id,
@@ -210,10 +215,12 @@ class ReplicaRepository(BaseRepository):
             WHERE mr.replica_id = ?
             """,
             [str(replica_id)],
-        ).fetchone()
+        )
 
+        full_row = result.fetchone()
         if full_row:
-            return self._row_to_model(full_row)
+            columns = [desc[0] for desc in result.description]
+            return self._row_to_model(full_row, columns)
         return None
 
     def create(self, replica: Replica) -> Replica:
@@ -568,7 +575,9 @@ class ReplicaRepository(BaseRepository):
             params.append(device_id)
 
         result = cursor.execute(query, params)
-        replicas = [self._row_to_model(row) for row in result.fetchall()]
+        columns = [desc[0] for desc in result.description]
+        rows = result.fetchall()
+        replicas = [self._row_to_model(row, columns) for row in rows]
         return replicas
 
     def mark_unavailable_by_worker(self, worker_id: str) -> int:
@@ -631,7 +640,9 @@ class ReplicaRepository(BaseRepository):
             """
         )
 
-        return [self._row_to_model(row) for row in result.fetchall()]
+        columns = [desc[0] for desc in result.description]
+        rows = result.fetchall()
+        return [self._row_to_model(row, columns) for row in rows]
 
     def mark_as_stale(self, replica_id: UUID) -> bool:
         """Mark a replica as stale (for recovery purposes)."""
@@ -704,7 +715,9 @@ class ReplicaRepository(BaseRepository):
             """
         )
 
-        orphaned = [self._row_to_model(row) for row in result.fetchall()]
+        columns = [desc[0] for desc in result.description]
+        rows = result.fetchall()
+        orphaned = [self._row_to_model(row, columns) for row in rows]
         if orphaned:
             logger.warning(f"Found {len(orphaned)} orphaned replicas")
         return orphaned
@@ -741,7 +754,9 @@ class ReplicaRepository(BaseRepository):
             [worker_id],
         )
 
-        return [self._row_to_model(row) for row in result.fetchall()]
+        columns = [desc[0] for desc in result.description]
+        rows = result.fetchall()
+        return [self._row_to_model(row, columns) for row in rows]
 
     def update_worker_id(self, replica_id: UUID, new_worker_id: str) -> bool:
         """Update the worker_id for a replica."""
@@ -795,7 +810,9 @@ class ReplicaRepository(BaseRepository):
             [recovery_time],
         )
 
-        return [self._row_to_model(row) for row in result.fetchall()]
+        columns = [desc[0] for desc in result.description]
+        rows = result.fetchall()
+        return [self._row_to_model(row, columns) for row in rows]
 
     def cleanup_stale_replicas(self, recovery_time: int) -> int:
         """
@@ -822,69 +839,57 @@ class ReplicaRepository(BaseRepository):
             logger.info(f"Marked {cleaned_up_count} stale replicas as unavailable")
         return cleaned_up_count
 
-    def _row_to_model(self, row: tuple) -> Replica:
-        """Convert a database row to Replica object.
+    def _row_to_model(self, row: tuple, columns: Sequence[str]) -> Replica:
+        """Convert a database row to Replica object using column metadata."""
 
-        The repository has historically used slightly different SELECT column
-        orders across methods.  This helper normalises the tuple layout by
-        detecting whether ``disk_path`` is present after ``artifact_id``.
-        """
+        if not columns:
+            raise ValueError("Replica row conversion requires column metadata.")
 
-        replica_id = _to_uuid(row[0])
-        artifact_id = row[1]
+        column_index = {column: idx for idx, column in enumerate(columns)}
 
-        # Layout A (with disk_path):
-        # [replica_id, artifact_id, disk_path, node_id, node_address, node_port, ...]
-        # Layout B (without disk_path):
-        # [replica_id, artifact_id, node_id, node_address, node_port, ...]
-        # Some queries now include verification_json before worker_id. We detect
-        # presence by row length heuristics.
-        has_disk_path = len(row) >= 17
+        def get(column: str, *, default=None):
+            idx = column_index.get(column)
+            if idx is None:
+                return default
+            value = row[idx]
+            if value is None and default is not None:
+                return default
+            return value
 
-        idx = 2
-        disk_path = row[idx] if has_disk_path else None
-        if has_disk_path:
-            idx += 1
+        def require(column: str):
+            value = get(column)
+            if value is None:
+                raise ValueError(f"Replica row missing required column: {column}")
+            return value
 
-        node_id = row[idx]
-        node_address = row[idx + 1]
-        node_port = row[idx + 2]
-        memory_size = row[idx + 3]
-        memory_type = MemoryType(row[idx + 4])
-        device_id = row[idx + 5]
-        max_concurrency = row[idx + 6]
-        current_requests = row[idx + 7]
-        is_available = row[idx + 8]
-        remote_memory_keys = row[idx + 9] if row[idx + 9] else []
-        buffer_sizes = row[idx + 10] if row[idx + 10] else []
-        # Verification JSON may be present at idx + 11, depending on SELECT
-        verification_json = None
-        worker_id = None
-        created_at = None
-        updated_at = None
-        expires_at = None
+        replica_id = _to_uuid(require("replica_id"))
+        artifact_id = require("artifact_id")
+        disk_path = get("disk_path")
+        node_id = require("node_id")
+        node_address = require("node_address")
+        node_port = int(require("node_port"))
+        memory_size = int(require("memory_size"))
+        memory_type = MemoryType(require("memory_type"))
+        device_id_value = get("device_id")
+        device_id = int(device_id_value) if device_id_value is not None else None
+        max_concurrency = int(require("max_concurrency"))
+        current_requests_value = get("current_requests", default=0)
+        current_requests = int(current_requests_value or 0)
+        is_available = bool(require("is_available"))
 
-        remaining = len(row) - (idx + 11)
-        if remaining >= 5:
-            verification_json = row[idx + 11]
-            worker_id = row[idx + 12]
-            created_at = row[idx + 13]
-            updated_at = row[idx + 14]
-            expires_at = row[idx + 15]
-        elif remaining == 4:
-            verification_json = row[idx + 11]
-            worker_id = row[idx + 12]
-            created_at = row[idx + 13]
-            updated_at = row[idx + 14]
-        elif remaining == 3:
-            verification_json = row[idx + 11]
-            worker_id = row[idx + 12]
-            created_at = row[idx + 13]
-        elif remaining == 2:
-            worker_id = row[idx + 11]
-            created_at = row[idx + 12]
-        elif remaining == 1:
-            worker_id = row[idx + 11]
+        remote_memory_keys_value = get("remote_memory_keys", default=())
+        remote_memory_keys = (
+            list(remote_memory_keys_value) if remote_memory_keys_value else []
+        )
+
+        buffer_sizes_value = get("buffer_sizes", default=())
+        buffer_sizes = list(buffer_sizes_value) if buffer_sizes_value else []
+
+        verification_json = get("verification_json")
+        worker_id = get("worker_id")
+        created_at = get("created_at")
+        updated_at = get("updated_at")
+        expires_at = get("expires_at")
 
         return Replica(
             replica_id=replica_id,
@@ -937,4 +942,6 @@ class ReplicaRepository(BaseRepository):
             """,
             [disk_path],
         )
-        return [self._row_to_model(row) for row in result.fetchall()]
+        columns = [desc[0] for desc in result.description]
+        rows = result.fetchall()
+        return [self._row_to_model(row, columns) for row in rows]

--- a/tensorcast/global_store/repositories/replica_repository.py
+++ b/tensorcast/global_store/repositories/replica_repository.py
@@ -327,7 +327,8 @@ class ReplicaRepository(BaseRepository):
                     buffer_sizes = ?,
                     verification_json = ?,
                     memory_size = ?,
-                    worker_id = ?
+                    worker_id = ?,
+                    expires_at = ?
                 WHERE replica_id = ?
                 """,
                 [
@@ -338,6 +339,7 @@ class ReplicaRepository(BaseRepository):
                     replica.verification_json,
                     replica.memory_size,
                     replica.worker_id,
+                    replica.expires_at,
                     str(existing_replica_id),
                 ],
             )
@@ -349,8 +351,8 @@ class ReplicaRepository(BaseRepository):
                 INSERT INTO artifact_replicas (
                     replica_id, artifact_id, node_id, node_address, node_port,
                     memory_size, memory_type, device_id, max_concurrency,
-                    is_available, remote_memory_keys, buffer_sizes, verification_json, worker_id
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    is_available, remote_memory_keys, buffer_sizes, verification_json, worker_id, expires_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     str(replica.replica_id),
@@ -369,6 +371,7 @@ class ReplicaRepository(BaseRepository):
                     list(replica.buffer_sizes),
                     replica.verification_json,
                     replica.worker_id,
+                    replica.expires_at,
                 ],
             )
 
@@ -859,20 +862,29 @@ class ReplicaRepository(BaseRepository):
         worker_id = None
         created_at = None
         updated_at = None
+        expires_at = None
 
-        # Detect if verification_json present by checking remaining length
-        # After buffer_sizes we expect either worker_id at (idx+11) or
-        # verification_json then worker_id.
-        if len(row) >= idx + 14:
-            # Likely layout with verification_json
+        remaining = len(row) - (idx + 11)
+        if remaining >= 5:
             verification_json = row[idx + 11]
             worker_id = row[idx + 12]
             created_at = row[idx + 13]
-            updated_at = row[idx + 14] if len(row) > idx + 14 else None
-        else:
-            worker_id = row[idx + 11] if len(row) > idx + 11 else None
-            created_at = row[idx + 12] if len(row) > idx + 12 else None
-            updated_at = row[idx + 13] if len(row) > idx + 13 else None
+            updated_at = row[idx + 14]
+            expires_at = row[idx + 15]
+        elif remaining == 4:
+            verification_json = row[idx + 11]
+            worker_id = row[idx + 12]
+            created_at = row[idx + 13]
+            updated_at = row[idx + 14]
+        elif remaining == 3:
+            verification_json = row[idx + 11]
+            worker_id = row[idx + 12]
+            created_at = row[idx + 13]
+        elif remaining == 2:
+            worker_id = row[idx + 11]
+            created_at = row[idx + 12]
+        elif remaining == 1:
+            worker_id = row[idx + 11]
 
         return Replica(
             replica_id=replica_id,
@@ -893,6 +905,7 @@ class ReplicaRepository(BaseRepository):
             verification_json=verification_json,
             created_at=created_at,
             updated_at=updated_at,
+            expires_at=expires_at,
         )
 
     def find_by_disk_path(self, disk_path: str) -> list[Replica]:

--- a/tensorcast/global_store/repositories/replica_repository.py
+++ b/tensorcast/global_store/repositories/replica_repository.py
@@ -26,6 +26,35 @@ def _to_uuid(value: str | UUID) -> UUID:
 class ReplicaRepository(BaseRepository):
     """Repository for managing artifact replicas in the database."""
 
+    # Canonical column list for replica reads. Always keep in sync with schema.
+    # We expose a single source of truth for SELECT projections to guarantee
+    # column presence and ordering, while mapping by name in _row_to_model.
+    _REPLICA_PROJECTION = (
+        "mr.replica_id, mr.artifact_id, mr.disk_path, mr.node_id, mr.node_address, mr.node_port, "
+        "mr.memory_size, mr.memory_type, mr.device_id, mr.max_concurrency, "
+        "COALESCE(rc.current_requests, 0) AS current_requests, "
+        "mr.is_available, mr.remote_memory_keys, mr.buffer_sizes, mr.verification_json, mr.worker_id, "
+        "mr.created_at, mr.updated_at, mr.expires_at"
+    )
+
+    @staticmethod
+    def _replica_select_sql(join_type: str = "LEFT JOIN") -> str:
+        """Build the canonical SELECT for replicas with configurable join type.
+
+        Args:
+            join_type: SQL join type between artifact_replicas and replica_counters.
+                       Common values: "LEFT JOIN" (default) or "JOIN".
+
+        Returns:
+            A SELECT ... FROM ... SQL string without trailing WHERE/ORDER clauses.
+        """
+        return (
+            "SELECT "
+            + ReplicaRepository._REPLICA_PROJECTION
+            + " FROM artifact_replicas mr "
+            + f"{join_type} replica_counters rc ON rc.replica_id = mr.replica_id"
+        )
+
     def has_any_replica(self, artifact_id: str) -> bool:
         """Return True when at least one replica exists for *artifact_id*."""
 
@@ -39,36 +68,15 @@ class ReplicaRepository(BaseRepository):
     def find_by_id(self, replica_id: UUID, artifact_id: str) -> Replica | None:
         """Find a replica by ID and content-addressed artifact_id."""
         cursor = self.get_cursor()
-        query = cursor.execute(
-            """
-            SELECT
-                mr.replica_id,
-                mr.artifact_id,
-                mr.disk_path,
-                mr.node_id,
-                mr.node_address,
-                mr.node_port,
-                mr.memory_size,
-                mr.memory_type,
-                mr.device_id,
-                mr.max_concurrency,
-                COALESCE(rc.current_requests, 0) AS current_requests,
-                mr.is_available,
-                mr.remote_memory_keys,
-                mr.buffer_sizes,
-                mr.verification_json,
-                mr.worker_id,
-                mr.created_at,
-                mr.updated_at
-            FROM artifact_replicas mr
-            LEFT JOIN replica_counters rc ON rc.replica_id = mr.replica_id
-            WHERE mr.replica_id = ? AND mr.artifact_id = ?
-            """,
-            [str(replica_id), artifact_id],
+        sql = (
+            self._replica_select_sql("LEFT JOIN")
+            + " WHERE mr.replica_id = ? AND mr.artifact_id = ?"
         )
+        query = cursor.execute(sql, [str(replica_id), artifact_id])
 
         row = query.fetchone()
         if row:
+            assert query.description is not None
             columns = [desc[0] for desc in query.description]
             return self._row_to_model(row, columns)
         return None
@@ -84,36 +92,17 @@ class ReplicaRepository(BaseRepository):
     ) -> Replica | None:
         """Find existing replica with same identifying information."""
         cursor = self.get_cursor()
+        sql = (
+            self._replica_select_sql("LEFT JOIN")
+            + " WHERE mr.artifact_id = ?"
+            + " AND mr.node_id = ?"
+            + " AND mr.node_address = ?"
+            + " AND mr.node_port = ?"
+            + " AND mr.memory_type = ?"
+            + " AND mr.device_id = ?"
+        )
         query = cursor.execute(
-            """
-            SELECT
-                mr.replica_id,
-                mr.artifact_id,
-                mr.disk_path,
-                mr.node_id,
-                mr.node_address,
-                mr.node_port,
-                mr.memory_size,
-                mr.memory_type,
-                mr.device_id,
-                mr.max_concurrency,
-                COALESCE(rc.current_requests, 0) AS current_requests,
-                mr.is_available,
-                mr.remote_memory_keys,
-                mr.buffer_sizes,
-                mr.verification_json,
-                mr.worker_id,
-                mr.created_at,
-                mr.updated_at
-            FROM artifact_replicas mr
-            LEFT JOIN replica_counters rc ON rc.replica_id = mr.replica_id
-            WHERE mr.artifact_id = ?
-              AND mr.node_id = ?
-              AND mr.node_address = ?
-              AND mr.node_port = ?
-              AND mr.memory_type = ?
-              AND mr.device_id = ?
-            """,
+            sql,
             [
                 artifact_id,
                 node_id,
@@ -126,6 +115,7 @@ class ReplicaRepository(BaseRepository):
 
         row = query.fetchone()
         if row:
+            assert query.description is not None
             columns = [desc[0] for desc in query.description]
             return self._row_to_model(row, columns)
         return None
@@ -189,36 +179,12 @@ class ReplicaRepository(BaseRepository):
         replica_id = row[0]
 
         # Fetch full replica data including current_requests
-        result = cursor.execute(
-            """
-            SELECT
-                mr.replica_id,
-                mr.artifact_id,
-                mr.disk_path,
-                mr.node_id,
-                mr.node_address,
-                mr.node_port,
-                mr.memory_size,
-                mr.memory_type,
-                mr.device_id,
-                mr.max_concurrency,
-                rc.current_requests,
-                mr.is_available,
-                mr.remote_memory_keys,
-                mr.buffer_sizes,
-                mr.verification_json,
-                mr.worker_id,
-                mr.created_at,
-                mr.updated_at
-            FROM artifact_replicas mr
-            JOIN replica_counters rc ON rc.replica_id = mr.replica_id
-            WHERE mr.replica_id = ?
-            """,
-            [str(replica_id)],
-        )
+        sql = self._replica_select_sql("JOIN") + " WHERE mr.replica_id = ?"
+        result = cursor.execute(sql, [str(replica_id)])
 
         full_row = result.fetchone()
         if full_row:
+            assert result.description is not None
             columns = [desc[0] for desc in result.description]
             return self._row_to_model(full_row, columns)
         return None
@@ -537,17 +503,7 @@ class ReplicaRepository(BaseRepository):
         cursor = self.get_cursor()
 
         # Build dynamic query joining with replica_counters
-        query = (
-            "SELECT "
-            "mr.replica_id, mr.artifact_id, mr.disk_path, mr.node_id, mr.node_address, mr.node_port, "
-            "mr.memory_size, mr.memory_type, mr.device_id, mr.max_concurrency, "
-            "COALESCE(rc.current_requests, 0) AS current_requests, "
-            "mr.is_available, mr.remote_memory_keys, mr.buffer_sizes, mr.verification_json, mr.worker_id, "
-            "mr.created_at, mr.updated_at "
-            "FROM artifact_replicas mr "
-            "LEFT JOIN replica_counters rc ON rc.replica_id = mr.replica_id "
-            "WHERE 1=1"
-        )
+        query = self._replica_select_sql("LEFT JOIN") + " WHERE 1=1"
         params: list = []
 
         if artifact_id is not None:
@@ -575,6 +531,7 @@ class ReplicaRepository(BaseRepository):
             params.append(device_id)
 
         result = cursor.execute(query, params)
+        assert result.description is not None
         columns = [desc[0] for desc in result.description]
         rows = result.fetchall()
         replicas = [self._row_to_model(row, columns) for row in rows]
@@ -614,32 +571,10 @@ class ReplicaRepository(BaseRepository):
         cursor = self.get_cursor()
 
         result = cursor.execute(
-            """
-            SELECT
-                mr.replica_id,
-                mr.artifact_id,
-                mr.disk_path,
-                mr.node_id,
-                mr.node_address,
-                mr.node_port,
-                mr.memory_size,
-                mr.memory_type,
-                mr.device_id,
-                mr.max_concurrency,
-                COALESCE(rc.current_requests, 0) AS current_requests,
-                mr.is_available,
-                mr.remote_memory_keys,
-                mr.buffer_sizes,
-                mr.verification_json,
-                mr.worker_id,
-                mr.created_at,
-                mr.updated_at
-            FROM artifact_replicas mr
-            LEFT JOIN replica_counters rc ON rc.replica_id = mr.replica_id
-            ORDER BY mr.created_at DESC
-            """
+            self._replica_select_sql("LEFT JOIN") + " ORDER BY mr.created_at DESC"
         )
 
+        assert result.description is not None
         columns = [desc[0] for desc in result.description]
         rows = result.fetchall()
         return [self._row_to_model(row, columns) for row in rows]
@@ -689,32 +624,12 @@ class ReplicaRepository(BaseRepository):
         cursor = self.get_cursor()
 
         result = cursor.execute(
-            """
-            SELECT
-                mr.replica_id,
-                mr.artifact_id,
-                mr.disk_path,
-                mr.node_id,
-                mr.node_address,
-                mr.node_port,
-                mr.memory_size,
-                mr.memory_type,
-                mr.device_id,
-                mr.max_concurrency,
-                COALESCE(rc.current_requests, 0) AS current_requests,
-                mr.is_available,
-                mr.remote_memory_keys,
-                mr.buffer_sizes,
-                mr.worker_id,
-                mr.created_at,
-                mr.updated_at
-            FROM artifact_replicas mr
-            LEFT JOIN replica_counters rc ON rc.replica_id = mr.replica_id
-            LEFT JOIN workers w ON mr.worker_id = w.worker_id
-            WHERE mr.worker_id IS NOT NULL AND w.worker_id IS NULL
-            """
+            self._replica_select_sql("LEFT JOIN")
+            + " LEFT JOIN workers w ON mr.worker_id = w.worker_id"
+            + " WHERE mr.worker_id IS NOT NULL AND w.worker_id IS NULL"
         )
 
+        assert result.description is not None
         columns = [desc[0] for desc in result.description]
         rows = result.fetchall()
         orphaned = [self._row_to_model(row, columns) for row in rows]
@@ -727,33 +642,12 @@ class ReplicaRepository(BaseRepository):
         cursor = self.get_cursor()
 
         result = cursor.execute(
-            """
-            SELECT
-                mr.replica_id,
-                mr.artifact_id,
-                mr.disk_path,
-                mr.node_id,
-                mr.node_address,
-                mr.node_port,
-                mr.memory_size,
-                mr.memory_type,
-                mr.device_id,
-                mr.max_concurrency,
-                COALESCE(rc.current_requests, 0) AS current_requests,
-                mr.is_available,
-                mr.remote_memory_keys,
-                mr.buffer_sizes,
-                mr.worker_id,
-                mr.created_at,
-                mr.updated_at
-            FROM artifact_replicas mr
-            LEFT JOIN replica_counters rc ON rc.replica_id = mr.replica_id
-            WHERE mr.worker_id = ?
-            ORDER BY mr.created_at DESC
-            """,
+            self._replica_select_sql("LEFT JOIN")
+            + " WHERE mr.worker_id = ? ORDER BY mr.created_at DESC",
             [worker_id],
         )
 
+        assert result.description is not None
         columns = [desc[0] for desc in result.description]
         rows = result.fetchall()
         return [self._row_to_model(row, columns) for row in rows]
@@ -783,33 +677,12 @@ class ReplicaRepository(BaseRepository):
         cursor = self.get_cursor()
 
         result = cursor.execute(
-            """
-            SELECT
-                mr.replica_id,
-                mr.artifact_id,
-                mr.disk_path,
-                mr.node_id,
-                mr.node_address,
-                mr.node_port,
-                mr.memory_size,
-                mr.memory_type,
-                mr.device_id,
-                mr.max_concurrency,
-                COALESCE(rc.current_requests, 0) AS current_requests,
-                mr.is_available,
-                mr.remote_memory_keys,
-                mr.buffer_sizes,
-                mr.worker_id,
-                mr.created_at,
-                mr.updated_at
-            FROM artifact_replicas mr
-            LEFT JOIN replica_counters rc ON rc.replica_id = mr.replica_id
-            WHERE EXTRACT(epoch FROM mr.updated_at) < ?
-            ORDER BY mr.updated_at DESC
-            """,
+            self._replica_select_sql("LEFT JOIN")
+            + " WHERE EXTRACT(epoch FROM mr.updated_at) < ? ORDER BY mr.updated_at DESC",
             [recovery_time],
         )
 
+        assert result.description is not None
         columns = [desc[0] for desc in result.description]
         rows = result.fetchall()
         return [self._row_to_model(row, columns) for row in rows]
@@ -871,7 +744,7 @@ class ReplicaRepository(BaseRepository):
         memory_size = int(require("memory_size"))
         memory_type = MemoryType(require("memory_type"))
         device_id_value = get("device_id")
-        device_id = int(device_id_value) if device_id_value is not None else None
+        device_id = int(device_id_value) if device_id_value is not None else -1
         max_concurrency = int(require("max_concurrency"))
         current_requests_value = get("current_requests", default=0)
         current_requests = int(current_requests_value or 0)
@@ -917,31 +790,10 @@ class ReplicaRepository(BaseRepository):
         """Find all replicas registered under a given disk path (legacy flow)."""
         cursor = self.get_cursor()
         result = cursor.execute(
-            """
-            SELECT
-                mr.replica_id,
-                mr.artifact_id,
-                mr.disk_path,
-                mr.node_id,
-                mr.node_address,
-                mr.node_port,
-                mr.memory_size,
-                mr.memory_type,
-                mr.device_id,
-                mr.max_concurrency,
-                COALESCE(rc.current_requests, 0) AS current_requests,
-                mr.is_available,
-                mr.remote_memory_keys,
-                mr.buffer_sizes,
-                mr.worker_id,
-                mr.created_at,
-                mr.updated_at
-            FROM artifact_replicas mr
-            LEFT JOIN replica_counters rc ON rc.replica_id = mr.replica_id
-            WHERE mr.disk_path = ?
-            """,
+            self._replica_select_sql("LEFT JOIN") + " WHERE mr.disk_path = ?",
             [disk_path],
         )
+        assert result.description is not None
         columns = [desc[0] for desc in result.description]
         rows = result.fetchall()
         return [self._row_to_model(row, columns) for row in rows]

--- a/tensorcast/types.py
+++ b/tensorcast/types.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import Literal, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
+from tensorcast.common.identity import ArtifactIdKind
 from tensorcast.proto.daemon.v1 import (
     store_daemon_pb2 as store_daemon_pb2,
 )
@@ -71,11 +72,43 @@ class ArtifactDescriptor(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     artifact_id: str
-    index_multihash: str
-    data_multihash: str
-    schema_version: str
-    encoding: str
+    index_multihash: str | None = None
+    data_multihash: str | None = None
+    schema_version: str | None = None
+    encoding: str | None = None
     total_size: int
+    id_kind: ArtifactIdKind = ArtifactIdKind.MI2
+
+    @field_validator(
+        "index_multihash",
+        "data_multihash",
+        "schema_version",
+        "encoding",
+        mode="before",
+    )
+    @classmethod
+    def _empty_str_is_none(cls, value: object) -> object:
+        if isinstance(value, str) and value.strip() == "":
+            return None
+        return value
+
+    @field_validator("id_kind", mode="before")
+    @classmethod
+    def _coerce_id_kind(cls, value: object) -> ArtifactIdKind:
+        if isinstance(value, ArtifactIdKind):
+            return value
+        if isinstance(value, str):
+            upper = value.upper()
+            if upper == "MI2":
+                return ArtifactIdKind.MI2
+            if upper == "CGID":
+                return ArtifactIdKind.CGID
+        if isinstance(value, int):
+            if value == 1:
+                return ArtifactIdKind.MI2
+            if value == 2:
+                return ArtifactIdKind.CGID
+        raise ValueError(f"Unsupported artifact id kind: {value!r}")
 
 
 class CanonicalRange(BaseModel):

--- a/tests/python/global_store/test_grpc_service.py
+++ b/tests/python/global_store/test_grpc_service.py
@@ -666,6 +666,25 @@ class TestGRPCService:
         assert sorted(r.off for r in detail.missing_ranges) == [0, 1]
         assert test_context.code == grpc.StatusCode.NOT_FOUND
 
+    def test_register_replica_with_cgid(
+        self, servicer, test_context, memory_info, registered_worker
+    ):
+        artifact_id = "cgid:test-suite-1"
+
+        register_request = global_store_pb2.RegisterReplicaRequest(
+            artifact_id=artifact_id,
+            mem_info=memory_info,
+            max_concurrency=1,
+            worker_id=registered_worker,
+        )
+        response = servicer.RegisterReplica(register_request, test_context)
+        assert response.status == global_store_pb2.Status.STATUS_OK
+        record = servicer.artifacts_repo.get(artifact_id)
+        assert record is not None
+        assert record["id_kind"] == "CGID"
+        assert record["index_multihash"] is None
+        assert record["data_multihash"] is None
+
     def test_get_artifact_canonical_partial_coverage(
         self, servicer, test_context, memory_info, registered_worker
     ):

--- a/tests/python/test_register_cgid.py
+++ b/tests/python/test_register_cgid.py
@@ -1,0 +1,122 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tensorcast.api._config import PlanType, RegisterArtifactOptions
+from tensorcast.api._register import _register_artifact_core
+from tensorcast.api._errors import TensorCastError
+from tensorcast.common.identity import ArtifactIdKind
+from tensorcast.types import (
+    ArtifactDescriptor,
+    BeginRegisterArtifactResult,
+    CoalescedHandshake,
+    CommitResult,
+)
+
+
+class _FakeDaemonCtl:
+    def __init__(self) -> None:
+        self.client_ids: list[str | None] = []
+        self.begin_total_sizes: list[int] = []
+
+    def begin_register_artifact(
+        self,
+        *,
+        device_id: int,
+        total_size_bytes: int,
+        ttl_ms: int | None = None,
+        tensor_index_key: str | None = None,
+        tensor_index_data: bytes | None = None,
+        encoding: str = "json",
+        schema_version: str = "v3",
+        client_artifact_id: str | None = None,
+        plan=None,
+        timeout_s: float = 30.0,
+        view=None,
+    ) -> BeginRegisterArtifactResult:
+        self.client_ids.append(client_artifact_id)
+        self.begin_total_sizes.append(int(total_size_bytes))
+        return BeginRegisterArtifactResult(
+            registration_id="reg-1",
+            device_id=device_id,
+            total_size=int(total_size_bytes),
+            handshake=CoalescedHandshake(daemon_ipc_handle=b""),
+        )
+
+    def commit_registered_artifact(self, registration_id: str, *, timeout_s: float = 30.0) -> CommitResult:
+        if not self.client_ids:
+            raise AssertionError("begin_register_artifact was not invoked before commit")
+        artifact_id = self.client_ids[-1] or "mi2:auto"
+        total_size = self.begin_total_sizes[-1] if self.begin_total_sizes else 0
+        descriptor = ArtifactDescriptor(
+            artifact_id=artifact_id,
+            index_multihash=None,
+            data_multihash=None,
+            schema_version=None,
+            encoding=None,
+            total_size=total_size,
+            id_kind=ArtifactIdKind.CGID if artifact_id.startswith("cgid:") else ArtifactIdKind.MI2,
+        )
+        return CommitResult(descriptor=descriptor, existed=False)
+
+    def abort_registered_artifact(self, registration_id: str, *, timeout_s: float = 15.0) -> bool:
+        return True
+
+
+def _patch_coalesced_upload(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tensorcast.api import _register as register_mod
+
+    def _fake_upload(self, *, artifact, ctx, layout, handle, handshake, cancel_event=None):
+        return dict(artifact)
+
+    monkeypatch.setattr(register_mod._CoalescedUploader, "upload", _fake_upload, raising=False)
+
+
+def test_register_artifact_with_cgid(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_coalesced_upload(monkeypatch)
+    client = _FakeDaemonCtl()
+    tensors = {"a": torch.zeros((4, 4), dtype=torch.float32)}
+    options = RegisterArtifactOptions(plan=PlanType.VRAM_COALESCED, lease_in_place=False)
+
+    result = _register_artifact_core(
+        artifact=tensors,
+        options=options,
+        device_id=0,
+        ttl_ms=None,
+        client_artifact_id="cgid:kvdeadbeef",
+        force_lease_in_place=False,
+        prevalidate_disk=False,
+        client=client,
+        daemon_address="fake-daemon",
+    )
+
+    assert client.client_ids == ["cgid:kvdeadbeef"]
+    assert result.descriptor.artifact_id == "cgid:kvdeadbeef"
+    assert result.descriptor.id_kind is ArtifactIdKind.CGID
+    assert result.descriptor.index_multihash is None
+    assert result.descriptor.data_multihash is None
+
+
+def test_register_artifact_rejects_non_cgid(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_coalesced_upload(monkeypatch)
+    client = _FakeDaemonCtl()
+    tensors = {"a": torch.zeros((2, 2), dtype=torch.float32)}
+    options = RegisterArtifactOptions(plan=PlanType.VRAM_COALESCED, lease_in_place=False)
+
+    with pytest.raises(TensorCastError) as exc_info:
+        _register_artifact_core(
+            artifact=tensors,
+            options=options,
+            device_id=0,
+            ttl_ms=None,
+            client_artifact_id="mi2:not-allowed",
+            force_lease_in_place=False,
+            prevalidate_disk=False,
+            client=client,
+            daemon_address="fake-daemon",
+        )
+
+    assert "cgid" in str(exc_info.value)

--- a/tests/python/test_store_session_api.py
+++ b/tests/python/test_store_session_api.py
@@ -29,6 +29,7 @@ from tensorcast.api.store import (
     Store,
     StoreOptions,
 )
+from tensorcast.common.identity import ArtifactIdKind
 from tensorcast.types import ArtifactDescriptor, ServerConfig
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
 
@@ -139,6 +140,7 @@ class FakeEnvironment:
             schema_version="v3",
             encoding="raw",
             total_size=offset,
+            id_kind=ArtifactIdKind.MI2,
         )
         index_bytes = json.dumps(index, separators=(",", ":"), sort_keys=True).encode("utf-8")
         device = 0 if device_id is None else int(device_id)

--- a/tests/python/test_store_session_api.py
+++ b/tests/python/test_store_session_api.py
@@ -118,6 +118,7 @@ class FakeEnvironment:
         artifact: dict[str, torch.Tensor],
         *,
         device_id: int | None,
+        client_artifact_id: str | None = None,
     ) -> RegistrationResult:
         index: dict[str, tuple[int, int, list[int], list[int], str, int]] = {}
         offset = 0
@@ -132,7 +133,11 @@ class FakeEnvironment:
                 int(tensor.storage_offset()),
             )
             offset += size_bytes
-        artifact_id = f"mi2:test:{plan.value}:{offset}"
+        normalized_client_id = (
+            client_artifact_id.strip() if client_artifact_id and client_artifact_id.strip() else None
+        )
+        artifact_id = normalized_client_id or f"mi2:test:{plan.value}:{offset}"
+        id_kind = ArtifactIdKind.CGID if artifact_id.startswith("cgid:") else ArtifactIdKind.MI2
         descriptor = ArtifactDescriptor(
             artifact_id=artifact_id,
             index_multihash="hash-index",
@@ -140,7 +145,7 @@ class FakeEnvironment:
             schema_version="v3",
             encoding="raw",
             total_size=offset,
-            id_kind=ArtifactIdKind.MI2,
+            id_kind=id_kind,
         )
         index_bytes = json.dumps(index, separators=(",", ":"), sort_keys=True).encode("utf-8")
         device = 0 if device_id is None else int(device_id)
@@ -176,6 +181,7 @@ class FakeEnvironment:
         options: RegisterArtifactOptions,
         device_id: int | None,
         ttl_ms: int | None,
+        client_artifact_id: str | None = None,
         force_lease_in_place: bool,
         prevalidate_disk: bool,
         client: FakeDaemonCtl,
@@ -195,7 +201,12 @@ class FakeEnvironment:
         if cancel_event is not None and cancel_event.is_set():
             raise concurrent.futures.CancelledError
         plan = PlanType.VRAM_LEASED if force_lease_in_place else options.plan
-        return self.make_registration_result(plan, artifact, device_id=device_id)
+        return self.make_registration_result(
+            plan,
+            artifact,
+            device_id=device_id,
+            client_artifact_id=client_artifact_id,
+        )
 
     def fake_materialize(
         self,
@@ -630,6 +641,7 @@ def test_register_function_delegates_to_session(
             self,
             tensors: store_mod.TensorDict,
             *,
+            artifact_id: str | None = None,
             key: str | None = None,
             options: RegisterArtifactOptions | None = None,
             ttl_ms: int | None = None,
@@ -638,6 +650,7 @@ def test_register_function_delegates_to_session(
                 (
                     tensors,
                     {
+                        "artifact_id": artifact_id,
                         "key": key,
                         "options": options,
                         "ttl_ms": ttl_ms,
@@ -671,6 +684,7 @@ def test_put_async_function_delegates_to_session(
             self,
             tensors: store_mod.TensorDict,
             *,
+            artifact_id: str | None = None,
             key: str | None = None,
             options: RegisterArtifactOptions | None = None,
             device: int | torch.device | None = None,
@@ -679,6 +693,7 @@ def test_put_async_function_delegates_to_session(
                 (
                     tensors,
                     {
+                        "artifact_id": artifact_id,
                         "key": key,
                         "options": options,
                         "device": device,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds CGID identity across stack (proto, schema, core/daemon, SDK, GS), bypassing hashing when client supplies cgid:..., persisting id_kind, and updating APIs/tests while preserving mi2 behavior.
> 
> - **Protocol/Schema**:
>   - Add `ArtifactIdKind` enum and `id_kind` to `common.v1.ArtifactDescriptor`; extend daemon `BeginRegisterArtifactRequest` with `client_artifact_id`.
>   - Relax `artifacts.index_multihash/data_multihash` to NULL; add `artifacts.id_kind` and `artifact_replicas.expires_at` (schema + migration 0017).
> - **Core (C++)**:
>   - New `core/common/artifact_identity.{h,cc}` with helpers to infer/validate `mi2:`/`cgid:`.
>   - `StoreEngine` accepts optional `client_artifact_id`, sets `id_kind`, skips multihash computation for CGID, propagates in results, and gates leaf writes to MI2.
> - **Daemon**:
>   - Validate `client_artifact_id` in RegistrationController; plumb `id_kind` through commit paths and responses.
>   - `LipManager` supports CGID (no hashing) vs MI2 (hashing) and records `id_kind`; extend `types.h` and `registration_manager.h`.
> - **SDK (Python)**:
>   - Add `tensorcast.common.identity` and exports; update `Store.register/put` to accept `artifact_id` (CGID), validate, and plumb to daemon.
>   - Extend `ArtifactDescriptor` with `id_kind` and make digest/schema fields optional; update `DaemonCtl` mappings.
> - **Global Store**:
>   - Persist artifacts with explicit `id_kind`; accept CGID (no digests) and MI2; expose `expires_at` for replicas; update repos and service logic; README note.
> - **Docs/Tests**:
>   - Add design/plan docs `0017-client-generated-artifact-id`.
>   - Add/extend C++ and Python tests for MI2/CGID commit paths and GS CGID registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6263d80e55404033f8d6dafbe24811093dbdc1ba. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->