### PR TITLE
refactor(cli): implement structured result types and validation helpe…

### DIFF
--- a/docs/designs/0035-view-spec-builder-refactor.md
+++ b/docs/designs/0035-view-spec-builder-refactor.md
@@ -1,0 +1,678 @@
+---
+slug: 0035-view-spec-builder-refactor
+title: ViewSpec Builder Refactoring (Design)
+areas: ["sdk"]
+related_code:
+  - tensorcast/api/store.py
+  - tensorcast/api/_register.py
+links:
+  schema: null
+---
+
+# Summary
+
+Refactor the `Store._build_view_spec` method and related `_resolve_view_inputs` to use structured result types and dedicated validation helpers. This eliminates complex tuple returns, introduces type-safe operation models, and separates validation/normalization concerns from protobuf assembly.
+
+The current implementation returns a 3-tuple `(ViewSpec | None, bool, dict[str, list[dict]])` from `_build_view_spec` and a 6-tuple from `_resolve_view_inputs`, making the code hard to maintain and extend. This design introduces:
+
+1. **Typed operation models** (`NarrowOp`, `TransposeOp`, `TensorViewOp` union)
+2. **Structured result types** (`ViewSpecBuildResult`, `ResolvedViewInputs`)
+3. **Dedicated validation helpers** (`validate_narrow`, `validate_transpose`)
+4. **Clear separation** between validation, normalization, and proto assembly
+
+```mermaid
+flowchart LR
+    A[User Input<br>slices/transpose] --> B[Validate<br>validate_narrow<br>validate_transpose]
+    B --> C[Normalize<br>identity folding<br>swap canonicalization]
+    C --> D[ViewSpecBuildResult<br>proto + typed ops]
+    D --> E[Consumers<br>register_view<br>get_view]
+```
+
+# Goals / Non-Goals
+
+## Goals
+
+1. **Type safety**: Replace `dict[str, list[dict[str, int | str]]]` with strongly-typed dataclasses (`NarrowOp`, `TransposeOp`).
+2. **Semantic clarity**: Replace positional tuple unpacking with named fields via result objects.
+3. **Testability**: Enable focused unit tests for each validation helper without invoking the full Store machinery.
+4. **Extensibility**: New transform operations (future: `reshape`, `squeeze`) can be added as new `TensorViewOp` variants without modifying existing validation logic.
+5. **Maintainability**: Reduce cognitive load by splitting the 200+ line `_build_view_spec` into smaller, single-purpose functions.
+6. **Pragmatic transition**: Provide adapter methods (`to_normalized_dict()`) only to ease short-term internal migration; prioritize clean semantics over preserving legacy quirks (pre-launch, no external compatibility promises).
+
+## Non-Goals
+
+- Changing the proto wire format (`ViewSpec`, `TensorViewOps`, etc.).
+- Modifying the C++ `ViewPlanner` or daemon-side execution.
+- Adding new transform types (this design only restructures existing `narrow`/`transpose` handling).
+- Changing the public SDK API signatures (`get_view`, `register_view`, etc.).
+
+# Architecture & Interfaces
+
+## 1. Typed Operation Models
+
+A new module `tensorcast/api/_view_ops.py` defines the core types:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence, Union
+
+# Narrow input contract: single spec per tensor
+SliceSpec = slice | tuple[int, slice]
+
+@dataclass(frozen=True, slots=True)
+class NarrowOp:
+    """Single-dimension slice operation (torch.narrow semantics).
+    
+    All indices are non-negative after normalization. Negative input indices
+    are converted to positive via `idx + extent` before storage.
+    """
+    dim: int
+    start: int
+    length: int
+
+@dataclass(frozen=True, slots=True)
+class TransposeOp:
+    """Single dimension-pair swap (torch.transpose semantics)."""
+    dim0: int
+    dim1: int
+
+# Sealed union of supported operations
+TensorViewOp = Union[NarrowOp, TransposeOp]
+```
+
+### Naming Compliance
+
+| Symbol | Kind | Convention | Compliant |
+|--------|------|------------|-----------|
+| `NarrowOp` | class | PascalCase | ✓ |
+| `TransposeOp` | class | PascalCase | ✓ |
+| `TensorViewOp` | type alias | PascalCase | ✓ |
+| `dim`, `start`, `length`, `dim0`, `dim1` | field | snake_case | ✓ |
+
+## 2. ViewSpecBuildResult
+
+```python
+@dataclass(frozen=True, slots=True)
+class ViewSpecBuildResult:
+    """Structured result from view spec construction."""
+    
+    proto: store_daemon_pb2.ViewSpec | None
+    """The protobuf ViewSpec, or None if all operations are identity."""
+    
+    tensor_ops: Mapping[str, list[TensorViewOp]]
+    """Per-tensor operation sequences, keyed by tensor name (sorted)."""
+
+    def __post_init__(self) -> None:
+        # Enforce invariant: proto is None iff tensor_ops is empty
+        if (self.proto is None) != (not self.tensor_ops):
+            raise ValueError("ViewSpecBuildResult must keep proto and tensor_ops in sync")
+
+    @property
+    def has_transpose(self) -> bool:
+        """True if any tensor has transpose operations."""
+        return any(
+            isinstance(op, TransposeOp)
+            for ops in self.tensor_ops.values()
+            for op in ops
+        )
+
+    @property
+    def is_identity(self) -> bool:
+        """True if no meaningful transforms exist."""
+        return not self.tensor_ops  # invariant guarantees proto is None in this case
+
+    def __repr__(self) -> str:
+        """Concise representation for debugging."""
+        op_count = sum(len(ops) for ops in self.tensor_ops.values())
+        return (
+            f"ViewSpecBuildResult(tensors={len(self.tensor_ops)}, "
+            f"ops={op_count}, is_identity={self.is_identity})"
+        )
+
+    def to_normalized_dict(self) -> dict[str, list[dict[str, int | str]]]:
+        """
+        Convert to legacy dict format for backward compatibility.
+        
+        Returns:
+            Mapping compatible with existing consumers like
+            `_compute_view_plan_metadata` and `_materialize_canonical_tensors`.
+        """
+        result: dict[str, list[dict[str, int | str]]] = {}
+        for name in sorted(self.tensor_ops.keys()):
+            op_list: list[dict[str, int | str]] = []
+            for op in self.tensor_ops[name]:
+                if isinstance(op, NarrowOp):
+                    op_list.append({
+                        "type": "narrow",
+                        "dim": op.dim,
+                        "start": op.start,
+                        "length": op.length,
+                    })
+                elif isinstance(op, TransposeOp):
+                    op_list.append({
+                        "type": "transpose",
+                        "dim0": op.dim0,
+                        "dim1": op.dim1,
+                    })
+            if op_list:
+                result[name] = op_list
+        return result
+
+# Module-level singleton for identity result (immutable, safe to share)
+_IDENTITY_RESULT: ViewSpecBuildResult | None = None
+
+def _get_identity_result() -> ViewSpecBuildResult:
+    """Return the cached identity result singleton."""
+    global _IDENTITY_RESULT
+    if _IDENTITY_RESULT is None:
+        _IDENTITY_RESULT = ViewSpecBuildResult(proto=None, tensor_ops={})
+    return _IDENTITY_RESULT
+
+# Add to ViewSpecBuildResult class:
+    @staticmethod
+    def identity() -> ViewSpecBuildResult:
+        """Return a cached identity (no-op) result singleton."""
+        return _get_identity_result()
+```
+
+### Naming Compliance
+
+| Symbol | Kind | Convention | Compliant |
+|--------|------|------------|-----------|
+| `ViewSpecBuildResult` | class | PascalCase | ✓ |
+| `proto`, `tensor_ops` | field | snake_case | ✓ |
+| `has_transpose`, `is_identity` | property | snake_case | ✓ |
+| `to_normalized_dict`, `identity` | method | snake_case | ✓ |
+
+## 3. ResolvedViewInputs
+
+Replaces the 6-tuple return from `_resolve_view_inputs`:
+
+```python
+from typing import Literal
+
+@dataclass(frozen=True, slots=True)
+class ResolvedViewInputs:
+    """Structured result from view input resolution."""
+    
+    artifact_id: str
+    """Resolved canonical artifact ID."""
+    
+    canonical_index_bytes: bytes | None
+    """Raw canonical index JSON bytes, or None when using view_id lookup."""
+    
+    build_result: ViewSpecBuildResult | None
+    """Build result, or None when resolving via pre-existing view_id."""
+    
+    disk_path_hint: str | None
+    """Optional disk path hint from key resolution."""
+    
+    view_id: str | None
+    """Pre-existing view_id when provided by caller (mutually exclusive with build_result)."""
+
+    def __post_init__(self) -> None:
+        # Enforce mutual exclusivity: exactly one of build_result or view_id must be set
+        has_build = self.build_result is not None
+        has_view_id = self.view_id is not None
+        if has_build == has_view_id:
+            raise ValueError(
+                "ResolvedViewInputs requires exactly one of build_result or view_id, "
+                f"got build_result={has_build}, view_id={has_view_id}"
+            )
+
+    @property
+    def variant(self) -> Literal["build", "id"]:
+        """Return which variant this resolution represents."""
+        return "build" if self.build_result is not None else "id"
+
+    @property
+    def view_spec(self) -> store_daemon_pb2.ViewSpec | None:
+        """Convenience accessor for the proto ViewSpec."""
+        return self.build_result.proto if self.build_result else None
+
+    @property
+    def has_transpose(self) -> bool:
+        """True if the resolved view includes transpose operations."""
+        return self.build_result.has_transpose if self.build_result else False
+
+    @property
+    def normalized_ops(self) -> dict[str, list[dict[str, int | str]]]:
+        """Legacy-compatible normalized operations dict."""
+        if self.build_result is None:
+            return {}
+        return self.build_result.to_normalized_dict()
+
+    @classmethod
+    def from_build_result(
+        cls,
+        *,
+        artifact_id: str,
+        canonical_index_bytes: bytes,
+        build_result: ViewSpecBuildResult,
+        disk_path_hint: str | None = None,
+    ) -> ResolvedViewInputs:
+        """Construct from a freshly built ViewSpec."""
+        return cls(
+            artifact_id=artifact_id,
+            canonical_index_bytes=canonical_index_bytes,
+            build_result=build_result,
+            disk_path_hint=disk_path_hint,
+            view_id=None,
+        )
+
+    @classmethod
+    def from_view_id(
+        cls,
+        *,
+        artifact_id: str,
+        view_id: str,
+        disk_path_hint: str | None = None,
+    ) -> ResolvedViewInputs:
+        """Construct from a pre-existing view_id (deferred spec lookup)."""
+        return cls(
+            artifact_id=artifact_id,
+            canonical_index_bytes=None,
+            build_result=None,
+            disk_path_hint=disk_path_hint,
+            view_id=view_id,
+        )
+```
+
+### Mutual Exclusivity (Type-Level)
+
+- `ResolvedViewInputs` enforces `build_result` XOR `view_id`:
+  - `__post_init__` raises if both are set or if neither is set.
+  - Two named constructors (`from_build_result`, `from_view_id`) make the variant explicit.
+  - A `variant` property (`Literal["build", "id"]`) is used in tests to assert exclusivity.
+
+### Naming Compliance
+
+| Symbol | Kind | Convention | Compliant |
+|--------|------|------------|-----------|
+| `ResolvedViewInputs` | class | PascalCase | ✓ |
+| `artifact_id`, `canonical_index_bytes`, etc. | field | snake_case | ✓ |
+| `view_spec`, `has_transpose`, `normalized_ops` | property | snake_case | ✓ |
+
+## 4. Validation Helpers
+
+Dedicated functions for validating and normalizing each operation type:
+
+```python
+def validate_narrow(
+    tensor_name: str,
+    shape: tuple[int, ...],
+    spec: SliceSpec,
+) -> NarrowOp | None:
+    """
+    Validate and normalize a single narrow (slice) specification.
+    
+    Args:
+        tensor_name: Name of the tensor (for error messages).
+        shape: Tensor shape from canonical index.
+        spec: User-provided slice specification (single spec per tensor).
+            Contract:
+            - Must be `slice` or `(int, slice)`
+            - `slice.step` must be `None` or `1`
+            - Negative start/stop are normalized via `idx + extent` (Python semantics)
+            - `None` start/stop are expanded to `[0, extent]`
+            - Bare `slice` implies dim=0; `(dim, slice)` uses explicit dim
+    
+    Returns:
+        NarrowOp with non-negative indices if the slice is non-identity,
+        None if it's a full-range identity slice.
+    
+    Raises:
+        ValueError: If validation fails (dimension out of range, invalid bounds, etc.).
+    
+    Example:
+        >>> validate_narrow("weight", (10, 20), slice(2, 5))
+        NarrowOp(dim=0, start=2, length=3)
+        >>> validate_narrow("weight", (10, 20), (1, slice(-5, None)))
+        NarrowOp(dim=1, start=15, length=5)  # negative normalized
+        >>> validate_narrow("weight", (10, 20), slice(None))
+        None  # identity, full range
+    """
+    ...
+
+
+def validate_transpose(
+    tensor_name: str,
+    shape: tuple[int, ...],
+    ops: Sequence[tuple[int, int]],
+) -> list[TransposeOp]:
+    """
+    Validate and normalize transpose operations into canonical swap sequence.
+    
+    Args:
+        tensor_name: Name of the tensor (for error messages).
+        shape: Tensor shape from canonical index.
+        ops: User-provided transpose pairs.
+    
+    Returns:
+        List of TransposeOp produced by a stable swap-to-place algorithm:
+        - Apply user swap pairs in order to derive target permutation
+        - Canonicalize by swapping each position into place left-to-right
+        - Cancellation: repeated identical swaps cancel (e.g., [(0, 1), (0, 1)] -> [])
+        - Stability: canonicalize(canonicalize(ops)) == canonicalize(ops)
+        - Empty list if the resulting permutation is identity
+    
+    Raises:
+        ValueError: If validation fails (dimensions out of range, etc.).
+    
+    Example:
+        >>> validate_transpose("weight", (10, 20, 30), [(0, 2)])
+        [TransposeOp(dim0=0, dim1=2)]
+        >>> validate_transpose("weight", (10, 20, 30), [(0, 1), (0, 1)])
+        []  # cancels out
+    """
+    ...
+```
+
+### Naming Compliance
+
+| Symbol | Kind | Convention | Compliant |
+|--------|------|------------|-----------|
+| `validate_narrow` | function | snake_case | ✓ |
+| `validate_transpose` | function | snake_case | ✓ |
+| `tensor_name`, `shape`, `spec`, `ops` | parameter | snake_case | ✓ |
+
+### Transpose Canonicalization (Fixed Algorithm)
+
+- **Algorithm**: swap-to-place, left-to-right. For each target position, swap the desired dim into place; stable w.r.t. input order.
+- **Cancellation**: Repeated identical swaps cancel out (e.g., `[(0,1), (0,1)]` → `[]`).
+- **Stability (idempotence)**: `canonicalize(canonicalize(ops)) == canonicalize(ops)` — applying canonicalization twice yields the same result.
+- **Determinism**: Given the same input sequence and shape, the canonicalized swap list is unique and reproducible.
+
+## 5. Orchestrator Function
+
+```python
+def build_view_spec(
+    *,
+    entry_shapes: Mapping[str, tuple[int, ...]],
+    slices: Mapping[str, SliceSpec] | None,
+    transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
+) -> ViewSpecBuildResult:
+    """
+    Build a ViewSpec from user-provided slice and transpose specifications.
+    
+    This function orchestrates validation, normalization, and proto assembly:
+    1. Check for slice/transpose conflicts (same tensor in both).
+    2. Validate and normalize each operation via dedicated helpers.
+    3. Assemble the protobuf ViewSpec.
+    4. Return structured result with typed operations.
+    
+    Args:
+        entry_shapes: Mapping of tensor names to their shapes.
+        slices: Optional slice specifications per tensor (one SliceSpec per tensor).
+        transpose: Optional transpose specifications per tensor.
+    
+    Returns:
+        ViewSpecBuildResult containing proto and typed operations.
+        Returns `ViewSpecBuildResult.identity()` if all operations fold to identity.
+    
+    Raises:
+        ValueError: If validation fails for any operation.
+    """
+    ...
+```
+
+### Naming Compliance
+
+| Symbol | Kind | Convention | Compliant |
+|--------|------|------------|-----------|
+| `build_view_spec` | function | snake_case | ✓ |
+| `entry_shapes`, `slices`, `transpose` | parameter | snake_case | ✓ |
+
+### Input Type Coercion
+
+The `Store` layer accepts the legacy `Sequence[object]` type for backward compatibility and
+coerces it to `SliceSpec` before calling `build_view_spec`:
+
+```python
+def _coerce_slice_spec(seq: Sequence[object]) -> SliceSpec:
+    """
+    Coerce legacy slice sequence to single SliceSpec.
+    
+    Raises:
+        ValueError: If sequence length != 1 or element type is invalid.
+    """
+    if len(seq) != 1:
+        raise ValueError(
+            f"Only a single narrow operation is supported per tensor (got {len(seq)})"
+        )
+    item = seq[0]
+    if isinstance(item, slice):
+        return item
+    if isinstance(item, tuple) and len(item) == 2:
+        dim, slc = item
+        if isinstance(dim, int) and isinstance(slc, slice):
+            return (dim, slc)
+    raise ValueError(
+        "Slice spec must be a slice object or (dim, slice) tuple"
+    )
+```
+
+## 6. Integration with Store
+
+The `Store` class delegates to the new module, handling type coercion at the boundary:
+
+```python
+# tensorcast/api/store.py
+
+from tensorcast.api._view_ops import (
+    build_view_spec,
+    ResolvedViewInputs,
+    SliceSpec,
+    ViewSpecBuildResult,
+    _coerce_slice_spec,
+)
+
+class Store:
+    def _build_view_spec(
+        self,
+        *,
+        canonical_index: CanonicalIndex,
+        slices: Mapping[str, Sequence[object]] | None,
+        transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
+    ) -> ViewSpecBuildResult:
+        """Build view spec, wrapping ValueError as ArtifactError.
+        
+        Accepts legacy Sequence[object] for backward compatibility and
+        coerces to SliceSpec internally.
+        """
+        entry_shapes = {e.name: tuple(e.shape) for e in canonical_index.entries}
+        try:
+            # Coerce legacy sequence format to SliceSpec
+            typed_slices: Mapping[str, SliceSpec] | None = None
+            if slices:
+                typed_slices = {
+                    name: _coerce_slice_spec(seq)
+                    for name, seq in slices.items()
+                }
+            return build_view_spec(
+                entry_shapes=entry_shapes,
+                slices=typed_slices,
+                transpose=transpose,
+            )
+        except ValueError as exc:
+            raise ArtifactError(
+                str(exc),
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            ) from exc
+
+    def _resolve_view_inputs(
+        self,
+        *,
+        client: DaemonCtl,
+        artifact_id: str | None,
+        key: str | None,
+        slices: Mapping[str, Sequence[object]] | None,
+        transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
+        view_id: str | None,
+    ) -> ResolvedViewInputs:
+        """Resolve view inputs, returning structured result."""
+        # ... implementation returns ResolvedViewInputs instead of 6-tuple
+        ...
+```
+
+## 7. Consumer Updates
+
+### register_view
+
+```python
+def register_view(self, tensors, *, artifact_id=None, key=None, ...):
+    resolved = self._resolve_view_inputs(...)
+    
+    if resolved.view_spec is None:
+        raise ArtifactError("View registration via pre-existing view_id not supported", ...)
+    
+    # Use property instead of tuple element
+    placement_choice = placement or ("CLIENT" if resolved.has_transpose else "SERVER")
+    
+    # Use adapter for legacy consumers
+    plan_metadata = _compute_view_plan_metadata(
+        resolved.canonical_index_bytes,
+        resolved.normalized_ops,  # calls to_normalized_dict() internally
+    )
+    ...
+```
+
+### get_view / get_view_into
+
+```python
+def get_view(self, *, artifact_id=None, key=None, ...):
+    resolved = self._resolve_view_inputs(...)
+    
+    placement_enum = self._resolve_transform_placement(
+        placement, has_transpose=resolved.has_transpose
+    )
+    
+    materialized, _ = self._perform_get_with_retry(
+        artifact_id=resolved.artifact_id,
+        view=resolved.view_spec,
+        canonical_index_hint=resolved.canonical_index_bytes,
+        disk_path_hint=resolved.disk_path_hint,
+        ...
+    )
+    ...
+```
+
+# Invariants & Error Model
+
+## Invariants
+
+1. **Mutual exclusivity**: A tensor cannot appear in both `slices` and `transpose` mappings.
+2. **Single narrow per tensor**: Each tensor supports at most one narrow operation (enforced by `SliceSpec` type).
+3. **Negative index normalization**: Negative slice start/stop are normalized to positive via `idx + extent` (Python semantics). After normalization, all stored indices are non-negative.
+4. **Step = 1**: Slice step must be 1 (no strided slicing).
+5. **Dimension bounds**: All dimension indices must be in `[0, ndim)`.
+6. **Range validity (post-normalization)**: `start >= 0`, `length > 0`, `start + length <= shape[dim]`.
+7. **Identity folding**: Full-range slices and identity transposes are folded out.
+8. **Deterministic ordering**: Tensor names in `tensor_ops` are ASCII-sorted.
+9. **Swap-to-place canonicalization**: Transpose canonicalization is stable; cancellation removes redundant swaps; `canonicalize(canonicalize(ops)) == canonicalize(ops)`.
+10. **Result invariants**: `ViewSpecBuildResult` enforces `proto is None` iff `tensor_ops` is empty.
+11. **Variant invariants**: `ResolvedViewInputs` enforces exactly one of `build_result` or `view_id` is set.
+12. **Identity immutability**: The cached identity result uses a read-only mapping to prevent downstream mutation from breaking invariants.
+
+## Error Model
+
+| Condition | Exception | Status Code |
+|-----------|-----------|-------------|
+| Tensor in both slices and transpose | `ValueError` → `ArtifactError` | `INVALID_ARGUMENT` |
+| Unknown tensor name | `ValueError` → `ArtifactError` | `INVALID_ARGUMENT` |
+| Dimension out of range | `ValueError` → `ArtifactError` | `INVALID_ARGUMENT` |
+| Invalid slice bounds | `ValueError` → `ArtifactError` | `INVALID_ARGUMENT` |
+| Non-unit step | `ValueError` → `ArtifactError` | `INVALID_ARGUMENT` |
+| Empty or malformed spec | `ValueError` → `ArtifactError` | `INVALID_ARGUMENT` |
+| Non-mapping `slices`/`transpose` inputs | `ValueError` → `ArtifactError` | `INVALID_ARGUMENT` |
+
+The validation layer (`_view_ops.py`) raises `ValueError` for all validation failures. The `Store` layer wraps these as `ArtifactError` with appropriate status codes.
+
+# Schema Changes
+
+None. This refactoring is purely internal to the Python SDK and does not affect:
+- Database schema (`schema.sql`)
+- Proto definitions
+- Wire format
+- Daemon behavior
+
+# Trade-offs & Risks
+
+| Trade-off | Rationale |
+|-----------|-----------|
+| New module (`_view_ops.py`) | Adds a file but provides clear separation; the module is small (~300 lines) and focused. |
+| Adapter method (`to_normalized_dict`) | Enables incremental migration; can be removed once all consumers are updated. |
+| `Union` type for `TensorViewOp` | Python's type system handles this well; pattern matching via `isinstance` is idiomatic. |
+
+| Risk | Mitigation |
+|------|------------|
+| Behavioral regression | Existing tests cover all validation edge cases; add focused unit tests for new helpers. |
+| Performance overhead from dataclass creation | Negligible; view spec construction is not on hot path (happens once per request). |
+| Migration incomplete | Adapter method ensures backward compatibility; migration can be phased. |
+
+# Compatibility & Acceptance Criteria
+
+## Backward Compatibility
+
+- **API/Wire**: No changes to public SDK signatures (`get_view`, `register_view`, etc.) or proto surfaces.
+- **Behavioral parity**: Negative index normalization is preserved (consistent with current implementation). All stored indices in `NarrowOp` are non-negative after normalization.
+- **Operational stance**: Project is pre-launch; adapters (`to_normalized_dict()`) exist only to ease internal migration, not to preserve legacy quirks.
+
+## Acceptance Criteria
+
+1. **Type safety**: `mypy` and `pyright` pass with strict mode on `_view_ops.py`.
+2. **Test coverage**:
+   - Unit tests for `validate_narrow`: negative indices normalized correctly, full-range identity returns `None`, `(dim, slice)` vs bare `slice`, bounds checking (post-normalization), step=1 enforcement.
+   - Unit tests for `validate_transpose`: identity permutation, stable swap-to-place canonicalization, dimension bounds, cancellation of repeated identical swaps.
+   - Unit tests for `build_view_spec`: conflict detection, identity folding, deterministic ordering, invariant enforcement (`proto`/`tensor_ops` sync).
+   - Unit tests for `ResolvedViewInputs`: constructors enforce mutual exclusivity, `variant` property works, `__post_init__` raises on invalid state.
+   - Unit tests for `to_normalized_dict()`: round-trip equivalence with legacy code paths; verify output matches what `_compute_view_plan_metadata` expects.
+   - Unit tests for `_coerce_slice_spec`: valid inputs coerced, invalid inputs raise `ValueError`.
+   - Integration tests: existing `register_view`/`get_view` tests pass unchanged.
+3. **Performance**: No measurable regression in view registration/retrieval latency.
+4. **Lint**: `ruff check` and `ruff format` pass on all modified files.
+
+# References
+
+- [0016-artifact-view-v1](./0016-artifact-view-v1.md) — Canonical view architecture and supported transforms. This refactor preserves all proto/wire semantics defined there.
+- `tensorcast/api/store.py` — Current implementation of `_build_view_spec` and `_resolve_view_inputs`.
+- `tensorcast/api/_register.py` — Consumers of `normalized_ops` (`_compute_view_plan_metadata`, `_materialize_canonical_tensors`).
+
+# Appendix: Implementation Notes
+
+## A. Negative Index Normalization
+
+The current implementation already supports negative indices (see `store.py` lines 1584-1587). This design preserves that behavior for consistency:
+
+```python
+# Before normalization
+slice(-5, None) on dim with extent=20  →  start=15, stop=20
+
+# After normalization (stored in NarrowOp)
+NarrowOp(dim=d, start=15, length=5)  # all positive
+```
+
+Normalization happens in `validate_narrow` before the `NarrowOp` is created, ensuring invariant #6 (range validity) can be checked on positive values only.
+
+## B. Debug Logging
+
+The `build_view_spec` function includes optional debug logging at `VLOG(1)` equivalent level:
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+def build_view_spec(...) -> ViewSpecBuildResult:
+    logger.debug(
+        "build_view_spec: tensors=%d, slices=%d, transposes=%d",
+        len(entry_shapes),
+        len(slices or {}),
+        len(transpose or {}),
+    )
+    # ... implementation ...
+    logger.debug("build_view_spec result: %r", result)
+    return result
+```

--- a/docs/plans/0035-view-spec-builder-refactor.md
+++ b/docs/plans/0035-view-spec-builder-refactor.md
@@ -1,0 +1,55 @@
+---
+slug: 0035-view-spec-builder-refactor
+title: ViewSpec Builder Refactoring (Plan)
+links:
+  design: ../designs/0035-view-spec-builder-refactor.md
+areas: ["sdk"]
+related_code:
+  - tensorcast/api/store.py
+  - tensorcast/api/_register.py
+  - tests/python/test_store_view_api.py
+---
+
+# Objective
+
+Refactor view-spec construction and resolution to use the typed models from the paired design, remove tuple-based returns and legacy compatibility surfaces, and land targeted tests while keeping current SDK APIs and wire semantics unchanged.
+
+# Current State & Grounding
+- `_build_view_spec` mixes validation, normalization, and proto assembly, returning a 3-tuple `(ViewSpec | None, bool, MutableNormalizedViewOps)`; error handling is intertwined with protobuf mutation (`tensorcast/api/store.py:1485`).
+- `_resolve_view_inputs` returns a 6-tuple and repeats identity/view_id branching plus canonical index fetching (`tensorcast/api/store.py:1766`).
+- View registration depends on the legacy `normalized_ops` dict for plan computation and tensor materialization (`tensorcast/api/_register.py:600`).
+- Tests assert tuple ordering directly (`tests/python/test_store_view_api.py:77`) and rely on `normalized_ops` shape for registration/get flows.
+- Design intent captured in `docs/designs/0035-view-spec-builder-refactor.md` (typed ops, structured results, adapters for legacy consumers).
+
+# Phases & Milestones
+
+- [x] Phase 1: Scaffold typed ops module
+  - [x] Milestone 1: Add `_view_ops.py` with `NarrowOp`, `TransposeOp`, `TensorViewOp`, `ViewSpecBuildResult`, `ResolvedViewInputs`, and helpers (`validate_narrow`, `validate_transpose`, `build_view_spec`, `_coerce_slice_spec`).
+  - [x] Milestone 2: Add focused unit tests for the helpers and invariants (identity folding, swap-to-place canonicalization, mutual exclusivity).
+- [x] Phase 2: Store integration
+  - [x] Milestone 1: Refactor `Store._build_view_spec` to delegate to `build_view_spec`, returning structured results while preserving `ArtifactError` wrapping.
+  - [x] Milestone 2: Refactor `Store._resolve_view_inputs` to emit `ResolvedViewInputs`; update `get_view`, `get_view_into`, and related helpers to consume properties instead of tuple slots.
+  - [x] Milestone 3: Remove tuple/`normalized_ops` compatibility in Store paths; ensure all consumers use structured results directly.
+- [x] Phase 3: Registration alignment and legacy removal
+  - [x] Milestone 1: Refactor `_compute_view_plan_metadata`, `_materialize_canonical_tensors`, and registration paths to consume typed ops/structured results; delete `normalized_ops` dict surfaces.
+  - [x] Milestone 2: Refresh tests in `tests/python/test_store_view_api.py` and add new cases covering mutual exclusivity and legacy removal (assert old tuple/dict paths are gone).
+  - [x] Milestone 3: Add doc cross-links or notes in the design/plan index if required by CI.
+
+# Tasks
+- Implement `_view_ops.py` per design, including identity singleton handling and deterministic ordering.
+- Wire `Store._build_view_spec` and `_resolve_view_inputs` to structured results, keeping `ArtifactError` messages consistent.
+- Update call sites in `Store.get_view`, `Store.get_view_into`, and registration flows to consume `ResolvedViewInputs` and `ViewSpecBuildResult`.
+- Remove legacy tuple returns and `normalized_ops` dict adapters; ensure registration helpers accept typed ops instead of legacy dicts.
+- Extend or add tests for validation helpers and end-to-end Store flows using the new return types; assert legacy surfaces are absent.
+- Keep logging/debug output consistent with existing verbosity; add only minimal new debug hooks if needed.
+- Update any relevant docs or indexes if required after code changes (no schema or proto updates expected).
+
+# Test / Rollout / Backout
+- Unit tests: `uv run pytest tests/python/test_store_view_api.py` plus any new helper-specific test modules.
+- Lint/format: `uv run ruff check .` and `uv run ruff format .` on touched files.
+- Backout: revert the refactor commit set if needed; do not reintroduce tuple/adapter surfaces—fix forward in the structured path.
+
+# Risks & Tracking
+- Regression risk in view placement logic when swapping tuple indices for properties; mitigate with targeted tests on `has_transpose`/placement selection.
+- Potential mismatch when converting registration helpers to typed ops; validate via round-trip tests against `_compute_view_plan_metadata`.
+- Typed helper adoption may miss edge cases (negative indices, empty transpose); ensure test matrix covers legacy scenarios before rollout.

--- a/tensorcast/api/_register.py
+++ b/tensorcast/api/_register.py
@@ -47,6 +47,7 @@ from tensorcast.api._indices import (
 from tensorcast.api._io_disk import save_dict
 from tensorcast.api._runtime import require_runtime
 from tensorcast.api._utils import validate_disk_index_matches
+from tensorcast.api._view_ops import NarrowOp, TransposeOp, ViewSpecBuildResult
 from tensorcast.common.identity import ArtifactIdKind, validate_client_generated_id
 from tensorcast.observability.otel import ensure_client_otel
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
@@ -65,10 +66,6 @@ from tensorcast.types import (
 # Internal alignment hint for layout computation.
 # Currently unused by the underlying calculator but kept for API clarity.
 DEFAULT_ALIGN = 1
-
-
-NormalizedViewOp = Mapping[str, int | str]
-NormalizedViewOps = Mapping[str, Sequence[NormalizedViewOp]]
 
 
 @dataclass
@@ -630,10 +627,11 @@ def _merge_canonical_ranges(
 
 def _compute_view_plan_metadata(
     canonical_index_bytes: bytes,
-    normalized_ops: NormalizedViewOps,
+    build_result: ViewSpecBuildResult,
 ) -> ViewPlanMetadata:
-    if not normalized_ops:
+    if build_result.is_identity:
         raise TensorCastError("View registration requires explicit view operations")
+    normalized_ops = build_result.to_normalized_dict()
     native_plan = compute_view_registration_plan(canonical_index_bytes, normalized_ops)
     forward = native_plan["forward"]
     write_chunks = tuple(
@@ -723,7 +721,7 @@ def _torch_dtype_from_string(dtype_str: str) -> torch.dtype:
 
 def _materialize_canonical_tensors(
     canonical_index_bytes: bytes,
-    normalized_ops: NormalizedViewOps,
+    build_result: ViewSpecBuildResult,
     tensors: Mapping[str, torch.Tensor],
 ) -> dict[str, torch.Tensor]:
     tensor_meta_index, _ = _tensor_indices_from_canonical_index_bytes(
@@ -740,15 +738,15 @@ def _materialize_canonical_tensors(
         if tensor_cpu.device.type != "cpu":
             tensor_cpu = tensor_cpu.to(torch.device("cpu"), non_blocking=False)
         tensor_cpu = tensor_cpu.contiguous()
-        ops = list(normalized_ops.get(name, []))
+        ops = list(build_result.tensor_ops.get(name, ()))
         # Apply inverse operations (reverse order)
         for op in reversed(ops):
-            if op["type"] == "transpose":
-                tensor_cpu = tensor_cpu.transpose(int(op["dim0"]), int(op["dim1"]))
-            elif op["type"] == "narrow":
-                dim = int(op["dim"])
-                start = int(op["start"])
-                length = int(op["length"])
+            if isinstance(op, TransposeOp):
+                tensor_cpu = tensor_cpu.transpose(int(op.dim0), int(op.dim1))
+            elif isinstance(op, NarrowOp):
+                dim = int(op.dim)
+                start = int(op.start)
+                length = int(op.length)
                 full = torch.zeros(
                     tuple(int(d) for d in shape),
                     dtype=tensor_cpu.dtype,
@@ -758,7 +756,9 @@ def _materialize_canonical_tensors(
                 full[tuple(slice_spec)].copy_(tensor_cpu)
                 tensor_cpu = full
             else:
-                raise TensorCastError(f"Unsupported view operation type: {op['type']}")
+                raise TensorCastError(
+                    f"Unsupported view operation type: {type(op).__name__}"
+                )
         # Ensure dtype matches canonical requirements
         target_dtype = _torch_dtype_from_string(dtype_str)
         if tensor_cpu.dtype != target_dtype:

--- a/tensorcast/api/_view_ops.py
+++ b/tensorcast/api/_view_ops.py
@@ -1,0 +1,364 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal, Mapping, Sequence, Union
+
+from tensorcast.proto.daemon.v1 import store_daemon_pb2
+
+logger = logging.getLogger(__name__)
+
+SliceSpec = slice | tuple[int, slice]
+TensorViewOpsMapping = Mapping[str, Sequence["TensorViewOp"]]
+
+
+@dataclass(frozen=True, slots=True)
+class NarrowOp:
+    """Single-dimension slice operation (torch.narrow semantics)."""
+
+    dim: int
+    start: int
+    length: int
+
+
+@dataclass(frozen=True, slots=True)
+class TransposeOp:
+    """Single dimension-pair swap (torch.transpose semantics)."""
+
+    dim0: int
+    dim1: int
+
+
+TensorViewOp = Union[NarrowOp, TransposeOp]
+
+
+@dataclass(frozen=True, slots=True)
+class ViewSpecBuildResult:
+    """Structured result from view spec construction."""
+
+    proto: store_daemon_pb2.ViewSpec | None
+    tensor_ops: Mapping[str, Sequence[TensorViewOp]]
+
+    def __post_init__(self) -> None:
+        if (self.proto is None) != (not self.tensor_ops):
+            raise ValueError(
+                "ViewSpecBuildResult must keep proto and tensor_ops in sync"
+            )
+
+    @property
+    def has_transpose(self) -> bool:
+        return any(
+            isinstance(op, TransposeOp)
+            for ops in self.tensor_ops.values()
+            for op in ops
+        )
+
+    @property
+    def is_identity(self) -> bool:
+        return not self.tensor_ops
+
+    def __repr__(self) -> str:
+        op_count = sum(len(ops) for ops in self.tensor_ops.values())
+        return (
+            f"ViewSpecBuildResult(tensors={len(self.tensor_ops)}, "
+            f"ops={op_count}, is_identity={self.is_identity})"
+        )
+
+    def to_normalized_dict(self) -> dict[str, list[dict[str, int | str]]]:
+        result: dict[str, list[dict[str, int | str]]] = {}
+        for name in sorted(self.tensor_ops.keys()):
+            op_list: list[dict[str, int | str]] = []
+            for op in self.tensor_ops[name]:
+                if isinstance(op, NarrowOp):
+                    op_list.append(
+                        {
+                            "type": "narrow",
+                            "dim": op.dim,
+                            "start": op.start,
+                            "length": op.length,
+                        }
+                    )
+                elif isinstance(op, TransposeOp):
+                    op_list.append(
+                        {
+                            "type": "transpose",
+                            "dim0": op.dim0,
+                            "dim1": op.dim1,
+                        }
+                    )
+            if op_list:
+                result[name] = op_list
+        return result
+
+    @staticmethod
+    def identity() -> ViewSpecBuildResult:
+        return _get_identity_result()
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedViewInputs:
+    """Structured result from view input resolution."""
+
+    artifact_id: str
+    canonical_index_bytes: bytes | None
+    build_result: ViewSpecBuildResult | None
+    disk_path_hint: str | None
+    view_id: str | None
+
+    def __post_init__(self) -> None:
+        has_build = self.build_result is not None
+        has_view_id = self.view_id is not None
+        if has_build == has_view_id:
+            raise ValueError(
+                "ResolvedViewInputs requires exactly one of build_result or view_id"
+            )
+
+    @property
+    def variant(self) -> Literal["build", "id"]:
+        return "build" if self.build_result is not None else "id"
+
+    @property
+    def view_spec(self) -> store_daemon_pb2.ViewSpec | None:
+        return self.build_result.proto if self.build_result else None
+
+    @property
+    def has_transpose(self) -> bool:
+        return self.build_result.has_transpose if self.build_result else False
+
+    @property
+    def normalized_ops(self) -> dict[str, list[dict[str, int | str]]]:
+        if self.build_result is None:
+            return {}
+        return self.build_result.to_normalized_dict()
+
+    @classmethod
+    def from_build_result(
+        cls,
+        *,
+        artifact_id: str,
+        canonical_index_bytes: bytes,
+        build_result: ViewSpecBuildResult,
+        disk_path_hint: str | None = None,
+    ) -> "ResolvedViewInputs":
+        return cls(
+            artifact_id=artifact_id,
+            canonical_index_bytes=canonical_index_bytes,
+            build_result=build_result,
+            disk_path_hint=disk_path_hint,
+            view_id=None,
+        )
+
+    @classmethod
+    def from_view_id(
+        cls,
+        *,
+        artifact_id: str,
+        view_id: str,
+        disk_path_hint: str | None = None,
+    ) -> "ResolvedViewInputs":
+        return cls(
+            artifact_id=artifact_id,
+            canonical_index_bytes=None,
+            build_result=None,
+            disk_path_hint=disk_path_hint,
+            view_id=view_id,
+        )
+
+
+_IDENTITY_RESULT: ViewSpecBuildResult | None = None
+
+
+def _get_identity_result() -> ViewSpecBuildResult:
+    global _IDENTITY_RESULT
+    if _IDENTITY_RESULT is None:
+        _IDENTITY_RESULT = ViewSpecBuildResult(
+            proto=None, tensor_ops=MappingProxyType({})
+        )
+    return _IDENTITY_RESULT
+
+
+def _coerce_slice_spec(seq: Sequence[object]) -> SliceSpec:
+    if len(seq) != 1:
+        raise ValueError(
+            f"Only a single narrow operation is supported per tensor (got {len(seq)})"
+        )
+    item = seq[0]
+    if isinstance(item, slice):
+        return item
+    if isinstance(item, tuple) and len(item) == 2:
+        dim, slc = item
+        if isinstance(dim, int) and isinstance(slc, slice):
+            return (dim, slc)
+    raise ValueError("Slice spec must be a slice object or (dim, slice) tuple")
+
+
+def validate_narrow(
+    tensor_name: str,
+    shape: tuple[int, ...],
+    spec: SliceSpec,
+) -> NarrowOp | None:
+    if isinstance(spec, slice):
+        dim = 0
+        slice_obj = spec
+    elif isinstance(spec, tuple) and len(spec) == 2:
+        dim, slice_obj = spec
+        if not isinstance(dim, int) or not isinstance(slice_obj, slice):
+            raise ValueError("Slice spec must be a slice object or (dim, slice) tuple")
+    else:
+        raise ValueError("Slice spec must be a slice object or (dim, slice) tuple")
+
+    ndims = len(shape)
+    if dim < 0 or dim >= ndims:
+        raise ValueError(
+            f"Slice dim {dim} out of range for tensor '{tensor_name}' (ndim={ndims})"
+        )
+
+    step = 1 if slice_obj.step is None else slice_obj.step
+    if step != 1:
+        raise ValueError(f"Slice step must be 1 for tensor '{tensor_name}'")
+
+    dim_extent = shape[dim]
+    start = 0 if slice_obj.start is None else int(slice_obj.start)
+    stop = dim_extent if slice_obj.stop is None else int(slice_obj.stop)
+
+    if start < 0:
+        start += dim_extent
+    if stop < 0:
+        stop += dim_extent
+
+    if start < 0 or start >= dim_extent:
+        raise ValueError(f"Slice start {start} out of range for tensor '{tensor_name}'")
+    if stop <= start:
+        raise ValueError(
+            f"Slice stop {stop} must be greater than start {start} for tensor '{tensor_name}'"
+        )
+
+    length = stop - start
+    if length > dim_extent:
+        raise ValueError(
+            f"Slice length {length} exceeds dimension {dim_extent} for tensor '{tensor_name}'"
+        )
+    if start + length > dim_extent:
+        raise ValueError(
+            f"Slice range [{start}, {stop}) exceeds dimension {dim_extent} for tensor '{tensor_name}'"
+        )
+    if start == 0 and length == dim_extent:
+        return None
+
+    return NarrowOp(dim=int(dim), start=int(start), length=int(length))
+
+
+def validate_transpose(
+    tensor_name: str,
+    shape: tuple[int, ...],
+    ops: Sequence[tuple[int, int]],
+) -> list[TransposeOp]:
+    ndims = len(shape)
+    if not ops:
+        raise ValueError(
+            f"Transpose spec for '{tensor_name}' must be a non-empty sequence"
+        )
+
+    permutation = list(range(ndims))
+    for dim_pair in ops:
+        if not isinstance(dim_pair, Sequence) or len(dim_pair) != 2:
+            raise ValueError(
+                f"Transpose spec for '{tensor_name}' must contain dim pairs"
+            )
+        dim0, dim1 = dim_pair
+        if not isinstance(dim0, int) or not isinstance(dim1, int):
+            raise ValueError(
+                f"Transpose dims must be integers for tensor '{tensor_name}'"
+            )
+        a = int(dim0)
+        b = int(dim1)
+        if a == b:
+            continue
+        if a < 0 or a >= ndims or b < 0 or b >= ndims:
+            raise ValueError(
+                f"Transpose dims {a},{b} out of range for tensor '{tensor_name}'"
+            )
+        permutation[a], permutation[b] = permutation[b], permutation[a]
+
+    if permutation == list(range(ndims)):
+        return []
+
+    canonical_ops: list[TransposeOp] = []
+    current = list(range(ndims))
+    for target_idx in range(ndims):
+        desired = permutation[target_idx]
+        if current[target_idx] == desired:
+            continue
+        source_idx = current.index(desired)
+        if target_idx == source_idx:
+            continue
+        canonical_ops.append(TransposeOp(dim0=int(target_idx), dim1=int(source_idx)))
+        current[target_idx], current[source_idx] = (
+            current[source_idx],
+            current[target_idx],
+        )
+    return canonical_ops
+
+
+def build_view_spec(
+    *,
+    entry_shapes: Mapping[str, tuple[int, ...]],
+    slices: Mapping[str, SliceSpec] | None,
+    transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
+) -> ViewSpecBuildResult:
+    if not slices and not transpose:
+        return ViewSpecBuildResult.identity()
+
+    entry_shapes_map = dict(entry_shapes)
+    tensor_names_slices = set(slices.keys()) if slices else set()
+    tensor_names_transpose = set(transpose.keys()) if transpose else set()
+    overlap = tensor_names_slices & tensor_names_transpose
+    if overlap:
+        offending = ", ".join(sorted(overlap))
+        raise ValueError(
+            f"Cannot apply slices and transpose to the same tensor(s): {offending}"
+        )
+
+    tensor_ops: dict[str, list[TensorViewOp]] = {}
+
+    if slices:
+        for name, slice_spec in sorted(slices.items()):
+            shape = entry_shapes_map.get(name)
+            if shape is None:
+                raise ValueError(f"View references unknown tensor '{name}'")
+            narrow_op = validate_narrow(name, shape, slice_spec)
+            if narrow_op is None:
+                continue
+            tensor_ops.setdefault(name, []).append(narrow_op)
+
+    if transpose:
+        for name, dim_pairs in sorted(transpose.items()):
+            shape = entry_shapes_map.get(name)
+            if shape is None:
+                raise ValueError(f"View references unknown tensor '{name}'")
+            normalized = validate_transpose(name, shape, dim_pairs)
+            if normalized:
+                tensor_ops.setdefault(name, []).extend(normalized)
+
+    if not tensor_ops:
+        return ViewSpecBuildResult.identity()
+
+    ordered_ops = {name: tensor_ops[name] for name in sorted(tensor_ops.keys())}
+    view_spec_proto = store_daemon_pb2.ViewSpec()
+    for name, view_ops in ordered_ops.items():
+        op_container = view_spec_proto.tensors[name]
+        for view_op in view_ops:
+            op_proto = op_container.ops.add()
+            if isinstance(view_op, NarrowOp):
+                op_proto.narrow.dim = int(view_op.dim)
+                op_proto.narrow.start = int(view_op.start)
+                op_proto.narrow.length = int(view_op.length)
+            elif isinstance(view_op, TransposeOp):
+                op_proto.transpose.dim0 = int(view_op.dim0)
+                op_proto.transpose.dim1 = int(view_op.dim1)
+    result = ViewSpecBuildResult(proto=view_spec_proto, tensor_ops=ordered_ops)
+    logger.debug("build_view_spec result: %r", result)
+    return result

--- a/tensorcast/api/store.py
+++ b/tensorcast/api/store.py
@@ -58,6 +58,13 @@ from tensorcast.api._register import (
 )
 from tensorcast.api._runtime import require_runtime
 from tensorcast.api._utils import validate_disk_index_matches
+from tensorcast.api._view_ops import (
+    ResolvedViewInputs,
+    SliceSpec,
+    ViewSpecBuildResult,
+    _coerce_slice_spec,
+    build_view_spec,
+)
 from tensorcast.daemon_ctl import DaemonCtl, get_daemon_client
 from tensorcast.observability.otel import set_span_attributes
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
@@ -94,9 +101,6 @@ ArtifactStatusCode = Literal[
     "DATA_LOSS",
     "UNAUTHENTICATED",
 ]
-
-NormalizedViewOpDict = dict[str, int | str]
-MutableNormalizedViewOps = dict[str, list[NormalizedViewOpDict]]
 
 
 class ArtifactError(RuntimeError):
@@ -1488,213 +1492,49 @@ class Store:
         canonical_index: CanonicalIndex,
         slices: Mapping[str, Sequence[object]] | None,
         transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
-    ) -> tuple[
-        store_daemon_pb2.ViewSpec | None,
-        bool,
-        MutableNormalizedViewOps,
-    ]:
-        if not slices and not transpose:
-            return None, False, {}
-
-        entry_map: dict[str, CanonicalIndexEntry] = {
-            entry.name: entry for entry in canonical_index.entries
+    ) -> ViewSpecBuildResult:
+        entry_shapes = {
+            entry.name: tuple(entry.shape) for entry in canonical_index.entries
         }
+        try:
+            if slices is not None and not isinstance(slices, Mapping):
+                raise ValueError("Slice spec must be a mapping of tensor name to slice")
+            if transpose is not None and not isinstance(transpose, Mapping):
+                raise ValueError(
+                    "Transpose spec must be a mapping of tensor name to dim pairs"
+                )
+            typed_slices: Mapping[str, SliceSpec] | None = None
+            if slices:
+                typed_slices = {}
+                for name, spec_seq in slices.items():
+                    if not isinstance(spec_seq, Sequence) or not spec_seq:
+                        raise ValueError(
+                            f"Slice spec for '{name}' must be a non-empty sequence"
+                        )
+                    typed_slices[name] = _coerce_slice_spec(spec_seq)
 
-        tensor_names_slices = set(slices.keys()) if slices else set()
-        tensor_names_transpose = set(transpose.keys()) if transpose else set()
-        overlap = tensor_names_slices & tensor_names_transpose
-        if overlap:
-            offending = ", ".join(sorted(overlap))
+            if transpose:
+                for name, ops in transpose.items():
+                    if not isinstance(ops, Sequence):
+                        raise ValueError(
+                            f"Transpose spec for '{name}' must be a non-empty sequence"
+                        )
+                    if not ops:
+                        raise ValueError(
+                            f"Transpose spec for '{name}' must be a non-empty sequence"
+                        )
+
+            return build_view_spec(
+                entry_shapes=entry_shapes,
+                slices=typed_slices,
+                transpose=transpose,
+            )
+        except ValueError as exc:
             raise ArtifactError(
-                f"Cannot apply slices and transpose to the same tensor(s): {offending}",
+                str(exc),
                 status_code="INVALID_ARGUMENT",
                 retryable=False,
-            )
-
-        tensor_ops: dict[str, store_daemon_pb2.TensorViewOps] = {}
-        normalized_ops: MutableNormalizedViewOps = {}
-        has_ops = False
-        has_transpose = False
-
-        def ensure_ops(name: str) -> store_daemon_pb2.TensorViewOps:
-            if name not in tensor_ops:
-                tensor_ops[name] = store_daemon_pb2.TensorViewOps()
-            normalized_ops.setdefault(name, [])
-            return tensor_ops[name]
-
-        # Narrow handling (single-dimension)
-        if slices:
-            for name, spec_seq in sorted(slices.items()):
-                entry = entry_map.get(name)
-                if entry is None:
-                    raise ArtifactError(
-                        f"View references unknown tensor '{name}'",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                if not isinstance(spec_seq, Sequence) or not spec_seq:
-                    raise ArtifactError(
-                        f"Slice spec for '{name}' must be a non-empty sequence",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                resolved: list[tuple[int, slice]] = []
-                inferred_dim = 0
-                for item in spec_seq:
-                    if isinstance(item, slice):
-                        resolved.append((inferred_dim, item))
-                        inferred_dim += 1
-                    elif (
-                        isinstance(item, tuple)
-                        and len(item) == 2
-                        and isinstance(item[0], int)
-                        and isinstance(item[1], slice)
-                    ):
-                        resolved.append((int(item[0]), item[1]))
-                    else:
-                        raise ArtifactError(
-                            f"Slice spec for '{name}' must contain slice objects or (dim, slice) tuples",
-                            status_code="INVALID_ARGUMENT",
-                            retryable=False,
-                        )
-                if len(resolved) != 1:
-                    raise ArtifactError(
-                        f"Only a single narrow operation is supported per tensor (got {len(resolved)} for '{name}')",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                dim, slice_obj = resolved[0]
-                ndims = len(entry.shape)
-                if dim < 0 or dim >= ndims:
-                    raise ArtifactError(
-                        f"Slice dim {dim} out of range for tensor '{name}' (ndim={ndims})",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                step = 1 if slice_obj.step is None else slice_obj.step
-                if step != 1:
-                    raise ArtifactError(
-                        f"Slice step must be 1 for tensor '{name}'",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                dim_extent = entry.shape[dim]
-                start = 0 if slice_obj.start is None else int(slice_obj.start)
-                stop = dim_extent if slice_obj.stop is None else int(slice_obj.stop)
-                if start < 0:
-                    start += dim_extent
-                if stop < 0:
-                    stop += dim_extent
-                if start < 0 or start >= dim_extent:
-                    raise ArtifactError(
-                        f"Slice start {start} out of range for tensor '{name}'",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                if stop <= start:
-                    raise ArtifactError(
-                        f"Slice stop {stop} must be greater than start {start} for tensor '{name}'",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                length = stop - start
-                if length > dim_extent:
-                    raise ArtifactError(
-                        f"Slice length {length} exceeds dimension {dim_extent} for tensor '{name}'",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                # Ensure the requested slice does not exceed the dimension bounds.
-                # Example: dim_extent=10, start=8, stop=15 -> length=7 (<=10) but 8+7>10
-                # Reject such cases to avoid server-side errors.
-                if start + length > dim_extent:
-                    raise ArtifactError(
-                        f"Slice range [{start}, {stop}) exceeds dimension {dim_extent} for tensor '{name}'",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                if start == 0 and length == dim_extent:
-                    continue  # identity
-                op_container = ensure_ops(name)
-                op = op_container.ops.add()
-                op.narrow.dim = int(dim)
-                op.narrow.start = int(start)
-                op.narrow.length = int(length)
-                normalized_ops[name].append(
-                    {
-                        "type": "narrow",
-                        "dim": int(dim),
-                        "start": int(start),
-                        "length": int(length),
-                    }
-                )
-                has_ops = True
-
-        if transpose:
-            for name, ops in sorted(transpose.items()):
-                entry = entry_map.get(name)
-                if entry is None:
-                    raise ArtifactError(
-                        f"View references unknown tensor '{name}'",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                if not isinstance(ops, Sequence) or not ops:
-                    raise ArtifactError(
-                        f"Transpose spec for '{name}' must be a non-empty sequence",
-                        status_code="INVALID_ARGUMENT",
-                        retryable=False,
-                    )
-                ndims = len(entry.shape)
-                permutation = list(range(ndims))
-                for dim0, dim1 in ops:
-                    a = int(dim0)
-                    b = int(dim1)
-                    if a == b:
-                        continue
-                    if a < 0 or a >= ndims or b < 0 or b >= ndims:
-                        raise ArtifactError(
-                            f"Transpose dims {a},{b} out of range for tensor '{name}'",
-                            status_code="INVALID_ARGUMENT",
-                            retryable=False,
-                        )
-                    permutation[a], permutation[b] = permutation[b], permutation[a]
-                if permutation == list(range(ndims)):
-                    continue
-                # Canonicalise permutation using swap-to-place strategy
-                current = list(range(ndims))
-                op_container = ensure_ops(name)
-                for target_idx in range(ndims):
-                    desired = permutation[target_idx]
-                    if current[target_idx] == desired:
-                        continue
-                    source_idx = current.index(desired)
-                    if target_idx == source_idx:
-                        continue
-                    swap_op = op_container.ops.add()
-                    swap_op.transpose.dim0 = int(target_idx)
-                    swap_op.transpose.dim1 = int(source_idx)
-                    current[target_idx], current[source_idx] = (
-                        current[source_idx],
-                        current[target_idx],
-                    )
-                    normalized_ops[name].append(
-                        {
-                            "type": "transpose",
-                            "dim0": int(target_idx),
-                            "dim1": int(source_idx),
-                        }
-                    )
-                    has_ops = True
-                    has_transpose = True
-
-        if not has_ops:
-            return None, False, {}
-
-        spec = store_daemon_pb2.ViewSpec()
-        for name in sorted(tensor_ops.keys()):
-            spec.tensors[name].CopyFrom(tensor_ops[name])
-        return spec, has_transpose, normalized_ops
+            ) from exc
 
     def _resolve_view_inputs(
         self,
@@ -1705,14 +1545,7 @@ class Store:
         slices: Mapping[str, Sequence[object]] | None,
         transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
         view_id: str | None,
-    ) -> tuple[
-        str,
-        bytes | None,
-        store_daemon_pb2.ViewSpec | None,
-        bool,
-        str | None,
-        MutableNormalizedViewOps,
-    ]:
+    ) -> ResolvedViewInputs:
         resolved_artifact_id, resolved_key = artifact_id, key
         resolved_artifact_id, resolved_key = self._resolve_identifiers(
             resolved_artifact_id, resolved_key, None
@@ -1732,11 +1565,6 @@ class Store:
                     retryable=False,
                 )
 
-        canonical_index_bytes: bytes | None = None
-        view_spec: store_daemon_pb2.ViewSpec | None = None
-        has_transpose = False
-        normalized_ops: MutableNormalizedViewOps = {}
-
         if view_id is not None:
             if slices or transpose:
                 raise ArtifactError(
@@ -1744,13 +1572,10 @@ class Store:
                     status_code="INVALID_ARGUMENT",
                     retryable=False,
                 )
-            return (
-                resolved_artifact_id,
-                canonical_index_bytes,
-                view_spec,
-                has_transpose,
-                disk_path_hint,
-                normalized_ops,
+            return ResolvedViewInputs.from_view_id(
+                artifact_id=resolved_artifact_id,
+                view_id=view_id,
+                disk_path_hint=disk_path_hint,
             )
 
         # Building a spec requires canonical metadata.
@@ -1763,18 +1588,16 @@ class Store:
 
         canonical_index_bytes = client.get_artifact_index_by_id(resolved_artifact_id)
         canonical_index = self._canonical_index_from_bytes(canonical_index_bytes)
-        view_spec, has_transpose, normalized_ops = self._build_view_spec(
+        build_result = self._build_view_spec(
             canonical_index=canonical_index,
             slices=slices,
             transpose=transpose,
         )
-        return (
-            resolved_artifact_id,
-            canonical_index_bytes,
-            view_spec,
-            has_transpose,
-            disk_path_hint,
-            normalized_ops,
+        return ResolvedViewInputs.from_build_result(
+            artifact_id=resolved_artifact_id,
+            canonical_index_bytes=canonical_index_bytes,
+            build_result=build_result,
+            disk_path_hint=disk_path_hint,
         )
 
     @staticmethod
@@ -2174,14 +1997,7 @@ class Store:
                 retryable=False,
             )
         client = self._ensure_client()
-        (
-            resolved_artifact_id,
-            canonical_index_bytes,
-            view_spec,
-            has_transpose,
-            _,
-            normalized_ops,
-        ) = self._resolve_view_inputs(
+        resolved = self._resolve_view_inputs(
             client=client,
             artifact_id=artifact_id,
             key=key,
@@ -2189,28 +2005,38 @@ class Store:
             transpose=transpose,
             view_id=view_id,
         )
-        if view_spec is None:
+        if resolved.variant == "id":
             raise ArtifactError(
                 "View registration via pre-existing view_id is not supported yet",
                 status_code="UNIMPLEMENTED",
                 retryable=False,
             )
+        assert resolved.build_result is not None
+        if resolved.build_result.is_identity:
+            raise ArtifactError(
+                "View registration requires explicit view operations",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        placement_has_transpose = resolved.has_transpose
         placement_choice = placement
         if placement_choice is None:
-            placement_choice = "CLIENT" if has_transpose else "SERVER"
+            placement_choice = "CLIENT" if placement_has_transpose else "SERVER"
         placement_enum = self._resolve_transform_placement(
-            placement_choice, has_transpose=has_transpose
+            placement_choice, has_transpose=placement_has_transpose
         )
-        assert canonical_index_bytes is not None
+        assert resolved.canonical_index_bytes is not None
+        canonical_index_bytes = resolved.canonical_index_bytes
         canonical_index = self._canonical_index_from_bytes(canonical_index_bytes)
         plan_metadata = _compute_view_plan_metadata(
-            canonical_index_bytes, normalized_ops
+            canonical_index_bytes, resolved.build_result
         )
         canonical_ranges = _merge_canonical_ranges(plan_metadata.write_chunks)
         view_options = store_daemon_pb2.ViewRegistrationOptions()
-        if view_id:
-            view_options.view_id = view_id
-        view_options.spec.CopyFrom(view_spec)
+        if resolved.view_id:
+            view_options.view_id = resolved.view_id
+        assert resolved.build_result.proto is not None
+        view_options.spec.CopyFrom(resolved.build_result.proto)
         view_options.placement = placement_enum
         view_options.canonical_size_bytes = canonical_index.total_size_bytes
         for rng in canonical_ranges:
@@ -2223,7 +2049,7 @@ class Store:
             upload_tensors = dict(tensors)
         elif placement_enum == TransformPlacement.TRANSFORM_PLACEMENT_CLIENT:
             upload_tensors = _materialize_canonical_tensors(
-                canonical_index_bytes, normalized_ops, tensors
+                resolved.canonical_index_bytes, resolved.build_result, tensors
             )
         else:
             raise ArtifactError(
@@ -2356,14 +2182,7 @@ class Store:
                 retryable=False,
             )
         client = self._ensure_client()
-        (
-            resolved_artifact_id,
-            canonical_index_bytes,
-            view_spec,
-            has_transpose,
-            disk_path_hint,
-            _,
-        ) = self._resolve_view_inputs(
+        resolved = self._resolve_view_inputs(
             client=client,
             artifact_id=artifact_id,
             key=key,
@@ -2372,24 +2191,24 @@ class Store:
             view_id=view_id,
         )
         placement_enum: TransformPlacement | None = None
-        if view_spec is not None or placement is not None:
+        if resolved.view_spec is not None or placement is not None:
             placement_enum = self._resolve_transform_placement(
-                placement, has_transpose=has_transpose
+                placement, has_transpose=resolved.has_transpose
             )
 
         materialized, _ = self._perform_get_with_retry(
             method="get_view",
-            artifact_id=resolved_artifact_id,
+            artifact_id=resolved.artifact_id,
             key=None,
             device=device,
             fallback=None,
             cancel_event=None,
             options_override=options,
-            view=view_spec,
-            view_id=view_id,
+            view=resolved.view_spec,
+            view_id=resolved.view_id,
             placement=placement_enum,
-            canonical_index_hint=canonical_index_bytes,
-            disk_path_hint=disk_path_hint,
+            canonical_index_hint=resolved.canonical_index_bytes,
+            disk_path_hint=resolved.disk_path_hint,
         )
         return materialized.state_dict
 
@@ -2596,14 +2415,7 @@ class Store:
                 retryable=False,
             )
         client = self._ensure_client()
-        (
-            resolved_artifact_id,
-            canonical_index_bytes,
-            view_spec,
-            has_transpose,
-            disk_path_hint,
-            _,
-        ) = self._resolve_view_inputs(
+        resolved = self._resolve_view_inputs(
             client=client,
             artifact_id=artifact_id,
             key=key,
@@ -2612,24 +2424,24 @@ class Store:
             view_id=view_id,
         )
         placement_enum: TransformPlacement | None = None
-        if view_spec is not None or placement is not None:
+        if resolved.view_spec is not None or placement is not None:
             placement_enum = self._resolve_transform_placement(
-                placement, has_transpose=has_transpose
+                placement, has_transpose=resolved.has_transpose
             )
 
         materialized, device_id = self._perform_get_with_retry(
             method="get_view_into",
-            artifact_id=resolved_artifact_id,
+            artifact_id=resolved.artifact_id,
             key=None,
             device=device,
             fallback=None,
             cancel_event=None,
             options_override=options,
-            view=view_spec,
-            view_id=view_id,
+            view=resolved.view_spec,
+            view_id=resolved.view_id,
             placement=placement_enum,
-            canonical_index_hint=canonical_index_bytes,
-            disk_path_hint=disk_path_hint,
+            canonical_index_hint=resolved.canonical_index_bytes,
+            disk_path_hint=resolved.disk_path_hint,
         )
         try:
             layout_bytes = (

--- a/tests/python/test_store_view_api.py
+++ b/tests/python/test_store_view_api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import threading
-from typing import Any, cast
+from typing import Any
 from types import SimpleNamespace
 
 import grpc
@@ -19,6 +19,12 @@ from tensorcast.api.store import (
     Store,
     StoreOptions,
     ArtifactError,
+)
+from tensorcast.api._view_ops import (
+    NarrowOp,
+    ResolvedViewInputs,
+    TransposeOp,
+    ViewSpecBuildResult,
 )
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
 
@@ -77,53 +83,74 @@ class _PlacementRpcError(grpc.RpcError):
 def test_build_view_spec_narrow_normalizes_length() -> None:
     store = _fresh_store()
     canonical = _make_canonical_index()
-    view_spec, has_transpose, ops = Store._build_view_spec(
+    result = Store._build_view_spec(
         store,
         canonical_index=canonical,
         slices={"weights": (slice(32, 96),)},
         transpose=None,
     )
-    assert view_spec is not None
-    assert not has_transpose
-    assert "weights" in view_spec.tensors
-    view_ops = view_spec.tensors["weights"].ops
+    assert isinstance(result, ViewSpecBuildResult)
+    assert result.proto is not None
+    assert not result.has_transpose
+    assert "weights" in result.proto.tensors
+    view_ops = result.proto.tensors["weights"].ops
     assert len(view_ops) == 1
     narrow = view_ops[0].narrow
     assert narrow.dim == 0
     assert narrow.start == 32
     assert narrow.length == 64
-    assert ops["weights"][0]["type"] == "narrow"
+    assert result.tensor_ops["weights"][0] == NarrowOp(dim=0, start=32, length=64)
 
 
 def test_build_view_spec_identity_returns_none() -> None:
     store = _fresh_store()
     canonical = _make_canonical_index()
-    view_spec, has_transpose, _ = Store._build_view_spec(
+    result = Store._build_view_spec(
         store,
         canonical_index=canonical,
         slices={"weights": (slice(0, 256),)},
         transpose=None,
     )
-    assert view_spec is None
-    assert not has_transpose
+    assert result.proto is None
+    assert result.is_identity
+    assert not result.has_transpose
 
 
 def test_build_view_spec_transpose_canonicalizes_sequence() -> None:
     store = _fresh_store()
     canonical = _make_three_dim_index()
-    view_spec, has_transpose, ops_map = Store._build_view_spec(
+    result = Store._build_view_spec(
         store,
         canonical_index=canonical,
         slices=None,
         transpose={"tensor": [(0, 1), (0, 2)]},
     )
-    assert view_spec is not None
-    assert has_transpose
-    ops = view_spec.tensors["tensor"].ops
+    assert result.proto is not None
+    assert result.has_transpose
+    ops = result.proto.tensors["tensor"].ops
     # Canonical ordering should be deterministic
     assert [(op.transpose.dim0, op.transpose.dim1) for op in ops] == [(0, 2), (1, 2)]
-    assert len(ops_map["tensor"]) == 2
-    assert ops_map["tensor"][0]["type"] == "transpose"
+    assert len(result.tensor_ops["tensor"]) == 2
+    assert all(isinstance(op, TransposeOp) for op in result.tensor_ops["tensor"])
+
+
+def test_build_view_spec_rejects_non_mapping_inputs() -> None:
+    store = _fresh_store()
+    canonical = _make_canonical_index()
+    with pytest.raises(ArtifactError, match="Slice spec must be a mapping"):
+        Store._build_view_spec(
+            store,
+            canonical_index=canonical,
+            slices=[(slice(0, 1),)],
+            transpose=None,
+        )
+    with pytest.raises(ArtifactError, match="Transpose spec must be a mapping"):
+        Store._build_view_spec(
+            store,
+            canonical_index=canonical,
+            slices=None,
+            transpose=[(0, 1)],
+        )
 
 
 def test_get_view_invokes_perform_with_spec(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -135,6 +162,11 @@ def test_get_view_invokes_perform_with_spec(monkeypatch: pytest.MonkeyPatch) -> 
     fake_spec.tensors["weights"].ops[-1].narrow.start = 0
     fake_spec.tensors["weights"].ops[-1].narrow.length = 16
 
+    build_result = ViewSpecBuildResult(
+        proto=fake_spec,
+        tensor_ops={"weights": [NarrowOp(dim=0, start=0, length=16)]},
+    )
+
     def fake_resolve(
         self,
         *,
@@ -144,18 +176,13 @@ def test_get_view_invokes_perform_with_spec(monkeypatch: pytest.MonkeyPatch) -> 
         slices: Any,
         transpose: Any,
         view_id: str | None,
-    ) -> tuple[
-        str,
-        bytes | None,
-        store_daemon_pb2.ViewSpec | None,
-        bool,
-        str | None,
-        dict[str, list[dict[str, int | str]]],
-    ]:
+    ) -> ResolvedViewInputs:
         assert client is fake_client
-        return "artifact-123", b"{}", fake_spec, False, None, {
-            "weights": [{"type": "narrow", "dim": 0, "start": 0, "length": 16}]
-        }
+        return ResolvedViewInputs.from_build_result(
+            artifact_id="artifact-123",
+            canonical_index_bytes=b"{}",
+            build_result=build_result,
+        )
 
     monkeypatch.setattr(Store, "_resolve_view_inputs", fake_resolve)
 
@@ -228,15 +255,12 @@ def test_get_view_into_uses_layout_index(monkeypatch: pytest.MonkeyPatch) -> Non
         slices: Any,
         transpose: Any,
         view_id: str | None,
-    ) -> tuple[
-        str,
-        bytes | None,
-        store_daemon_pb2.ViewSpec | None,
-        bool,
-        str | None,
-        dict[str, list[dict[str, int | str]]],
-    ]:
-        return "artifact-123", b"{}", None, False, None, {}
+    ) -> ResolvedViewInputs:
+        return ResolvedViewInputs.from_build_result(
+            artifact_id="artifact-123",
+            canonical_index_bytes=b"{}",
+            build_result=ViewSpecBuildResult.identity(),
+        )
 
     monkeypatch.setattr(Store, "_resolve_view_inputs", fake_resolve)
 
@@ -307,21 +331,15 @@ def test_register_view_client_placement_builds_canonical(monkeypatch: pytest.Mon
         slices: Any,
         transpose: Any,
         view_id: str | None,
-    ) -> tuple[
-        str,
-        bytes | None,
-        store_daemon_pb2.ViewSpec | None,
-        bool,
-        str | None,
-        dict[str, list[dict[str, int | str]]],
-    ]:
-        return (
-            "artifact-123",
-            canonical_index,
-            view_spec,
-            False,
-            None,
-            {"weights": [{"type": "narrow", "dim": 0, "start": 1, "length": 2}]},
+    ) -> ResolvedViewInputs:
+        build_result = ViewSpecBuildResult(
+            proto=view_spec,
+            tensor_ops={"weights": [NarrowOp(dim=0, start=1, length=2)]},
+        )
+        return ResolvedViewInputs.from_build_result(
+            artifact_id="artifact-123",
+            canonical_index_bytes=canonical_index,
+            build_result=build_result,
         )
 
     monkeypatch.setattr(Store, "_resolve_view_inputs", fake_resolve)

--- a/tests/python/test_view_ops.py
+++ b/tests/python/test_view_ops.py
@@ -1,0 +1,122 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import pytest
+
+from tensorcast.api._view_ops import (
+    NarrowOp,
+    ResolvedViewInputs,
+    TransposeOp,
+    ViewSpecBuildResult,
+    build_view_spec,
+    validate_narrow,
+    validate_transpose,
+    _coerce_slice_spec,
+)
+
+
+def test_validate_narrow_normalizes_and_folds_identity() -> None:
+    op = validate_narrow("weights", (10, 20), (1, slice(-5, None)))
+    assert op == NarrowOp(dim=1, start=15, length=5)
+    assert validate_narrow("weights", (8,), slice(None)) is None
+
+
+def test_validate_narrow_rejects_invalid_params() -> None:
+    with pytest.raises(ValueError, match="Slice step must be 1"):
+        validate_narrow("weights", (8,), slice(None, None, 2))
+    with pytest.raises(ValueError, match="out of range"):
+        validate_narrow("weights", (4,), (1, slice(0, 2)))
+
+
+def test_validate_transpose_canonicalizes_and_cancels() -> None:
+    ops = validate_transpose("tensor", (2, 3, 4), [(0, 1), (0, 2)])
+    assert [(op.dim0, op.dim1) for op in ops] == [(0, 2), (1, 2)]
+
+    cancelled = validate_transpose("tensor", (2, 3), [(0, 1), (0, 1)])
+    assert cancelled == []
+
+    with pytest.raises(ValueError, match="out of range"):
+        validate_transpose("tensor", (2, 3), [(0, 3)])
+
+
+def test_build_view_spec_conflict_and_identity() -> None:
+    entry_shapes = {"weights": (4,)}
+    with pytest.raises(ValueError, match="Cannot apply slices and transpose"):
+        build_view_spec(
+            entry_shapes=entry_shapes,
+            slices={"weights": slice(0, 1)},
+            transpose={"weights": [(0, 0)]},
+        )
+
+    identity = build_view_spec(
+        entry_shapes=entry_shapes,
+        slices={"weights": slice(None)},
+        transpose=None,
+    )
+    assert identity is ViewSpecBuildResult.identity()
+    assert identity.proto is None
+    assert identity.tensor_ops == {}
+
+
+def test_build_view_spec_orders_tensor_ops() -> None:
+    entry_shapes = {"b": (4,), "a": (2, 2)}
+    result = build_view_spec(
+        entry_shapes=entry_shapes,
+        slices={"b": slice(0, 2)},
+        transpose={"a": [(0, 1)]},
+    )
+    assert list(result.tensor_ops.keys()) == ["a", "b"]
+    assert result.proto is not None
+    assert result.tensor_ops["a"][0] == TransposeOp(dim0=0, dim1=1)
+    assert result.tensor_ops["b"][0] == NarrowOp(dim=0, start=0, length=2)
+
+
+def test_identity_result_is_read_only() -> None:
+    identity = ViewSpecBuildResult.identity()
+    with pytest.raises(TypeError):
+        identity.tensor_ops["weights"] = []  # type: ignore[index]
+
+
+def test_resolved_view_inputs_variants() -> None:
+    build_result = build_view_spec(
+        entry_shapes={"weights": (4,)},
+        slices={"weights": slice(1, 3)},
+        transpose=None,
+    )
+    resolved_build = ResolvedViewInputs.from_build_result(
+        artifact_id="artifact",
+        canonical_index_bytes=b"{}",
+        build_result=build_result,
+    )
+    assert resolved_build.variant == "build"
+    assert resolved_build.has_transpose is False
+    assert resolved_build.view_spec is build_result.proto
+    assert resolved_build.normalized_ops["weights"][0]["type"] == "narrow"
+
+    resolved_id = ResolvedViewInputs.from_view_id(
+        artifact_id="artifact",
+        view_id="view-123",
+    )
+    assert resolved_id.variant == "id"
+    assert resolved_id.has_transpose is False
+    assert resolved_id.view_spec is None
+    assert resolved_id.normalized_ops == {}
+
+    with pytest.raises(ValueError):
+        ResolvedViewInputs(
+            artifact_id="artifact",
+            canonical_index_bytes=None,
+            build_result=None,
+            disk_path_hint=None,
+            view_id=None,
+        )
+
+
+def test_coerce_slice_spec_validates() -> None:
+    assert _coerce_slice_spec((slice(0, 1),)) == slice(0, 1)
+    assert _coerce_slice_spec(((1, slice(0, 1)),)) == (1, slice(0, 1))
+    with pytest.raises(ValueError):
+        _coerce_slice_spec(())
+    with pytest.raises(ValueError):
+        _coerce_slice_spec((object(),))


### PR DESCRIPTION
…rs for view spec construction

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 90af91da4cddced2137b232ed9e4002468c5c104. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->