### PR TITLE
feat(store): implement lazy artifact handle with metadata caching

### DIFF
--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -73,6 +73,14 @@ graph TD
 - **Interface**: Uses the functional facade (`tensorcast.get`, `tensorcast.get_into`) backed by the shared Store to request artifacts via daemon `MaterializeByKey` (RFC‑0017).
 - **Memory Access**: Maps CUDA IPC handles for zero‑copy GPU access; falls back to RAM/DISK as needed
 - **Lifecycle**: Confirms, references, and unloads replicas via daemon RPCs
+- **Lazy Handles**: `tensorcast.artifact(...)` returns a store-bound handle that
+  exposes metadata (`tensor_names`, `describe`) and selective tensor fetch
+  without changing the eager `get*` APIs. Handles surface
+  `FAILED_PRECONDITION` if used after `Store.close()`.
+- **Metadata Cache**: A process-wide `ArtifactCache` stores canonical indices
+  (default TTL 600s, max 1000 entries) to avoid repeated daemon lookups.
+  Tunables: `TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS`,
+  `TENSORCAST_STORE_CACHE_MAX_ENTRIES`.
 
 ## Key Design Principles
 

--- a/docs/designs/0036-02-artifact-handle-core.md
+++ b/docs/designs/0036-02-artifact-handle-core.md
@@ -99,7 +99,7 @@ Phase 2 adds `ArtifactCache` alongside the key cache so metadata can be reused a
 - `Store.artifact(...) -> Artifact`
 - `tensorcast.from_disk(path) -> Artifact` (convenience wrapper, see Phase 4)
 
-Factories require exactly one of `key`, `artifact_id`, or `disk_path`. When `disk_path` is provided, the factory calls the daemon to resolve the artifact identity from the disk path (the daemon reads `tensor_index.json` and computes/verifies the artifact ID). All construction paths return the same `Artifact` type—there is no special subclass for disk-backed artifacts. They capture a `weakref.ref[Store]` to avoid keeping the Store alive indefinitely.
+Factories require at least one of `key`, `artifact_id`, or `disk_path`. Multiple identifiers may be provided; handles keep all known hints so cloning/serialization works even after resolution. When `disk_path` is provided, the factory calls the daemon to resolve the artifact identity from the disk path (the daemon reads `tensor_index.json` and computes/verifies the artifact ID). All construction paths return the same `Artifact` type—there is no special subclass for disk-backed artifacts. They capture a `weakref.ref[Store]` to avoid keeping the Store alive indefinitely.
 
 > **Note**: The `disk_path=` parameter and `from_disk()` function are defined here for completeness but are fully implemented in Phase 4 (`0036-04-disk-artifact-variant.md`).
 

--- a/docs/designs/0036-02-artifact-handle-core.md
+++ b/docs/designs/0036-02-artifact-handle-core.md
@@ -1,0 +1,345 @@
+---
+slug: 0036-artifact-handle-core
+title: Lazy Artifact Handle Phase 2 – Handle + Metadata Cache
+areas: ["sdk"]
+related_code:
+  - tensorcast/api/store/artifact.py
+  - tensorcast/api/store/runtime.py
+  - tensorcast/api/store/materialization.py
+  - tensorcast/api/store/cache.py
+  - tensorcast/api/store/views.py
+links:
+  predecessor: ./0036-01-materialization-pipeline-v2.md
+  successor: ./0036-03-lazy-artifact-handle.md
+  disk_variant: ./0036-04-disk-artifact-variant.md
+---
+
+# Summary
+
+Phase 2 introduces the public `Artifact` handle abstraction on top of the Phase 1 pipeline capabilities. The handle exposes lazy metadata access (`tensor_names`, `describe()`), selective tensor materialization, and store-bound lifecycle management while keeping the eager `store.get()` API untouched. This stage also adds a process-wide `ArtifactCache` that stores canonical indices and key→artifact mappings so user code can inspect metadata without hitting the daemon repeatedly.
+
+Delivering this slice separately lets us validate the lazy identity + metadata flow with minimal API surface and without shipping advanced features such as views, batching, or prefetch (Phase 3).
+
+# Goals / Non-Goals
+
+## Goals
+
+1. Public `Artifact` type with synchronous `.tensor_dict()`, `.tensor()`, `.with_fallback()`, `.exists()`, `.to_dict()`, `.from_dict()`.
+   - Selective materialization (`names=`) is part of Phase 2 to validate lazy handles (consumed by Phase 3 view/batch/prefetch).
+2. Store-bound factory functions: `tc.artifact()` and `Store.artifact()` that reuse the existing Store session singleton.
+3. `ArtifactCache` inside `StoreRuntimeContext` that caches canonical indices and disk hints with TTL-based eviction and LRU bounds (default TTL 600s, max 1000 entries; env overrides described below).
+4. Thread-safe handle state machine that lazily resolves keys and metadata, delegating selective fetches to the Phase 1 iterator pipeline.
+
+## Non-Goals
+
+- View composition, batching, async variants, or prefetch tickets (Phase 3).
+- Changes to the daemon RPC surface (already handled in Phase 1).
+- Altering Global Store metadata schemas.
+
+# Architecture & Interfaces
+
+## Module layout & Store binding
+
+### Module layout
+
+| Module | Responsibility | Phase |
+|--------|----------------|-------|
+| `tensorcast/api/store/artifact.py` | Public `Artifact` class plus serialization helpers | Phase 2 |
+| `tensorcast/api/store/cache.py` | `ArtifactCache` and supporting dataclasses | Phase 2 |
+| `tensorcast/api/store/materialization.py` | Updated pipeline facade that accepts selective tensor lists | Phase 1 foundation |
+| `tensorcast/api/store/views.py` | View orchestrator helpers (stubbed in Phase 2, fully used in Phase 3) | Phase 2 scaffolding |
+
+Public symbols are re-exported via `tensorcast.api.store` and `tensorcast`, so end users rarely import the deep modules directly. IDE users can still jump to `artifact.py` for the handle definition.
+
+### Store binding conceptual model
+
+```mermaid
+flowchart LR
+    subgraph "Process Singleton"
+        ST["Store (tc.init)"]
+        RTC["StoreRuntimeContext"]
+        AC["ArtifactCache"]
+    end
+    subgraph "User Handles"
+        A1["Artifact(key=...)"]
+        A2["Artifact(artifact_id=...)"]
+    end
+    ST --> RTC --> AC
+    A1 -.weakref.-> ST
+    A2 -.weakref.-> ST
+    A1 -->|"metadata"| AC
+    A2 -->|"metadata"| AC
+```
+
+Every handle holds a `weakref` to the originating `Store`. If the store closes, `artifact.is_valid` flips to `False` and subsequent materialization calls raise `ArtifactError(status_code="FAILED_PRECONDITION")` while previously cached metadata remains readable. This matches the lifecycle guidance in `StoreRuntimeContext._after_fork_child` and prevents dangling gRPC channels after `fork()`.
+
+## Motivation: runtime caches are key-only today
+
+`StoreRuntimeContext` currently caches only key→artifact_id mappings. Handles need canonical indices, disk hints, and generation counters to avoid repeated RPCs. The snippet below shows the existing `_key_cache` helper.
+
+```225:258:tensorcast/api/store/runtime.py
+    def cache_key_mapping(...):
+        ...
+        self._key_cache[key] = _KeyCacheEntry(...)
+
+    def resolve_key_mapping_cached(...):
+        ...
+        artifact_id, disk_path = self.ensure_client().resolve_key_mapping(key)
+        self.cache_key_mapping(key, artifact_id=resolved_id, disk_path=resolved_path)
+        return resolved_id, resolved_path
+```
+
+Phase 2 adds `ArtifactCache` alongside the key cache so metadata can be reused across handles and processes (respecting fork semantics handled by `StoreRuntimeContext._after_fork_child`).
+
+## Public API surface
+
+### Factory helpers
+
+- `tensorcast.artifact(key=..., artifact_id=..., disk_path=..., *, fallback=None) -> Artifact`
+- `Store.artifact(...) -> Artifact`
+- `tensorcast.from_disk(path) -> Artifact` (convenience wrapper, see Phase 4)
+
+Factories require exactly one of `key`, `artifact_id`, or `disk_path`. When `disk_path` is provided, the factory calls the daemon to resolve the artifact identity from the disk path (the daemon reads `tensor_index.json` and computes/verifies the artifact ID). All construction paths return the same `Artifact` type—there is no special subclass for disk-backed artifacts. They capture a `weakref.ref[Store]` to avoid keeping the Store alive indefinitely.
+
+> **Note**: The `disk_path=` parameter and `from_disk()` function are defined here for completeness but are fully implemented in Phase 4 (`0036-04-disk-artifact-variant.md`).
+
+### Artifact class
+
+```python
+class Artifact:
+    """Lazy handle to a TensorCast artifact (Phase 2 feature set)."""
+
+    # Identity & metadata (no data transfer)
+    @property
+    def artifact_id(self) -> str: ...
+    @property
+    def key(self) -> str | None: ...
+    @property
+    def tensor_names(self) -> tuple[str, ...]: ...
+    def tensor_meta(self, name: str) -> TensorMeta: ...
+    def describe(self) -> ArtifactDescriptor: ...
+
+    # Materialization (delegates to Phase 1 iterator)
+    def tensor_dict(
+        self, *, device: torch.device | str, names: Sequence[str] | None = None
+    ) -> dict[str, torch.Tensor]: ...
+    def tensor(
+        self, name: str, *, device: torch.device | str, cache: bool = True
+    ) -> torch.Tensor: ...
+    def tensor_dict_into(
+        self, target: dict[str, torch.Tensor], *, device: torch.device | str | None = None
+    ) -> None: ...
+
+    # Lifecycle & configuration
+    def with_fallback(self, fallback: FallbackOptions) -> Artifact: ...
+    def exists(self) -> bool: ...
+    @property
+    def is_valid(self) -> bool: ...
+    def release(self) -> None: ...
+
+    # Serialization (process-local)
+    def to_dict(self) -> dict[str, object]: ...
+    @classmethod
+    def from_dict(cls, data: dict[str, object], store: Store) -> Artifact: ...
+```
+
+Handles are immutable except for lazy metadata caching and the `_released` flag. Construction never performs I/O; metadata is fetched on first access through the shared cache.
+
+### Tensor metadata types
+
+```python
+@dataclass(frozen=True, slots=True)
+class TensorMeta:
+    name: str
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    dtype: torch.dtype
+    storage_offset: int
+    size_bytes: int
+
+@dataclass(frozen=True, slots=True)
+class ArtifactDescriptor:
+    artifact_id: str
+    tensor_names: tuple[str, ...]
+    tensor_metas: Mapping[str, TensorMeta]
+    total_bytes: int
+    generation: int | None
+```
+
+`TensorMeta` is derived from `CanonicalIndexEntry` but omits UMA-specific offsets. `ArtifactDescriptor` is a normalized snapshot returned by `Artifact.describe()` and used by higher layers (e.g., view planning in Phase 3).
+
+### Metadata caching
+
+`ArtifactCache` is a process-wide LRU + TTL cache stored on `StoreRuntimeContext`. Defaults:
+- TTL: 600s (`TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS`; `<=0` disables caching)
+- Max entries: 1000 (`TENSORCAST_STORE_CACHE_MAX_ENTRIES`; `<=0` disables caching)
+
+Entry schema (immutable payload + expiry metadata):
+- `artifact_id: str`
+- `disk_path: str | None`
+- `canonical_index_bytes: bytes`
+- `parsed_index: CanonicalIndex`
+- `generation: int | None`
+- `expires_at: float` (monotonic deadline)
+- `hit_count: int` (for metrics only; not used for eviction)
+
+Cache API (new in Phase 2):
+- `get_artifact_index_cached(artifact_id) -> ArtifactCacheEntry | None`
+- `cache_artifact_index(entry: ArtifactCacheEntry) -> None` (enforces LRU + size)
+- `invalidate_artifact(artifact_id: str, key: str | None = None) -> None`
+- Fork safety: `_after_fork_child` rebuilds cache structures to avoid inherited locks.
+
+Metrics:
+- `store.artifact_cache.hit`, `.miss`, `.evict`, `.invalidate`
+- Dimensions: `artifact_id` (hashed/truncated), `reason` (`ttl`, `lru`, `explicit`)
+
+```mermaid
+flowchart TB
+    subgraph StoreRuntimeContext
+        KC["KeyCache<br>key → artifact_id"]
+        AC["ArtifactCache<br>artifact_id → CanonicalIndex"]
+    end
+    subgraph Handle
+        HC["_canonical_index (per-handle)"]
+    end
+    KC --> AC
+    AC --> HC
+```
+
+#### Cache behavior
+
+- Process-wide `ArtifactCache` stores `{artifact_id, disk_path, canonical_index_bytes, parsed_index, generation, expires_at}`.
+- Entries expire after `TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS` (default 600s) or when `StoreRuntimeContext.invalidate_artifact()` is called.
+- Maximum entries default to 1000 (`TENSORCAST_STORE_CACHE_MAX_ENTRIES`), evicted via LRU on insert.
+- Fork handling: `_after_fork_child()` rebuilds the cache to avoid inheriting stale mutexes.
+
+#### Handle lookup flow
+
+1. Check `_canonical_index` without locking.
+2. Acquire `_lock` and re-check (double-checked locking).
+3. Query `ArtifactCache` by `artifact_id`. On hit, copy the parsed index into the handle.
+4. On miss, fetch `canonical_index_bytes` via daemon RPC, populate `ArtifactCache`, then set handle fields.
+5. Metadata-only operations (e.g., `tensor_names`) never touch the daemon again unless the cache entry expires.
+
+### Handle state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> UnresolvedKey: key= ctor
+    [*] --> UnresolvedDisk: disk_path= ctor
+    [*] --> Identified: artifact_id= ctor
+    UnresolvedKey --> Identified: resolve key via daemon
+    UnresolvedDisk --> Identified: resolve disk via daemon
+    Identified --> Indexed: fetch canonical index
+    Indexed --> Released: release()
+    Identified --> Failed: metadata error
+    UnresolvedKey --> Failed: key NOT_FOUND
+    UnresolvedDisk --> Failed: disk path invalid
+    Released --> [*]
+    Failed --> [*]
+```
+
+All three construction paths (`key=`, `artifact_id=`, `disk_path=`) converge to the same `Identified` state after daemon resolution. From there, the artifact behaves identically regardless of how it was constructed.
+
+`Artifact` instances track the following private fields:
+
+- `_artifact_id: str | None`
+- `_key_hint: str | None`
+- `_disk_path_hint: str | None` — used for disk-backed construction and materialization fallback
+- `_fallback: FallbackOptions | None`
+- `_canonical_index_bytes: bytes | None`
+- `_canonical_index: CanonicalIndex | None`
+- `_generation: int | None`
+- `_store_ref: weakref.ref[Store]`
+- `_view_spec: ViewSpecBuildResult | None` (always `None` in Phase 2)
+- `_lock: threading.RLock`
+- `_released: bool`
+
+`release()` flips `_released` to `True`, preventing further materialization but leaving metadata accessible for debugging. If `store.close()` fires, dereferencing `_store_ref` returns `None` and subsequent materialization attempts raise `ArtifactError(status_code="FAILED_PRECONDITION")`.
+
+### Lifecycle semantics (`exists()`, `is_valid`, `release()`)
+
+- `is_valid`: True iff `_released` is False *and* `_store_ref()` returns a live Store. Any materialization attempt when invalid raises `FAILED_PRECONDITION`; metadata access remains allowed.
+- `exists()`: shallow existence probe without tensor transfer.
+  - `key` handle → check `_key_cache`, then `resolve_key_mapping_cached`; on miss, RPC to daemon.
+  - `artifact_id` handle → try `ArtifactCache`; on miss, call `get_artifact_index_by_id` (lightweight metadata RPC). Cache the result on success.
+  - `disk_path` handle → read local `tensor_index.json` to compute/verify artifact id (Phase 4 full path), fallback to daemon lookup in Phase 2 if local parse fails.
+  - Errors bubble as `ArtifactError` with retryable flag based on daemon response; NOT_FOUND invalidates caches for that id/key.
+- `release()`: idempotent; marks handle invalid for future materialization but leaves cached metadata readable for diagnostics. `exists()` still works post-release (metadata-only).
+
+### Materialization path
+
+`Artifact.tensor_dict()` calls a new `_materialize_subset(names, device)` helper:
+
+1. Validate `names` vs. `_canonical_index`, raising `INVALID_ARGUMENT` early.
+2. Build a `MaterializationRequest` struct that carries `artifact_id`, `tensor_names`, `device`, `view_spec=None`, and `fallback`.
+3. Invoke `StoreRuntimeContext.materialization_pipeline.get_subset(request)`, which wraps Phase 1’s iterator and returns a `dict` as needed.
+
+Because handles validate tensor names against cached metadata, `MaterializationPipeline` can trust caller-provided subsets and skip redundant checks.
+
+### Serialization and process safety
+
+`Artifact.to_dict()` returns:
+
+```python
+{
+    "artifact_id": "...",
+    "key": "...",
+    "fallback": fallback.to_dict() if fallback else None,
+    "canonical_index": base64.b64encode(...).decode(),
+    "generation": self._generation,
+}
+```
+
+`Artifact.from_dict(data, store)` reconstructs a handle bound to the provided Store. Metadata bytes are copied into the handle but *not* inserted into the shared cache to avoid accidental unbounded growth when deserializing large batches. If generation is missing or the cached entry is past TTL, the handle triggers a fresh cache lookup/daemon fetch on first metadata access.
+
+Generation source: Daemon v2 materialization/index RPCs surface `generation` alongside canonical index bytes. Cache entries, `ArtifactDescriptor`, and serialization all carry this generation to detect staleness across disk/daemon variants.
+
+### Cache invalidation triggers (Phase 2)
+
+- `RegistrationPipeline`: after successful register/put/register_view (including overwrite), call `invalidate_artifact(artifact_id, key)` and clear `_key_cache` for the key.
+- `Store.deregister_artifact`: on success, call `invalidate_artifact(artifact_id, key=None)` and drop any cached key mapping.
+- `MaterializationPipeline`: on `NOT_FOUND` or `FAILED_PRECONDITION` from daemon, invalidate the artifact_id (and key if known) before surfacing the error.
+- `StoreRuntimeContext.invalidate_artifact`: explicit API used by the above and exposed for future cleanup hooks (e.g., lease expiry).
+
+### ViewOrchestrator cache reuse
+
+`ViewOrchestrator.resolve_view_inputs` first probes `ArtifactCache` for `artifact_id`; on hit, it returns `ResolvedViewInputs` using the cached canonical index bytes without hitting the daemon. On miss, it fetches via `client.get_artifact_index_by_id`, populates `ArtifactCache`, and proceeds. This establishes cache benefits for view requests before Phase 3 adds the view composition surface.
+
+### Naming compliance
+
+| Symbol | Kind | Compliance |
+|--------|------|------------|
+| `Artifact` | Python class | PascalCase |
+| `ArtifactDescriptor` | Python dataclass | PascalCase |
+| `TensorMeta` | Python dataclass | PascalCase |
+| `ArtifactCache` | Python class | PascalCase |
+| `artifact()` | Function | snake_case |
+| `tensor_dict()` / `tensor()` / `with_fallback()` | Methods | snake_case |
+
+All new modules reside under `tensorcast/api/store/` per SDK guidance, re-exported via `tensorcast.api.store.__init__`.
+
+# Trade-offs & Risks
+
+- **Store lifecycle coupling**: Handles become invalid when the Store is closed. We mitigate accidental use-after-close by exposing `is_valid` and raising deterministic errors.
+- **Cache memory pressure**: A 1000-entry index cache with 1 MiB indices consumes up to ~1 GiB. TTL + LRU eviction and env var overrides allow tuning, and we publish metrics (`artifact_cache.entries`, `artifact_cache.evictions`).
+- **Concurrency complexity**: Double-checked locking in each handle requires careful testing to avoid deadlocks. Unit tests cover concurrent metadata access, release, and serialization.
+- **Fork safety**: Handles created before `os.fork()` may hold metadata from the parent. Because metadata bytes are immutable, the child can reuse them, but we document that materialization requires reinitializing the Store (already handled by `StoreRuntimeContext._after_fork_child`).
+
+# Compatibility & Acceptance Criteria
+
+1. **State machine unit tests**: `tests/python/api/test_artifact_state.py` covers transitions, repeated `.release()`, and error cases.
+2. **Metadata cache tests**: `tests/python/api/test_artifact_cache.py` asserts TTL expiry, LRU eviction, fork reset semantics, generation carry-through, and cache hit/miss metrics.
+3. **Selective materialization tests**: `tests/python/api/test_artifact_tensor_subset.py` verifies that `Artifact.tensor("foo")` only hydrates one tensor and that `MaterializationPipeline` receives `tensor_names`.
+4. **Existence/lifecycle tests**: `tests/python/api/test_artifact_exists.py` exercises `exists()`, store-close invalidation, and release idempotency.
+5. **View cache reuse tests**: `tests/python/api/test_view_orchestrator_cache.py` asserts `resolve_view_inputs` hits `ArtifactCache` before daemon RPC.
+6. **Serialization round-trip**: `Artifact.to_dict()` / `from_dict()` preserve identity, canonical index bytes, and generation while enforcing TTL refresh on stale metadata.
+7. **Doc updates**: `tensorcast/api/store/README.md` documents the new handle API, cache env vars (`TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS`, `TENSORCAST_STORE_CACHE_MAX_ENTRIES`), and lifecycle semantics; `docs/architecture/architecture-overview.md` references lazy handles and cache behavior.
+
+# References
+
+- `docs/designs/0036-01-materialization-pipeline-v2.md`
+- `tensorcast/api/store/runtime.py`
+- `tensorcast/api/store/materialization.py`
+- `tensorcast/api/store/__init__.py`
+- `docs/designs/0036-03-lazy-artifact-handle.md`

--- a/docs/designs/0036-03-lazy-artifact-handle.md
+++ b/docs/designs/0036-03-lazy-artifact-handle.md
@@ -1,0 +1,746 @@
+---
+slug: 0036-lazy-artifact-handle
+title: Lazy Artifact Handle API
+areas: ["sdk"]
+related_code:
+  - tensorcast/api/store/__init__.py
+  - tensorcast/api/store/runtime.py
+  - tensorcast/api/store/cache.py  # new: ArtifactCache
+  - tensorcast/api/store/artifact.py  # new: Artifact (unified for all sources)
+  - tensorcast/api/store/view_composer.py  # new: ViewSpecComposer
+  - tensorcast/api/store/batch_context.py  # new: BatchContext, MaterializationBatcher
+links:
+  phase1: ./0036-01-materialization-pipeline-v2.md
+  phase2: ./0036-02-artifact-handle-core.md
+  successor: ./0036-04-disk-artifact-variant.md
+  prior_design: ./0014-store-session-api-modernization.md
+  view_design: ./0016-artifact-view-v1.md
+---
+
+# Summary
+
+Phase 3 completes the **Lazy Artifact Handle** program by layering view composition, batching, async materialization, and prefetch tickets on top of the Phase 1 pipeline upgrade (`0036-01`) and the Phase 2 core handle (`0036-02`). An `Artifact` object represents a deferred reference to a stored artifact—holding identity and metadata without immediately transferring tensor data. Users gain explicit control over when and which tensors materialize, enabling partial loading, source-aware fetching, and composable view derivation.
+
+The shift from eager `store.get() → dict[str, Tensor]` to `tc.artifact() → Artifact` followed by explicit `.tensor_dict()` / `.tensor()` transforms the API from **imperative** (fetch now) to **declarative** (describe intent, execute later).
+
+Phase 2 is now implemented in `tensorcast/api/store/artifact.py` and
+`tensorcast/api/store/cache.py`, including the process-wide `ArtifactCache`
+driven by `TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS` and
+`TENSORCAST_STORE_CACHE_MAX_ENTRIES`. Phase 3 builds directly on that baseline.
+
+```python
+# Current (eager)
+state_dict = tc.get(key="model:v2", device="cuda:0")
+
+# Proposed (lazy)
+artifact = tc.artifact(key="model:v2")
+print(artifact.tensor_names)  # metadata only; no data transfer
+shard = artifact.tensor("wte.weight", device="cuda:0")  # single tensor
+full = artifact.tensor_dict(device="cuda:0")  # all tensors
+```
+
+# Goals / Non-Goals
+
+## Goals
+
+1. **View composition & derivation** — `.view()`, `.subset()`, and `ViewBuilder` produce child artifacts with composed `ViewSpec` objects, including validation and placement rules.
+2. **Materialization batching & async coalescing** — `BatchContext` (sync) and `MaterializationBatcher` (async) reduce per-tensor RPC overhead while preserving iterator semantics from Phase 1.
+3. **Prefetch tickets & replica reuse** — `prefetch()` exposes tickets backed by daemon `wait_for_completion=false` responses, plus explicit `QueryReplicaStatus` / `ReleaseReplica`.
+4. **Disk parity foundation** — View composition and batching APIs work identically for disk-backed artifacts (constructed via `tc.from_disk()`). The actual `from_disk()` entry point is implemented in Phase 4 (`0036-04-disk-artifact-variant.md`).
+5. **Extended fallback & source policies** — `FallbackOptions` gains explicit `prefer` modes, checksum controls, and per-handle `replica_uuid` wiring to integrate with prefetch tickets.
+6. **Public async surface** — Async `tensor*` variants integrate with the batcher and store event loop without blocking the existing runtime executor.
+
+## Non-Goals
+
+- Re-defining identity, metadata caching, or store binding (covered by `0036-02`).
+- Repeating daemon/proto transport changes (covered by `0036-01`).
+- Cross-store artifact transfer coordination (out of scope).
+- Persistent serialization of Artifact handles (handles remain process-local).
+
+> **Note:** Phase 1 (`0036-01`) and Phase 2 (`0036-02`) cover the transport and handle fundamentals. This document references those capabilities and limits itself to the incremental surfaces listed above.
+
+# Architecture & Interfaces
+
+## New Modules Introduced in Phase 3
+
+Phase 2 already established `artifact.py` and `cache.py`. This phase adds the higher-level orchestration pieces.
+
+> **Design principle**: All artifacts—whether constructed via `key=`, `artifact_id=`, or `disk_path=`—share identical interfaces and go through the same Store session / daemon gRPC flow. The `tc.from_disk(path)` entry point (Phase 4) returns a standard `Artifact` object, not a special subclass.
+
+| Module | Contents | Notes |
+|--------|----------|-------|
+| `tensorcast/api/store/view_composer.py` | `ViewSpecComposer`, `ViewBuilder`, helpers for composing RFC‑0016 view plans | Consumes canonical metadata from Phase 2 |
+| `tensorcast/api/store/batch_context.py` | `BatchContext`, `MaterializationBatcher`, `PendingFetch`, `PrefetchTicket` | Couples to the Phase 1 iterator + daemon ticket fields |
+
+Public entry points (`tensorcast.api.store`) continue to re-export the new symbols so user code can simply call `tc.artifact(...).view(...)` or `tc.from_disk(...)`.
+
+## Conceptual Model
+
+See `0036-02-artifact-handle-core.md` for the base handle + store binding diagrams. Phase 3 reuses that foundation and layers new behaviors (views, batching, async, disk parity) without changing the lifecycle contract.
+
+## Daemon & RPC Extensions
+
+Phase 1 already introduced the v2 selective-materialization RPC. Phase 3 adds two incremental capabilities required for prefetch tickets and explicit source policies:
+
+- **Replica Tickets** – `MaterializeReplicaResponse` now carries an optional `ReplicaTicket { string replica_uuid, string device_uuid, google.protobuf.Timestamp expires_at, LoadStatus status }` whenever `wait_for_completion=false`. The SDK surfaces that via `Artifact.prefetch()` and later passes the `replica_uuid` back through `Materialize*` requests. Two lightweight RPCs are added:
+  - `QueryReplicaStatus(ReplicaTicket)` – returns `{status, expires_at}` so the SDK can await readiness without reissuing a materialize call.
+  - `ReleaseReplica(ReplicaTicket)` – allows explicit cleanup when the ticket is abandoned before consumption.
+- **Source Preferences** – `SourcePreference preference` and `DiskFallbackHint` (disk path + checksum policy) become first-class request fields. They are wired directly from the extended `FallbackOptions` documented below so that daemon-side schedulers can differentiate `local_only`, `disk-first`, or `p2p` requests without relying on heuristics.
+
+All other protocol changes (tensor-name subsets, descriptor iterators) remain as defined in `0036-01`.
+
+## Public API
+
+### Entry points added in Phase 3
+
+- `tc.artifact_async(...)` / `Store.artifact_async(...)` – coroutine factory that mirrors `tc.artifact` but defers identity resolution onto the store event loop for async workflows.
+- `Artifact.prefetch()` – kicks off background loads and exposes tickets (paired with new RPC fields).
+- Async `Artifact.tensor_async()` / `.tensor_dict_async()` – surfaced as coroutines rather than `ArtifactFuture`.
+- Sync helpers `Artifact.view()`, `.subset()`, `.view_builder()` are exported via `tensorcast.api.store`.
+
+> **Note**: `tc.from_disk(path)` is covered in Phase 4 (`0036-04-disk-artifact-variant.md`). View and batching APIs defined here work with disk-backed artifacts once Phase 4 is implemented.
+
+### Artifact API additions (Phase 3)
+
+Phase 2 already covered identity, metadata, and synchronous `tensor*` helpers. This phase introduces:
+
+- `Artifact.view(...)`, `.slice(...)`, `.subset(...)` — return derived handles whose `ViewSpec` is composed via `ViewSpecComposer`.
+- `Artifact.view_builder()` — fluent API that records multiple operations before materializing a child handle.
+- `Artifact.batch(device=...)` — sync batching context manager described below.
+- `Artifact.tensor_async()` / `.tensor_dict_async()` — coroutine equivalents wired into `MaterializationBatcher`.
+- `Artifact.prefetch(device=...)` — kicks off background materialization and returns a `PrefetchTicket`.
+
+All additions reuse the same locking/state rules documented in `0036-02`; only the behaviors listed above are new.
+
+### ViewBuilder (Fluent API)
+
+```python
+class ViewBuilder:
+    """Fluent builder for constructing artifact views."""
+    def slice(self, tensor_slices: Mapping[str, SliceSpec]) -> ViewBuilder: ...
+    def transpose(self, tensor_dims: Mapping[str, Sequence[tuple[int, int]]]) -> ViewBuilder: ...
+    def select(self, names: Sequence[str]) -> ViewBuilder: ...
+    def build(self) -> Artifact: ...
+```
+
+### BatchContext (RPC Coalescing)
+
+```python
+class BatchContext:
+    """Context manager for batching multiple tensor fetches into a single RPC."""
+    
+    def __init__(self, artifact: Artifact, device: str | torch.device) -> None: ...
+    def __enter__(self) -> BatchContext: ...
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None: ...
+    
+    def add(self, name: str) -> None:
+        """Queue a tensor for batch fetch. Does not block."""
+        ...
+    
+    def get(self, name: str) -> torch.Tensor:
+        """Get a previously added tensor. Blocks until batch completes on first call."""
+        ...
+    
+    @property
+    def tensors(self) -> dict[str, torch.Tensor]:
+        """All fetched tensors. Blocks until batch completes."""
+        ...
+```
+
+Usage:
+
+```python
+with artifact.batch(device="cuda:0") as batch:
+    batch.add("layer.0.weight")
+    batch.add("layer.0.bias")
+# Single RPC issued on context exit
+w = batch.get("layer.0.weight")
+b = batch.get("layer.0.bias")
+```
+
+### SliceSpec Type
+
+Reuses existing definition from `tensorcast.api._view_ops`:
+
+```python
+SliceSpec = slice | tuple[int, slice]
+# slice(0, 128)        → narrow dim=0, [0:128]
+# (1, slice(64, 192))  → narrow dim=1, [64:192]
+```
+
+> `Store.artifact()` and `tc.artifact()` construction semantics remain unchanged from Phase 2; no new entry points are introduced here.
+
+### from_disk Variant
+
+> **See Phase 4**: The `tc.from_disk(path)` entry point is fully specified in [0036-04-disk-artifact-variant.md](./0036-04-disk-artifact-variant.md).
+
+**Summary**: `tc.from_disk(path)` returns a standard `Artifact` (not a special subclass) by going through the same Store session / daemon gRPC flow. The view composition, batching, and prefetch APIs defined in this document work identically with disk-backed artifacts.
+
+### Extended FallbackOptions
+
+```python
+@dataclass(frozen=True)
+class FallbackOptions:
+    prefer: Literal["auto", "local", "p2p", "disk"] = "auto"
+    disk_path: str | None = None
+    allow_p2p: bool = True
+    verify_checksums: bool = True
+    prefer_disk: bool | None = None  # deprecated alias, kept for compat
+    replica_uuid: str | None = None  # For prefetch integration
+
+    @classmethod
+    def for_disk(cls, path: str, *, verify: bool = True) -> FallbackOptions: ...
+    @classmethod
+    def local_only(cls) -> FallbackOptions: ...
+```
+
+| `prefer` | Behavior |
+|----------|----------|
+| `"auto"` | Daemon chooses optimal source |
+| `"local"` | Local daemon replica only; fail if unavailable |
+| `"p2p"` | Allow remote P2P transfer |
+| `"disk"` | Load from `disk_path` first; daemon/P2P as fallback |
+
+Compatibility strategy:
+
+- Existing callers that pass `prefer_disk=True` continue to work; the constructor maps it to `prefer="disk"` if `prefer` is not explicitly provided.
+- `StoreOptions.fallback` remains optional; unspecified fields fall back to the per-session defaults.
+- The new `replica_uuid` surfaces Prefetch tickets without changing eager APIs—legacy code simply leaves it `None`.
+- SDK-to-daemon translation lives in `FallbackResolver`, ensuring the new enum is forwarded through RPCs while the rest of the Python code keeps a stable signature.
+
+## Internal Architecture
+
+### Artifact State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> UnresolvedKey: tc.artifact(key=...)
+    [*] --> Identified: tc.artifact(artifact_id=...)
+    UnresolvedKey --> Identified: key resolution
+    Identified --> Indexed: fetch canonical index
+    Indexed --> Indexed: .tensor*() calls
+    Indexed --> Released: .release()
+    UnresolvedKey --> Failed: key NOT_FOUND
+    Identified --> Failed: index fetch error
+    Failed --> [*]
+    Released --> [*]
+```
+
+| State | Description | Cached Data |
+|-------|-------------|-------------|
+| `UnresolvedKey` | Constructed from key; no artifact_id yet | `key_hint` only |
+| `Identified` | Has `artifact_id` (via key lookup or direct) | `artifact_id`, optional `disk_path_hint` |
+| `Indexed` | Canonical index fetched and cached | Index bytes, tensor list |
+| `Released` | Explicitly released; metadata still accessible | Cached metadata (read-only) |
+| `Failed` | Resolution or fetch error occurred | Error details |
+
+### Handle State Storage
+
+```python
+class Artifact:
+    # Identity (immutable after construction)
+    _artifact_id: str | None
+    _key_hint: str | None
+
+    # Cached metadata (protected by _lock, lazy-initialized)
+    _generation: int | None
+    _canonical_index_bytes: bytes | None
+    _canonical_index: CanonicalIndex | None
+
+    # Fallback options (immutable; changed via with_fallback())
+    _fallback: FallbackOptions | None
+
+    # View composition (immutable; set at construction)
+    _view_spec: ViewSpecBuildResult | None
+
+    # Lifecycle
+    _store_ref: weakref.ref[Store]
+    _released: bool
+    _lock: threading.RLock
+```
+
+### Thread Safety Model
+
+#### Field Categories
+
+| Category | Fields | Thread Safety |
+|----------|--------|---------------|
+| **Immutable** | `_artifact_id`, `_key_hint`, `_fallback`, `_view_spec`, `_store_ref` | Safe for concurrent read |
+| **Lazy-initialized** | `_canonical_index_bytes`, `_canonical_index`, `_generation` | Protected by `_lock`; init once, then read-only |
+| **Lifecycle** | `_released` | Protected by `_lock`; transitions only `False → True` |
+
+#### Concurrency Semantics
+
+```mermaid
+sequenceDiagram
+    participant T1 as Thread 1
+    participant T2 as Thread 2
+    participant A as Artifact
+    participant L as _lock
+    participant C as ArtifactCache
+
+    T1->>A: tensor_names (first access)
+    T1->>L: acquire
+    T1->>C: lookup index
+    C-->>T1: cache miss
+    T1->>C: fetch & store
+    T1->>L: release
+    
+    par Concurrent metadata access
+        T2->>A: tensor_names
+        T2->>L: acquire
+        Note over T2,L: Waits for T1
+    end
+    
+    T1-->>T1: return names
+    L-->>T2: acquired
+    T2->>C: lookup index
+    C-->>T2: cache hit
+    T2->>L: release
+    T2-->>T2: return names
+```
+
+#### Invariants
+
+1. **Double-checked locking**: Metadata fields use double-checked locking pattern—check without lock, acquire lock, re-check, initialize if still null.
+2. **Independent child locks**: Child artifacts from `.view()` have their own `_lock` instances. Parent and child can be accessed concurrently without contention.
+3. **View derivation is pure**: `.view()` reads parent's cached index (acquiring parent's lock briefly) then creates child with independent state.
+4. **Materialization is stateless**: `.tensor_dict()` delegates to `MaterializationPipeline` which handles its own thread safety. Multiple threads calling `.tensor_dict()` concurrently each receive independent tensor allocations.
+5. **Release is idempotent**: Multiple threads calling `.release()` is safe; only the first call has effect.
+
+#### Parent-Child Lifecycle Independence
+
+View artifacts (`child = parent.view(...)`) are fully independent after construction:
+- Child copies `_artifact_id` and `_canonical_index_bytes` from parent at creation time
+- Child holds its own `_store_ref` (same Store, independent weakref)
+- Parent `.release()` does not affect child's validity
+- Child can outlive parent
+
+### View Composition
+
+When `.view()` is called, the returned child Artifact holds:
+1. Parent's `artifact_id` (copied, immutable)
+2. Parent's `canonical_index_bytes` (copied, no parent dependency)
+3. Composed `ViewSpec` = parent's spec ⊕ new spec
+
+**Implementation note:** all spec composition runs through the existing `ViewOrchestrator`. `ViewBuilder` merely emits `ViewOp` descriptions; `ViewOrchestrator.compose(parent_spec, ops)` performs normalization, placement resolution, RFC‑0016 validation, and depth enforcement so we do not fork a second implementation.
+
+#### ViewSpecComposer
+
+Handles flattening and validation of chained view operations:
+
+```python
+class ViewSpecComposer:
+    @staticmethod
+    def compose(parent: ViewSpecBuildResult, child: ViewSpecBuildResult) -> ViewSpecBuildResult:
+        """Flatten parent ⊕ child into single ViewSpec."""
+        ...
+```
+
+#### Composition Rules
+
+| Parent Op | Child Op | Result | Notes |
+|-----------|----------|--------|-------|
+| `narrow(dim, a, len_a)` | `narrow(dim, c, len_c)` | `narrow(dim, a+c, len_c)` | Requires `c + len_c ≤ len_a` |
+| `narrow(dim, a, len_a)` | `narrow(dim', ...)` where `dim' ≠ dim` | Both ops preserved | Different dimensions |
+| `transpose(d0, d1)` | `transpose(d2, d3)` | Composed permutation | Folded to minimal swaps |
+| `transpose(d0, d1)` | `transpose(d0, d1)` | Identity (removed) | Self-inverse |
+| `narrow(dim, ...)` | `transpose(...)` on same tensor | `INVALID_ARGUMENT` | Per RFC-0016 |
+| Identity | Any op | Child op only | Parent is no-op |
+
+#### Validation
+
+- **Dimension bounds**: Slice dimensions must be valid for the (possibly already sliced) tensor shape
+- **Length bounds**: `start + length ≤ parent_length` for chained narrows
+- **Exclusivity**: A single tensor cannot have both narrow and transpose ops (even across composition)
+- **Depth limit**: Maximum 8 chained `.view()` calls to prevent runaway composition
+
+### Materialization Batching
+
+To avoid per-tensor RPC overhead:
+
+| Pattern | Mechanism | Use Case |
+|---------|-----------|----------|
+| `tensor_dict(names=[...])` | Single RPC for subset | Known tensor set |
+| `artifact.batch(device=...)` | Explicit sync batching | Incremental discovery |
+| `.tensor_async()` concurrent calls | `MaterializationBatcher` | Async workflows |
+
+#### Sync Batching
+
+`artifact.batch()` returns a `BatchContext` (see API above) that collects tensor names and issues a single RPC on context exit.
+
+#### Async Batching
+
+`MaterializationBatcher` coalesces concurrent `.tensor_async()` calls:
+
+```python
+class MaterializationBatcher:
+    """Coalesces async tensor fetches within a time window."""
+    
+    _pending: dict[BatchKey, list[PendingFetch]]
+    _window_ms: float = 1.0  # Coalescing window
+    
+    # BatchKey = (artifact_id, view_spec_hash, device)
+```
+
+Flow:
+1. `.tensor_async(name)` submits to batcher with key `(artifact_id, view_spec_hash, device)`
+2. Batcher waits up to 1ms for additional requests with same key
+3. Single RPC fetches all tensors; results distributed to awaiting futures
+
+Sync `.tensor()` calls bypass the batcher and issue immediate RPCs—use `batch()` context for sync batching.
+
+#### Threading Model & Scheduling
+
+**Context:** `StoreRuntimeContext` maintains a single-thread executor (`_executor = ThreadPoolExecutor(max_workers=1)`) for async callbacks and cleanup. Reusing this executor for batching with blocking waits would cause deadlock or severe performance degradation.
+
+**Design Principles:**
+
+1. **Independent Scheduler** — `MaterializationBatcher` uses a dedicated daemon thread for batch dispatch, completely separate from `StoreRuntimeContext._executor`:
+
+```python
+class MaterializationBatcher:
+    """Lock-free batcher with independent scheduling."""
+    
+    _pending_queue: queue.Queue[PendingFetch]  # Thread-safe queue
+    _batch_groups: dict[BatchKey, BatchGroup]  # Protected by _group_lock
+    _group_lock: threading.Lock  # Short-lived, guards only group assignment
+    _dispatch_thread: threading.Thread  # Dedicated daemon thread
+    _window_ms: float = 1.0
+    _shutdown: threading.Event
+    
+    def __init__(self) -> None:
+        self._dispatch_thread = threading.Thread(
+            target=self._dispatch_loop,
+            daemon=True,
+            name="MaterializationBatcher-Dispatch"
+        )
+        self._dispatch_thread.start()
+    
+    def submit(self, fetch: PendingFetch) -> asyncio.Future[torch.Tensor]:
+        """Non-blocking submission. Returns future immediately."""
+        future: asyncio.Future[torch.Tensor] = asyncio.get_event_loop().create_future()
+        fetch.future = future
+        self._pending_queue.put_nowait(fetch)
+        return future
+    
+    def _dispatch_loop(self) -> None:
+        """Background loop: drain queue, group by key, flush after window."""
+        while not self._shutdown.is_set():
+            try:
+                fetch = self._pending_queue.get(timeout=self._window_ms / 1000)
+                self._assign_to_group(fetch)
+            except queue.Empty:
+                pass
+            self._flush_ready_groups()
+```
+
+2. **Lock-Free Request Path** — Submission uses `queue.Queue` (thread-safe, GIL-based) with `put_nowait()` for non-blocking enqueue. The `_group_lock` protects only the brief batch-key assignment, never held during I/O:
+
+```python
+@dataclass
+class BatchGroup:
+    key: BatchKey
+    fetches: list[PendingFetch]
+    created_at: float  # time.monotonic()
+    deadline: float    # created_at + window_ms
+
+def _assign_to_group(self, fetch: PendingFetch) -> None:
+    """Assign fetch to batch group. Lock held only for dict lookup/insert."""
+    with self._group_lock:  # ~microseconds
+        group = self._batch_groups.get(fetch.batch_key)
+        if group is None:
+            now = time.monotonic()
+            group = BatchGroup(
+                key=fetch.batch_key,
+                fetches=[],
+                created_at=now,
+                deadline=now + self._window_ms / 1000,
+            )
+            self._batch_groups[fetch.batch_key] = group
+        group.fetches.append(fetch)
+
+def _flush_ready_groups(self) -> None:
+    """Flush groups past deadline. RPC happens outside lock."""
+    now = time.monotonic()
+    ready_groups: list[BatchGroup] = []
+    
+    with self._group_lock:
+        expired_keys = [k for k, g in self._batch_groups.items() if g.deadline <= now]
+        for k in expired_keys:
+            ready_groups.append(self._batch_groups.pop(k))
+    
+    # RPC dispatch outside lock — no contention
+    for group in ready_groups:
+        self._dispatch_group(group)
+```
+
+3. **RPC Dispatch** — Actual materialization RPCs execute on the Store's async event loop (via `asyncio.run_coroutine_threadsafe`), not on the batcher thread. This keeps the dispatch thread responsive:
+
+```python
+def _dispatch_group(self, group: BatchGroup) -> None:
+    """Issue single RPC for batch group, distribute results to futures."""
+    names = [f.tensor_name for f in group.fetches]
+    coro = self._materialize_batch(group.key, names)
+    
+    # Submit to Store's event loop, not blocking dispatch thread
+    loop = self._store_ref().event_loop
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    future.add_done_callback(lambda f: self._distribute_results(group, f))
+```
+
+**Threading Topology:**
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│                          User Threads                                   │
+│  .tensor_async() → batcher.submit() → queue.put_nowait() → return      │
+└───────────────────────────────┬────────────────────────────────────────┘
+                                │ (non-blocking)
+                                ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│             MaterializationBatcher Dispatch Thread                      │
+│  _pending_queue.get() → _assign_to_group() → _flush_ready_groups()     │
+│  (daemon thread, independent of StoreRuntimeContext._executor)          │
+└───────────────────────────────┬────────────────────────────────────────┘
+                                │ asyncio.run_coroutine_threadsafe()
+                                ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                    Store Event Loop (asyncio)                           │
+│  _materialize_batch() → daemon gRPC → distribute results to futures    │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+**Invariants:**
+
+- `submit()` never blocks; callers receive `Future` immediately
+- `_group_lock` held for < 1µs (dict operations only)
+- RPC I/O happens on Store's event loop, not dispatch thread
+- Dispatch thread is daemon; no explicit shutdown required for process exit
+- `StoreRuntimeContext._executor` remains unchanged; batcher is fully independent
+
+### View-Specific Metadata Cache
+
+Global metadata caching is defined in `0036-02`. Phase 3 only adds a per-handle cache for view-derived metadata so repeated `.tensor_names` / `.describe()` calls on the same view do not re-run the planner.
+
+```python
+@dataclass(frozen=True)
+class ViewMetadataCache:
+    view_id: str
+    view_index_bytes: bytes
+    view_data_hash: str
+    tensor_names: tuple[str, ...]
+    nbytes: int
+```
+
+```
+
+`ViewMetadataCache` is computed once per derived artifact via `ViewPlanner` and stored on the handle (not in the shared `ArtifactCache`) because each view can have different specs even if they share the same parent artifact.
+
+### Source Resolution Flow
+
+```mermaid
+flowchart TD
+    A["artifact.tensor_dict()"] --> B{prefer_disk?}
+    B -->|Yes| C{disk_path provided?}
+    C -->|Yes| D["Daemon materialization (preference=DISK)"]
+    C -->|No| E["Daemon materialization (auto)"]
+    B -->|No| F["Daemon materialization (auto/p2p)"]
+    D --> J["Return tensors"]
+    E --> J
+    F --> G{allow_p2p?}
+    G -->|Yes| H["P2P or local replica"]
+    G -->|No| I["Local replica only"]
+    H --> J
+    I --> J
+```
+
+All branches route through the daemon per [0038-daemon-only-disk-materialization](./0038-daemon-only-disk-materialization.md).
+
+### Prefetch Integration
+
+`artifact.prefetch(device=...)` issues `MaterializeReplicaRequest` with `wait_for_completion=False` (now fully supported end-to-end) and returns a `PrefetchTicket`. The daemon immediately replies with `{replica_uuid, load_status, device_uuid, expires_at}` while continuing to build the replica in the background. Clients can either poll `ticket.is_ready` (backed by `QueryReplicaStatus`) or optimistically invoke `.tensor_dict()` which reuses the `replica_uuid` hint.
+
+```python
+@dataclass
+class PrefetchTicket:
+    """Handle to a background prefetch operation."""
+    replica_uuid: str
+    artifact_id: str
+    device: torch.device
+    expires_at: float
+    started_at: float  # time.monotonic()
+    ttl_seconds: float = 30.0
+    
+    @property
+    def is_ready(self) -> bool:
+        """True if replica is fully materialized."""
+        ...
+    
+    @property
+    def is_expired(self) -> bool:
+        """True if TTL exceeded."""
+        ...
+    
+    def wait(self, timeout: float | None = None) -> bool:
+        """Block until ready or timeout. Returns True if ready."""
+        ...
+    
+    def cancel(self) -> None:
+        """Request daemon to unload the prefetched replica."""
+        ...
+```
+
+#### Prefetch Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant A as Artifact
+    participant D as Daemon
+    
+    U->>A: prefetch(device="cuda:0")
+    A->>D: MaterializeReplicaRequest(wait=False, preference=...)
+    D-->>A: replica_uuid + load_status (immediate)
+    A-->>U: PrefetchTicket
+    
+    Note over D: Background materialization
+    
+    U->>A: tensor_dict(device="cuda:0")
+    A->>A: Check FallbackOptions.replica_uuid
+    A->>D: MaterializeReplicaRequest(replica_uuid=..., tensor_names=?, wait=True)
+    D-->>A: Reuse existing replica
+    A-->>U: tensors
+```
+
+Subsequent `.tensor_dict()` calls reuse the prefetched replica via the new RPC field **and** by copying `replica_uuid` into `FallbackOptions`. The daemon recognizes the hint, pins the staged replica (or finishes it if still in-flight), and skips redundant data movement. If the request targets a different device or arrives after `expires_at`, the daemon returns `FAILED_PRECONDITION`; the SDK drops the stale ticket, records a metric, and retries without a replica hint so correctness is preserved.
+
+# Invariants & Error Model
+
+## Invariants
+
+1. **Identity immutability**: `artifact.artifact_id` never changes after resolution.
+2. **Metadata consistency**: Once fetched, canonical index is immutable and cached.
+3. **Store binding**: All materialization uses the bound Store's policies (retry, fallback, tracing).
+4. **View derivation purity**: `.view()` returns new handle without mutating original; child is independent of parent lifecycle.
+5. **Lazy by default**: Construction and view derivation never trigger data transfer or RPC.
+6. **Cache coherence**: `ArtifactCache` entries are immutable once written; updates create new entries.
+7. **Thread safety**: All public methods are safe for concurrent access (see Thread Safety Model).
+8. **Weakref validity**: If `_store_ref` dereferences to `None`, all materialization calls fail with `FAILED_PRECONDITION`.
+
+## Error Semantics
+
+| Condition | Status Code | Retryable |
+|-----------|-------------|-----------|
+| Store closed / Artifact released | `FAILED_PRECONDITION` | No |
+| Artifact not found / Key unmapped | `NOT_FOUND` | No |
+| Tensor name unknown / Invalid slice/transpose | `INVALID_ARGUMENT` | No |
+| Materialization timeout | `DEADLINE_EXCEEDED` | Yes |
+| Daemon unavailable | `UNAVAILABLE` | Yes |
+| Data integrity mismatch | `DATA_LOSS` | No |
+
+All errors raised as `ArtifactError` with structured status codes.
+
+# Usage Examples
+
+### Tensor-Parallel Sharding
+
+```python
+model = tc.artifact(key="llama-70b:v1")
+rank, tp_size = dist.get_rank(), dist.get_world_size()
+dim_size = model.tensor_meta("lm_head.weight").shape[0]
+shard_start = rank * (dim_size // tp_size)
+
+sharded = model.view(slices={
+    "lm_head.weight": (0, slice(shard_start, shard_start + dim_size // tp_size)),
+})
+weights = sharded.tensor_dict(device=f"cuda:{rank}")
+```
+
+### Selective Loading
+
+```python
+artifact = tc.artifact(key="gpt2:v3")
+attn_names = [n for n in artifact.tensor_names if "attn" in n]
+attn_tensors = artifact.tensor_dict(device="cuda:0", names=attn_names)
+```
+
+### Disk Fallback
+
+```python
+artifact = tc.artifact(key="model:stable").with_fallback(
+    FallbackOptions.for_disk("/mnt/checkpoints/model")
+)
+state_dict = artifact.tensor_dict(device="cuda:0")
+```
+
+### View Chaining
+
+```python
+artifact = tc.artifact(key="transformer:v1")
+base_view = artifact.subset(["embed", "layer.0.attn", "layer.0.mlp"])
+sliced = base_view.view(slices={"embed": slice(0, 32000)})
+tensors = sliced.tensor_dict(device="cuda:0")  # Composed view
+```
+
+### Prefetch for Latency Hiding
+
+```python
+artifacts = [tc.artifact(key=f"layer_{i}") for i in range(12)]
+for a in artifacts:
+    a.prefetch(device="cuda:0")  # Background loading
+for a in artifacts:
+    tensors = a.tensor_dict(device="cuda:0")  # May be faster
+```
+
+# Trade-offs & Risks
+
+| Risk | Mitigation |
+|------|------------|
+| **Stale handles** — Artifact deleted after handle creation | `.exists()` check; `generation` tracking; `NOT_FOUND` on materialize |
+| **Lazy resolution overhead** — Extra RPC for metadata | `ArtifactCache` with 10-min TTL; background prefetch option |
+| **Per-tensor RPC cost** | `MaterializationBatcher` coalesces async calls; `BatchContext` for sync |
+| **Batcher thread contention** | Independent daemon thread; lock-free queue submission; lock held < 1µs |
+| **View chain complexity** | Flatten composed ViewSpecs; depth limit of 8 |
+| **Memory leaks** — Forgotten handles | Weak Store reference; `__del__` logs unreleased; prefetch TTL cleanup |
+| **Prefetch vs. eviction** | TTL (30s default); track in Store session metadata |
+| **Store closed mid-use** | `_store_ref` weakref returns `None`; clear error with `FAILED_PRECONDITION` |
+| **Cache memory pressure** | LRU eviction at 1000 entries; configurable via env var |
+| **Fork safety** | Artifact inherits cached metadata; materialization uses forked Store session |
+| **API surface expansion** | Clear documentation; eager API (`store.get()`) remains for simple cases |
+
+# Compatibility & Acceptance Criteria
+
+## Compatibility
+
+- **Single-track upgrade** — All environments must roll out the v2 daemon/GS binaries and proto set before enabling the SDK. We do not support mixed clusters.
+- **API continuity** — `store.get()` / `store.register()` keep their surface area but internally call the lazy pipeline on top of the new RPCs.
+- **On-disk parity** — Disk artifacts share the same SelectionPlan + slice reader as daemon-backed artifacts, so view semantics remain identical across sources.
+
+## Acceptance Criteria
+
+1. **State machine tests**: Unit tests for Artifact state transitions (UnresolvedKey → Identified → Indexed → Released/Failed).
+2. **Lazy resolution tests**: Integration tests for key resolution, partial fetches, view composition, disk fallback.
+3. **Batching tests**: Verify RPC coalescing for async `.tensor_async()` calls and sync `batch()` context.
+4. **Selective streaming tests**: Daemon + SDK end-to-end suites proving `tensor_names` only transfers requested tensors, deserializes via payload descriptors, and never builds a full state dict when not needed.
+5. **Disk slice tests**: Once Phase 4 is implemented, `tc.from_disk(path).view(...)` must return byte-accurate slices identical to P2P-backed artifact output for the same `ViewSpec`. (Detailed tests in Phase 4.)
+6. **Prefetch tests**: Latency reduction ≥20% for repeated `.tensor_dict()` after prefetch, including device-mismatch/expiry scenarios that produce `FAILED_PRECONDITION` and trigger a retry.
+7. **Metadata purity tests**: Confirm no GPU memory touched for `.describe()` / `.tensor_names`.
+8. **Thread safety tests**: Concurrent `.tensor_dict()` from multiple threads; concurrent `.view()` derivation.
+9. **Parent-child lifecycle tests**: Child view remains valid after parent `.release()`.
+10. **Fork safety tests**: Artifact handles behave correctly after `os.fork()` (inherit parent's cached metadata, but new materialization uses forked Store).
+11. **Cache eviction tests**: LRU eviction when cache exceeds 1000 entries.
+12. **Benchmark**: `.tensor()` overhead vs. full `.tensor_dict()` for single-tensor access (target: <5% overhead with selective fetch enabled).
+
+# Naming Compliance
+
+All new public names follow Python naming in `AGENTS.md`:
+- Classes: `Artifact`, `ArtifactDescriptor`, `TensorMeta`, `ViewBuilder`, `PrefetchTicket`, `BatchContext`
+- Functions/methods: `artifact()`, `from_disk()`, `tensor_dict()`, `tensor()`, `with_fallback()`, `view_builder()`
+
+# References
+
+- [0014-store-session-api-modernization](./0014-store-session-api-modernization.md) — Current Store session API
+- [0016-artifact-view-v1](./0016-artifact-view-v1.md) — ViewSpec and view retrieval/registration
+- [tensor-first-artifact-architecture](../internals/tensor-first-artifact-architecture.md) — Tensor-first design philosophy
+- [0007-content-addressed-artifact-id](./0007-content-addressed-artifact-id.md) — mi2 identity model

--- a/docs/plans/0036-02-artifact-handle-core.md
+++ b/docs/plans/0036-02-artifact-handle-core.md
@@ -1,0 +1,73 @@
+---
+slug: 0036-artifact-handle-core
+title: Plan – Lazy Artifact Handle Phase 2 (Handle + Metadata Cache)
+links:
+  design: ../designs/0036-02-artifact-handle-core.md
+areas: ["sdk"]
+related_code:
+  - tensorcast/api/store/__init__.py
+  - tensorcast/api/store/runtime.py
+  - tensorcast/api/store/materialization.py
+  - tensorcast/api/store/views.py
+  - tensorcast/api/store/common.py
+  - tensorcast/api/store/cache.py
+  - tensorcast/api/store/artifact.py
+  - tests/python/api/test_materialization_pipeline_v2.py
+---
+
+# Objective
+
+Ship the Artifact handle and metadata cache defined in the Phase 2 design so SDK users can construct lazy handles (`tc.artifact(...)`) that expose metadata and selective materialization without changing the existing eager `get*` APIs. This plan grounds the work in today’s eager-only SDK, adds cache + lifecycle plumbing that Phase 3 (`0036-03-lazy-artifact-handle.md`) will build on for views/batching/prefetch, and keeps daemon/proto changes out of scope (handled in Phase 1).
+
+# Current State & Grounding
+- `tensorcast/api/store/__init__.py` only exposes eager retrieval (`get`, `get_view`, `get_into*`) that always materialize full `dict[str, Tensor]`; there is no `Artifact` handle or factory entry point.
+- `StoreRuntimeContext` (`tensorcast/api/store/runtime.py`) maintains a key→artifact_id/disk path cache with `TENSORCAST_STORE_KEY_CACHE_TTL_SECONDS` (30s default) but has no canonical index cache; `_after_fork_child` rebuilds the client/executor only.
+- `MaterializationPipeline` (`tensorcast/api/store/materialization.py`) already uses the streaming v2 pipeline and accepts `tensor_names`, but callers always request the full payload; metadata parsing happens per call with no reuse.
+- `ViewOrchestrator` (`tensorcast/api/store/views.py`) resolves view inputs by fetching canonical index bytes from the daemon on every request; repeated view calls re-download the same index.
+- Tests under `tests/python/api/test_materialization_pipeline_v2.py` cover streaming subset materialization and iterator cleanup; there is no coverage for handle lifecycles, metadata caching, or store shutdown interactions.
+- Phase 3 design (`docs/designs/0036-03-lazy-artifact-handle.md`) assumes a stable handle + cache foundation to layer views, batching, and async/prefetch; that foundation does not exist yet.
+
+# Phases & Milestones
+
+- [x] **Phase 1: Runtime cache foundation**
+  - [x] Introduce `ArtifactCache` with TTL + LRU limits (`TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS`, `TENSORCAST_STORE_CACHE_MAX_ENTRIES`), storing `{artifact_id, disk_path, canonical_index_bytes, parsed_index, generation, expires_at}`.
+  - [x] Wire cache lifecycle into `StoreRuntimeContext` (construction, `close()`, `_after_fork_child`, and an explicit `invalidate_artifact` helper) and emit hit/miss/eviction metrics via `store_metrics`.
+  - [x] Add `get_artifact_index_cached`, `cache_artifact_index`, `invalidate_artifact` APIs (thread-safe), and clear `_key_cache` on invalidations.
+
+- [x] **Phase 2: Artifact handle surfaces + selective materialization**
+  - [x] Add `tensorcast/api/store/artifact.py` implementing the Phase 2 state machine (`key=` / `artifact_id=` / `disk_path=` constructors converge to Identified → Indexed), metadata accessors (`tensor_names`, `tensor_meta`, `describe`, `exists`, `is_valid`), `with_fallback`, `release`, and `to_dict`/`from_dict` serialization (with generation and TTL refresh) with double-checked locking.
+  - [x] Expose factories `Store.artifact(...)`, `tensorcast.artifact(...)`, and a guarded `tensorcast.from_disk(path)` stub that binds handles to the process Store via `weakref`, preserves eager APIs unchanged, and propagates store-closed errors as `ArtifactError(status_code="FAILED_PRECONDITION")`.
+  - [x] Implement handle-driven selective materialization helper (e.g., `_materialize_subset`) that validates names against cached indices and forwards `tensor_names` into `MaterializationPipeline`; open the pipeline helper internally without changing eager `get*` surfaces.
+  - [x] Define `TensorMeta` / `ArtifactDescriptor` dataclasses derived from canonical indices so metadata surfaces stay stable for Phase 3 view composition.
+
+- [x] **Phase 3: Cache integration & invalidation hooks**  *(depends on Phase 2 selective fetch foundation)*
+  - [x] Populate `ArtifactCache` by reusing `DaemonCtl.get_artifact_index_by_id` (and disk hints from key resolution); share parsed indices with `ViewOrchestrator` to eliminate duplicate daemon fetches and surface cache hit/miss/TTL/eviction metrics.
+  - [x] Wire invalidation triggers: successful register/put/register_view overwrite paths, `deregister_artifact`, and `MaterializationPipeline` NOT_FOUND/FAILED_PRECONDITION errors should call `invalidate_artifact` and clear `_key_cache` entries as needed.
+  - [x] Integrate `ViewOrchestrator.resolve_view_inputs` with `ArtifactCache` (hit before daemon RPC) and record cache metrics.
+  - [x] Ensure observability spans/metrics record cache outcomes and subset materialization selectors while keeping existing `get*` behavior and telemetry unchanged.
+
+- [x] **Phase 4: Validation, docs, and readiness for Phase 3**
+  - [x] Add tests: `tests/python/api/test_artifact_cache.py` (TTL expiry, LRU eviction, fork reset, generation carry-through, invalidation hooks), `tests/python/api/test_artifact_handle.py` (state transitions, `release` idempotency, subset fetch, serialization TTL refresh, store-close invalidation), `tests/python/api/test_artifact_exists.py`, `tests/python/api/test_artifact_tensor_subset.py`, and extend `test_materialization_pipeline_v2.py` with a handle-driven subset regression and generation assertions.
+  - [x] Update SDK docs (`tensorcast/api/README.md` and a new `tensorcast/api/store/README.md` if needed) plus cross-links in `docs/designs/0036-03-lazy-artifact-handle.md` to describe the handle surface, cache env vars, lifecycle semantics, and selective materialization baseline.
+  - [x] Document env vars and metrics in `docs/architecture/architecture-overview.md` and ensure Phase 3 design references Phase 2 selective fetch + cache baseline as implemented.
+
+# Tasks
+- Define `tensorcast/api/store/cache.py` with TTL + LRU eviction, hit/miss/eviction counters, and thread-safe access; add an `ArtifactCacheEntry` struct that carries canonical index bytes, parsed index, generation, and disk hint.
+- Extend `StoreRuntimeContext` with cache accessors (`get_artifact_index_cached`, `cache_artifact_index`, `invalidate_artifact`) and reuse them inside `ViewOrchestrator.resolve_view_inputs` to stop re-fetching indices per call.
+- Implement `Artifact` with a per-handle lock and `weakref` to `Store`; guard metadata fetch via double-checked locking, validate constructor inputs (exactly one of key/artifact_id/disk_path), and surface `exists()` without materializing tensors.
+- Add handle-driven selective materialization helper that validates names against cached indices, forwards `tensor_names` into `MaterializationPipeline`, and ensures `MaterializationPayload` carries `generation`.
+- Update `tensorcast/api/store/__init__.py` exports and process-store helpers to create/bind handles while keeping eager `get*` behavior untouched; plumb fallback options, disk hints, and generation through factories into the handle.
+- Wire invalidation triggers in registration/deregistration/materialization error paths; ensure `_key_cache` entries are cleared on deregister and overwrite.
+- Add test fixtures/mocks for daemon index fetches and materialization subsets so cache and handle tests run under `uv run pytest` without daemon dependencies; document new env vars and metrics.
+
+# Test / Rollout / Backout
+- **Unit/Integration**: `uv run pytest tests/python/api/test_artifact_cache.py`, `uv run pytest tests/python/api/test_artifact_handle.py`, `uv run pytest tests/python/api/test_artifact_tensor_subset.py`, `uv run pytest tests/python/api/test_artifact_exists.py`, `uv run pytest tests/python/api/test_materialization_pipeline_v2.py`.
+- **Rollout**: New APIs are additive; keep eager `get*` paths unchanged while enabling handles in docs/examples. Monitor cache metrics (hits/misses/evictions) and materialization subset telemetry in staging before promoting.
+- **Backout**: If issues surface, drop handle exports from `tensorcast/api/store/__init__.py` and disable cache usage in `ViewOrchestrator`/materialization while retaining the existing eager APIs; clear caches on rollback to avoid stale metadata.
+
+# Risks & Tracking
+- **Concurrency correctness**: Double-checked locking around metadata and cache updates could deadlock or race; mitigate with targeted unit tests and careful lock scoping in handles + runtime.
+- **Cache staleness/memory pressure**: TTL/LRU configuration mistakes could serve stale indices or over-consume memory; mitigate with clear env defaults, metrics, and `invalidate_artifact` hooks when artifacts are deregistered or leases expire.
+- **Lifecycle coupling**: Handles rely on process Store weakrefs; misuse after `Store.close()` must raise deterministic errors without leaking executor threads or daemon channels.
+- **Disk/key resolution drift**: Disk-path hints and key resolution need to stay consistent between the key cache and the new artifact cache; add coverage for disk-hinted construction even though full disk entry point ships in Phase 4.
+- **Selective fetch regression risk**: Opening the `tensor_names` pipeline path for handles must not alter eager `get*` behavior; mitigate with subset-specific tests and metrics assertions.

--- a/tensorcast/api/README.md
+++ b/tensorcast/api/README.md
@@ -22,6 +22,10 @@ Module-level helpers (`tensorcast.api.store.register`, `get`, etc.) reuse a proc
   expose metadata (`tensor_names`, `tensor_meta`, `describe`) and selective
   materialization (`tensor_dict(names=...)`, `tensor(name, ...)`) without
   changing the eager `get*` APIs.
+- Handles accept whichever identifiers are available (`artifact_id`, key, or
+  disk path). At least one identifier is required, but resolved handles keep all
+  known hints so `with_fallback(...)` and `to_dict()/from_dict()` remain valid
+  even after key resolution.
 - Handles are bound to the originating `Store`; materialization after
   `Store.close()` or `Artifact.release()` raises
   `ArtifactError(status_code="FAILED_PRECONDITION")` while cached metadata

--- a/tensorcast/api/README.md
+++ b/tensorcast/api/README.md
@@ -16,6 +16,21 @@ Design 0037 refactored `tensorcast.api.store` into a structured subpackage:
 
 Module-level helpers (`tensorcast.api.store.register`, `get`, etc.) reuse a process-scoped `Store`. If you close that store (or invoke `shutdown_process_store()`), the next helper invocation transparently reinitializes a fresh instance instead of reusing the closed handle.
 
+## Artifact Handles & Metadata Cache
+
+- `tensorcast.artifact(...)` / `Store.artifact(...)` provide lazy handles that
+  expose metadata (`tensor_names`, `tensor_meta`, `describe`) and selective
+  materialization (`tensor_dict(names=...)`, `tensor(name, ...)`) without
+  changing the eager `get*` APIs.
+- Handles are bound to the originating `Store`; materialization after
+  `Store.close()` or `Artifact.release()` raises
+  `ArtifactError(status_code="FAILED_PRECONDITION")` while cached metadata
+  remains readable.
+- The runtime now maintains an `ArtifactCache` for canonical indices. Defaults
+  can be tuned with `TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS` (600s) and
+  `TENSORCAST_STORE_CACHE_MAX_ENTRIES` (1000). Metrics are emitted for cache
+  hits, misses, evictions (`reason=ttl|lru`), and invalidations (`reason=*`).
+
 ## Materialization v2 (descriptor streaming)
 
 - `MaterializationPipeline` streams `TensorPayloadDescriptor` + tensor pairs from the daemon v2 surface (`tensorcast.proto.daemon.v2`) by default; the v1 path and `TC_ENABLE_MATERIALIZE_V2` flag have been removed.

--- a/tensorcast/api/_materialize.py
+++ b/tensorcast/api/_materialize.py
@@ -45,6 +45,7 @@ class MaterializationPayload:
     descriptors: Sequence[TensorPayloadDescriptor]
     payload_iter: Callable[[], PayloadIterator]
     replica_uuid: str
+    generation: int | None = None
     state_dict: dict[str, torch.Tensor] | None = None
     disk_path: str | None = None
     view_index_bytes: bytes | None = None

--- a/tensorcast/api/_materialize.py
+++ b/tensorcast/api/_materialize.py
@@ -52,6 +52,9 @@ class MaterializationPayload:
     view_data_hash: str | None = None
     source: store_daemon_pb2.MaterializationSource | None = None
     device_uuid: str | None = None
+    ticket_replica_uuid: str | None = None
+    ticket_status: store_daemon_pb2.MaterializeReplicaStatus | None = None
+    ticket_created_at_ts: float | None = None
 
 
 def _tensor_payload_from_proto(
@@ -95,18 +98,11 @@ def materialize_artifact_v2(
         raise ValueError("Either artifact_id, key, or disk_path_hint is required")
     if view is not None and view_id is not None:
         raise ValueError("Specify at most one of view or view_id")
-    if artifact_id is None and (view is not None or view_id is not None):
-        raise ValueError("artifact_id is required when requesting a view")
 
     ensure_client_otel("tensorcast-client", role="client")
     tracer = trace.get_tracer(__name__)
 
     opts = options or GetArtifactOptions()
-    if not opts.wait_for_completion:
-        raise DaemonUnavailable(
-            "wait_for_completion=False is not supported for materialize_artifact_v2"
-        )
-
     dev_id = resolve_device(device_id)
     (
         pinned_ms,
@@ -210,10 +206,21 @@ def materialize_artifact_v2(
                 "artifact_id, key, or disk_path_hint is required for materialize_artifact_v2"
             )
 
+    ticket_replica_uuid: str | None = None
+    ticket_status: store_daemon_pb2.MaterializeReplicaStatus | None = None
+    ticket_created_at_ts: float | None = None
+    if response.HasField("ticket"):
+        ticket_replica_uuid = response.ticket.replica_uuid or None
+        ticket_status = response.ticket.status
+        try:
+            ticket_created_at_ts = response.ticket.created_at.ToDatetime().timestamp()
+        except Exception:  # noqa: BLE001
+            ticket_created_at_ts = None
+
     handle_bytes = b""
     if response.HasField("mem_handle"):
         handle_bytes = response.mem_handle.cuda_ipc_handle
-    if not handle_bytes:
+    if wait_for_completion and not handle_bytes:
         raise DaemonUnavailable(
             "Daemon returned empty mem_handle for materialization v2"
         )
@@ -248,9 +255,15 @@ def materialize_artifact_v2(
         _tensor_payload_from_proto(desc, default_device_uuid=device_uuid)
         for desc in response.payloads
     ]
-    cuda_memory_ptr = get_cuda_memory_ptr(dev_id, handle_bytes)
+    cuda_memory_ptr = (
+        get_cuda_memory_ptr(dev_id, handle_bytes) if handle_bytes else None
+    )
 
     def _iter() -> PayloadIterator:
+        if cuda_memory_ptr is None:
+            raise DaemonUnavailable(
+                "Materialization payload is missing a mem_handle; tensor data is not available"
+            )
         for desc in descriptors:
             meta_state_dict = {
                 desc.name: (
@@ -297,6 +310,9 @@ def materialize_artifact_v2(
         view_data_hash=None,
         source=materialized_source,
         device_uuid=device_uuid,
+        ticket_replica_uuid=ticket_replica_uuid,
+        ticket_status=ticket_status,
+        ticket_created_at_ts=ticket_created_at_ts,
     )
 
 

--- a/tensorcast/api/_metrics.py
+++ b/tensorcast/api/_metrics.py
@@ -27,6 +27,10 @@ class _MeterState:
         self._latency: _Histogram | None = None
         self._errors: _Counter | None = None
         self._retries: _Counter | None = None
+        self._cache_hits: _Counter | None = None
+        self._cache_misses: _Counter | None = None
+        self._cache_evictions: _Counter | None = None
+        self._cache_invalidations: _Counter | None = None
         self._disabled = False
 
     @property
@@ -72,11 +76,35 @@ class _MeterState:
                     unit="1",
                     description="Retry attempts for TensorCast Store client operations.",
                 )
+                self._cache_hits = meter.create_counter(
+                    name="tc_store_artifact_cache_hits_total",
+                    unit="1",
+                    description="Artifact cache hits in the TensorCast Store client.",
+                )
+                self._cache_misses = meter.create_counter(
+                    name="tc_store_artifact_cache_misses_total",
+                    unit="1",
+                    description="Artifact cache misses in the TensorCast Store client.",
+                )
+                self._cache_evictions = meter.create_counter(
+                    name="tc_store_artifact_cache_evictions_total",
+                    unit="1",
+                    description="Artifact cache evictions in the TensorCast Store client.",
+                )
+                self._cache_invalidations = meter.create_counter(
+                    name="tc_store_artifact_cache_invalidations_total",
+                    unit="1",
+                    description="Artifact cache invalidations in the TensorCast Store client.",
+                )
             except Exception as exc:  # noqa: BLE001
                 self._disabled = True
                 self._latency = None
                 self._errors = None
                 self._retries = None
+                self._cache_hits = None
+                self._cache_misses = None
+                self._cache_evictions = None
+                self._cache_invalidations = None
                 _logger.debug("Failed to initialise store OTel metrics", exc_info=exc)
                 return False
         return True
@@ -160,6 +188,54 @@ class _MeterState:
         except Exception:  # noqa: BLE001
             _logger.debug("Failed to increment store retry counter", exc_info=True)
 
+    def increment_cache_hit(self, daemon: str) -> None:
+        if not self.ensure():
+            return
+        if self._cache_hits is None:
+            return
+        try:
+            self._cache_hits.add(1, attributes={"daemon": daemon})
+        except Exception:  # noqa: BLE001
+            _logger.debug("Failed to increment cache hit counter", exc_info=True)
+
+    def increment_cache_miss(self, daemon: str) -> None:
+        if not self.ensure():
+            return
+        if self._cache_misses is None:
+            return
+        try:
+            self._cache_misses.add(1, attributes={"daemon": daemon})
+        except Exception:  # noqa: BLE001
+            _logger.debug("Failed to increment cache miss counter", exc_info=True)
+
+    def increment_cache_eviction(self, daemon: str, *, reason: str | None) -> None:
+        if not self.ensure():
+            return
+        if self._cache_evictions is None:
+            return
+        attributes = {"daemon": daemon}
+        if reason:
+            attributes["reason"] = reason
+        try:
+            self._cache_evictions.add(1, attributes=attributes)
+        except Exception:  # noqa: BLE001
+            _logger.debug("Failed to increment cache eviction counter", exc_info=True)
+
+    def increment_cache_invalidation(self, daemon: str, *, reason: str | None) -> None:
+        if not self.ensure():
+            return
+        if self._cache_invalidations is None:
+            return
+        attributes = {"daemon": daemon}
+        if reason:
+            attributes["reason"] = reason
+        try:
+            self._cache_invalidations.add(1, attributes=attributes)
+        except Exception:  # noqa: BLE001
+            _logger.debug(
+                "Failed to increment cache invalidation counter", exc_info=True
+            )
+
 
 _METRICS = _MeterState()
 
@@ -198,3 +274,19 @@ def increment_retry(
     selection: str | None = None,
 ) -> None:
     _METRICS.increment_retries(verb, daemon, status, source=source, selection=selection)
+
+
+def increment_artifact_cache_hit(daemon: str) -> None:
+    _METRICS.increment_cache_hit(daemon)
+
+
+def increment_artifact_cache_miss(daemon: str) -> None:
+    _METRICS.increment_cache_miss(daemon)
+
+
+def increment_artifact_cache_eviction(daemon: str, *, reason: str | None) -> None:
+    _METRICS.increment_cache_eviction(daemon, reason=reason)
+
+
+def increment_artifact_cache_invalidation(daemon: str, *, reason: str | None) -> None:
+    _METRICS.increment_cache_invalidation(daemon, reason=reason)

--- a/tensorcast/api/store/README.md
+++ b/tensorcast/api/store/README.md
@@ -1,0 +1,36 @@
+# TensorCast Store SDK
+
+The `tensorcast.api.store` package exposes registration, retrieval, and lazy
+artifact handle surfaces. This module builds on the process-wide `Store`
+singleton (`tensorcast.store()`) so callers can reuse daemon sessions without
+managing clients manually.
+
+## Artifact Handles
+
+- `tensorcast.artifact(...)` and `Store.artifact(...)` return a lazy `Artifact`
+  bound to the process `Store`. Handles support metadata accessors
+  (`tensor_names`, `tensor_meta`, `describe`), existence checks (`exists`), and
+  selective materialization via `tensor_dict(names=...)` and `tensor(name, ...)`.
+- Handles are tied to the originating `Store` lifecycle. After `Store.close()`
+  (or `release()` on the handle), materialization raises
+  `ArtifactError(status_code="FAILED_PRECONDITION")` while cached metadata
+  remains readable for debugging.
+- `with_fallback(...)` clones a handle with different fallback hints; eager
+  `get*` APIs remain unchanged.
+
+## Metadata Cache
+
+- The process runtime owns an `ArtifactCache` that stores canonical index bytes,
+  parsed indices, and disk hints keyed by `artifact_id`. Cache entries expire by
+  TTL and obey an LRU bound.
+- Environment defaults:
+  - `TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS=600` (set `<=0` to disable)
+  - `TENSORCAST_STORE_CACHE_MAX_ENTRIES=1000` (set `<=0` to disable)
+- Cache metrics are emitted as:
+  - `tc_store_artifact_cache_hits_total`
+  - `tc_store_artifact_cache_misses_total`
+  - `tc_store_artifact_cache_evictions_total` (dimensions: `reason=ttl|lru`)
+  - `tc_store_artifact_cache_invalidations_total` (dimension: `reason`)
+- Invalidation hooks run after registration, deregistration, and materialization
+  errors (`NOT_FOUND`/`FAILED_PRECONDITION`) to keep key→artifact mappings and
+  cached indices consistent.

--- a/tensorcast/api/store/README.md
+++ b/tensorcast/api/store/README.md
@@ -11,6 +11,11 @@ managing clients manually.
   bound to the process `Store`. Handles support metadata accessors
   (`tensor_names`, `tensor_meta`, `describe`), existence checks (`exists`), and
   selective materialization via `tensor_dict(names=...)` and `tensor(name, ...)`.
+- Handles retain whichever identifiers are available (`artifact_id`, `key`,
+  `disk_path`). At least one identifier is required when instantiating or
+  rehydrating a handle, but resolved handles may keep both `artifact_id` and
+  `key` so cloning (`with_fallback`) and serialization (`to_dict`/`from_dict`)
+  continue to work.
 - Handles are tied to the originating `Store` lifecycle. After `Store.close()`
   (or `release()` on the handle), materialization raises
   `ArtifactError(status_code="FAILED_PRECONDITION")` while cached metadata

--- a/tensorcast/api/store/__init__.py
+++ b/tensorcast/api/store/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import threading
+import weakref
 from collections.abc import Callable, Mapping, Sequence
 
 import torch
@@ -22,6 +23,7 @@ from tensorcast.api._region_cache import (
 )
 from tensorcast.api._register import RegistrationResult, _register_artifact_core
 from tensorcast.api._runtime import require_runtime
+from tensorcast.api.store.artifact import Artifact, ArtifactDescriptor, TensorMeta
 from tensorcast.api.store.async_ops import ArtifactFuture
 from tensorcast.api.store.handles import RegisteredArtifact
 from tensorcast.api.store.materialization import MaterializationPipeline
@@ -188,6 +190,22 @@ class Store:
     # ------------------------------------------------------------------
     # Retrieval APIs
     # ------------------------------------------------------------------
+    def artifact(
+        self,
+        *,
+        artifact_id: str | None = None,
+        key: str | None = None,
+        disk_path: str | None = None,
+        fallback: FallbackOptions | None = None,
+    ) -> Artifact:
+        return Artifact(
+            store_ref=weakref.ref(self),
+            artifact_id=artifact_id,
+            key=key,
+            disk_path=disk_path,
+            fallback=fallback,
+        )
+
     def get(
         self,
         *,
@@ -362,13 +380,15 @@ class Store:
     ) -> DeregisterArtifactOutcome:
         client = self._runtime.ensure_client()
         drain_ms = int(drain_timeout_s * 1000) if drain_timeout_s is not None else None
-        return client.deregister_artifact(
+        outcome = client.deregister_artifact(
             artifact_id,
             wait_for_drain=bool(wait),
             drain_timeout_ms=drain_ms,
             extend_ttl_ms=extend_ttl_ms,
             device_id=device_id,
         )
+        self._runtime.invalidate_artifact(artifact_id, key=None, reason="deregister")
+        return outcome
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -743,7 +763,31 @@ def get_into_async(
     )
 
 
+def artifact(
+    *,
+    artifact_id: str | None = None,
+    key: str | None = None,
+    disk_path: str | None = None,
+    fallback: FallbackOptions | None = None,
+) -> Artifact:
+    return _coerce_store().artifact(
+        artifact_id=artifact_id,
+        key=key,
+        disk_path=disk_path,
+        fallback=fallback,
+    )
+
+
+def from_disk(path: str, *, fallback: FallbackOptions | None = None) -> Artifact:
+    effective_fallback = fallback or FallbackOptions(
+        disk_path=path, prefer_disk=True, allow_p2p=False
+    )
+    return _coerce_store().artifact(disk_path=path, fallback=effective_fallback)
+
+
 __all__ = [
+    "Artifact",
+    "ArtifactDescriptor",
     "ArtifactError",
     "ArtifactFuture",
     "ArtifactStatusCode",
@@ -758,8 +802,11 @@ __all__ = [
     "StoreCapabilities",
     "Store",
     "StoreOptions",
+    "TensorMeta",
     "TensorDict",
     "TransformPlacement",
+    "artifact",
+    "from_disk",
     "store",
     "shutdown_process_store",
     "register",

--- a/tensorcast/api/store/artifact.py
+++ b/tensorcast/api/store/artifact.py
@@ -97,9 +97,9 @@ class Artifact:
         generation: int | None = None,
     ) -> None:
         identifiers = [bool(artifact_id), bool(key), bool(disk_path)]
-        if sum(identifiers) != 1:
+        if sum(identifiers) == 0:
             raise ArtifactError(
-                "Exactly one of artifact_id, key, or disk_path is required",
+                "At least one of artifact_id, key, or disk_path is required",
                 status_code="INVALID_ARGUMENT",
                 retryable=False,
             )
@@ -311,6 +311,7 @@ class Artifact:
         return {
             "artifact_id": self._artifact_id,
             "key": self._key_hint,
+            "disk_path": self._disk_path_hint,
             "fallback": _fallback_to_dict(self._fallback),
             "canonical_index": encoded_index,
             "generation": self._generation,
@@ -320,6 +321,7 @@ class Artifact:
     def from_dict(cls, data: Mapping[str, object], store: "Store") -> Artifact:
         artifact_id = data.get("artifact_id")
         key_hint = data.get("key")
+        disk_path = data.get("disk_path")
         fallback_dict = data.get("fallback")
         canonical_blob = data.get("canonical_index")
         generation = data.get("generation")
@@ -347,6 +349,7 @@ class Artifact:
             store_ref=weakref.ref(store),
             artifact_id=str(artifact_id) if artifact_id else None,
             key=str(key_hint) if key_hint else None,
+            disk_path=str(disk_path) if disk_path else None,
             fallback=fallback,
             canonical_index_bytes=canonical_index_bytes,
             canonical_index=canonical_index,

--- a/tensorcast/api/store/artifact.py
+++ b/tensorcast/api/store/artifact.py
@@ -1,0 +1,546 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import base64
+import threading
+import time
+import weakref
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Mapping, Sequence, cast
+
+import torch
+
+from tensorcast.api.store.cache import ArtifactCacheEntry
+from tensorcast.api.store.common import canonical_index_from_bytes
+from tensorcast.api.store.materialization import MaterializationPipeline
+from tensorcast.api.store.retry import map_materialization_error
+from tensorcast.api.store.types import (
+    ArtifactError,
+    CanonicalIndex,
+    CanonicalIndexEntry,
+    FallbackOptions,
+)
+
+if TYPE_CHECKING:
+    from tensorcast.api.store import Store
+    from tensorcast.api.store.runtime import StoreRuntimeContext
+
+
+@dataclass(frozen=True, slots=True)
+class TensorMeta:
+    name: str
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    dtype: torch.dtype
+    storage_offset: int
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactDescriptor:
+    artifact_id: str
+    tensor_names: tuple[str, ...]
+    tensor_metas: Mapping[str, TensorMeta]
+    total_bytes: int
+    generation: int | None
+
+
+def _fallback_to_dict(fallback: FallbackOptions | None) -> dict[str, object] | None:
+    if fallback is None:
+        return None
+    return {
+        "disk_path": fallback.disk_path,
+        "prefer_disk": bool(fallback.prefer_disk),
+        "allow_p2p": bool(fallback.allow_p2p),
+        "verify_checksums": bool(fallback.verify_checksums),
+    }
+
+
+def _fallback_from_dict(data: Mapping[str, object] | None) -> FallbackOptions | None:
+    if data is None:
+        return None
+    disk_path_value = data.get("disk_path")
+    disk_path = disk_path_value if isinstance(disk_path_value, str) else None
+    return FallbackOptions(
+        disk_path=disk_path,
+        prefer_disk=bool(data.get("prefer_disk", False)),
+        allow_p2p=bool(data.get("allow_p2p", True)),
+        verify_checksums=bool(data.get("verify_checksums", True)),
+    )
+
+
+def _meta_from_entry(entry: CanonicalIndexEntry) -> TensorMeta:
+    return TensorMeta(
+        name=entry.name,
+        shape=tuple(entry.shape),
+        stride=tuple(entry.stride),
+        dtype=entry.dtype,
+        storage_offset=int(entry.storage_offset),
+        size_bytes=int(entry.size_bytes),
+    )
+
+
+class Artifact:
+    """Lazy handle to a TensorCast artifact."""
+
+    def __init__(
+        self,
+        *,
+        store_ref: weakref.ReferenceType["Store"],
+        artifact_id: str | None = None,
+        key: str | None = None,
+        disk_path: str | None = None,
+        fallback: FallbackOptions | None = None,
+        canonical_index_bytes: bytes | None = None,
+        canonical_index: CanonicalIndex | None = None,
+        generation: int | None = None,
+    ) -> None:
+        identifiers = [bool(artifact_id), bool(key), bool(disk_path)]
+        if sum(identifiers) != 1:
+            raise ArtifactError(
+                "Exactly one of artifact_id, key, or disk_path is required",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        self._artifact_id = artifact_id
+        self._key_hint = key
+        self._disk_path_hint = disk_path
+        self._fallback = fallback
+        self._canonical_index_bytes = canonical_index_bytes
+        self._canonical_index = canonical_index
+        self._tensor_metas: dict[str, TensorMeta] | None = None
+        if canonical_index is not None:
+            self._tensor_metas = {
+                entry.name: _meta_from_entry(entry) for entry in canonical_index.entries
+            }
+        self._generation = generation
+        self._store_ref = store_ref
+        self._lock = threading.RLock()
+        self._released = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def artifact_id(self) -> str:
+        return self._ensure_identified()
+
+    @property
+    def key(self) -> str | None:
+        return self._key_hint
+
+    @property
+    def tensor_names(self) -> tuple[str, ...]:
+        canonical_index = self._ensure_metadata()
+        return tuple(entry.name for entry in canonical_index.entries)
+
+    def tensor_meta(self, name: str) -> TensorMeta:
+        canonical_index = self._ensure_metadata()
+        metas = self._tensor_metas or {}
+        if name in metas:
+            return metas[name]
+        for entry in canonical_index.entries:
+            if entry.name == name:
+                meta = _meta_from_entry(entry)
+                metas[name] = meta
+                self._tensor_metas = metas
+                return meta
+        raise ArtifactError(
+            f"Tensor '{name}' not found in artifact",
+            status_code="INVALID_ARGUMENT",
+            retryable=False,
+        )
+
+    def describe(self) -> ArtifactDescriptor:
+        canonical_index = self._ensure_metadata()
+        metas = self._tensor_metas or {
+            entry.name: _meta_from_entry(entry) for entry in canonical_index.entries
+        }
+        self._tensor_metas = metas
+        return ArtifactDescriptor(
+            artifact_id=self._ensure_identified(),
+            tensor_names=tuple(entry.name for entry in canonical_index.entries),
+            tensor_metas=dict(metas),
+            total_bytes=int(canonical_index.total_size_bytes),
+            generation=self._generation,
+        )
+
+    def tensor_dict(
+        self,
+        *,
+        device: torch.device | str,
+        names: Sequence[str] | None = None,
+    ) -> dict[str, torch.Tensor]:
+        canonical_index = self._ensure_metadata()
+        requested_names = self._validate_tensor_names(canonical_index, names)
+        store, runtime, pipeline = self._require_components()
+        payload, _ = pipeline.materialize_subset(
+            artifact_id=self._artifact_id,
+            key=None,
+            device=device,
+            fallback=self._fallback,
+            tensor_names=requested_names,
+            canonical_index_hint=self._canonical_index_bytes,
+            disk_path_hint=self._disk_path_hint,
+        )
+        try:
+            self._update_metadata_from_payload(payload, runtime)
+            state = pipeline._payload_state_dict(payload)
+            if requested_names is None:
+                return state
+            return {name: state[name] for name in requested_names}
+        finally:
+            pipeline._release_materialized(payload, runtime.ensure_client())
+
+    def tensor(
+        self,
+        name: str,
+        *,
+        device: torch.device | str,
+        cache: bool = True,  # cache retained for compatibility, no-op in v2
+    ) -> torch.Tensor:
+        _ = cache  # cache parameter is reserved for future use
+        result = self.tensor_dict(device=device, names=[name])
+        if name not in result:
+            raise ArtifactError(
+                f"Tensor '{name}' missing from materialized payload",
+                status_code="NOT_FOUND",
+                retryable=False,
+            )
+        return result[name]
+
+    def tensor_dict_into(
+        self,
+        target: dict[str, torch.Tensor],
+        *,
+        device: torch.device | str | None = None,
+    ) -> None:
+        canonical_index = self._ensure_metadata()
+        _ = self._validate_tensor_names(canonical_index, None)
+        _, _, pipeline = self._require_components()
+        pipeline.get_into(
+            target,
+            artifact_id=self._artifact_id,
+            key=None,
+            device=device,
+            fallback=self._fallback,
+        )
+
+    def with_fallback(self, fallback: FallbackOptions) -> Artifact:
+        clone = Artifact(
+            store_ref=self._store_ref,
+            artifact_id=self._artifact_id,
+            key=self._key_hint,
+            disk_path=self._disk_path_hint,
+            fallback=fallback,
+            canonical_index_bytes=self._canonical_index_bytes,
+            canonical_index=self._canonical_index,
+            generation=self._generation,
+        )
+        clone._released = self._released
+        clone._tensor_metas = dict(self._tensor_metas or {})
+        return clone
+
+    def exists(self) -> bool:
+        if self._canonical_index is not None:
+            return True
+        runtime = self._runtime_if_available()
+        if runtime is None:
+            raise ArtifactError(
+                "Store is closed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        try:
+            artifact_id = self._ensure_identified()
+        except ArtifactError as exc:
+            if exc.status_code == "NOT_FOUND":
+                return False
+            raise
+        cached = runtime.get_artifact_index_cached(artifact_id)
+        if cached:
+            self._hydrate_from_cache_entry(cached)
+            return True
+        try:
+            canonical_index_bytes = runtime.ensure_client().get_artifact_index_by_id(
+                artifact_id
+            )
+        except Exception as exc:  # noqa: BLE001
+            error = map_materialization_error(exc)
+            if error.status_code == "NOT_FOUND":
+                runtime.invalidate_artifact(
+                    artifact_id, key=self._key_hint, reason="exists_not_found"
+                )
+                return False
+            raise error from exc
+        canonical_index = canonical_index_from_bytes(canonical_index_bytes)
+        self._set_metadata(
+            canonical_index_bytes,
+            canonical_index,
+            generation=self._generation,
+            disk_path=self._disk_path_hint,
+        )
+        runtime.cache_artifact_index(
+            ArtifactCacheEntry(
+                artifact_id=artifact_id,
+                canonical_index_bytes=canonical_index_bytes,
+                parsed_index=canonical_index,
+                generation=self._generation,
+                disk_path=self._disk_path_hint,
+                expires_at=time.monotonic(),
+            )
+        )
+        return True
+
+    @property
+    def is_valid(self) -> bool:
+        store = self._store_ref() if self._store_ref is not None else None
+        return not self._released and store is not None and not store.closed
+
+    def release(self) -> None:
+        with self._lock:
+            self._released = True
+
+    def to_dict(self) -> dict[str, object]:
+        encoded_index: str | None = None
+        if self._canonical_index_bytes:
+            encoded_index = base64.b64encode(self._canonical_index_bytes).decode(
+                "utf-8"
+            )
+        return {
+            "artifact_id": self._artifact_id,
+            "key": self._key_hint,
+            "fallback": _fallback_to_dict(self._fallback),
+            "canonical_index": encoded_index,
+            "generation": self._generation,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object], store: "Store") -> Artifact:
+        artifact_id = data.get("artifact_id")
+        key_hint = data.get("key")
+        fallback_dict = data.get("fallback")
+        canonical_blob = data.get("canonical_index")
+        generation = data.get("generation")
+        canonical_index_bytes: bytes | None = None
+        canonical_index: CanonicalIndex | None = None
+        if canonical_blob:
+            try:
+                canonical_index_bytes = base64.b64decode(
+                    str(canonical_blob).encode("utf-8")
+                )
+                canonical_index = canonical_index_from_bytes(canonical_index_bytes)
+            except Exception as exc:  # noqa: BLE001
+                raise ArtifactError(
+                    "Failed to decode serialized artifact metadata",
+                    status_code="DATA_LOSS",
+                    retryable=False,
+                ) from exc
+        fallback = None
+        if isinstance(fallback_dict, Mapping):
+            fallback = _fallback_from_dict(cast(Mapping[str, object], fallback_dict))
+        generation_value = (
+            int(generation) if isinstance(generation, (int, float)) else None
+        )
+        return cls(
+            store_ref=weakref.ref(store),
+            artifact_id=str(artifact_id) if artifact_id else None,
+            key=str(key_hint) if key_hint else None,
+            fallback=fallback,
+            canonical_index_bytes=canonical_index_bytes,
+            canonical_index=canonical_index,
+            generation=generation_value,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _require_components(
+        self,
+    ) -> tuple["Store", StoreRuntimeContext, MaterializationPipeline]:
+        store = self._store_ref() if self._store_ref is not None else None
+        if store is None or store.closed or self._released:
+            raise ArtifactError(
+                "Artifact handle is released or store is closed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        return store, store._runtime, store._materialization
+
+    def _runtime_if_available(self) -> StoreRuntimeContext | None:
+        store = self._store_ref() if self._store_ref is not None else None
+        if store is None or store.closed:
+            return None
+        return store._runtime
+
+    def _ensure_identified(self) -> str:
+        if self._artifact_id:
+            return self._artifact_id
+        runtime = self._runtime_if_available()
+        if runtime is None:
+            raise ArtifactError(
+                "Store is closed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        with self._lock:
+            if self._artifact_id:
+                return self._artifact_id
+            if self._key_hint:
+                artifact_id, disk_path = runtime.resolve_key_mapping_cached(
+                    key=self._key_hint
+                )
+                if disk_path and not self._disk_path_hint:
+                    self._disk_path_hint = disk_path
+                if not artifact_id:
+                    raise ArtifactError(
+                        f"Artifact key '{self._key_hint}' is not mapped",
+                        status_code="NOT_FOUND",
+                        retryable=False,
+                    )
+                self._artifact_id = artifact_id
+                return artifact_id
+            if self._disk_path_hint:
+                raise ArtifactError(
+                    "Disk-backed artifact handles are not supported yet",
+                    status_code="UNIMPLEMENTED",
+                    retryable=False,
+                )
+            raise ArtifactError(
+                "Artifact handle missing identity",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+
+    def _ensure_metadata(self) -> CanonicalIndex:
+        if (
+            self._canonical_index is not None
+            and self._canonical_index_bytes is not None
+        ):
+            return self._canonical_index
+        runtime = self._runtime_if_available()
+        if runtime is None:
+            raise ArtifactError(
+                "Store is closed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        artifact_id = self._ensure_identified()
+        with self._lock:
+            if (
+                self._canonical_index is not None
+                and self._canonical_index_bytes is not None
+            ):
+                return self._canonical_index
+            cached = runtime.get_artifact_index_cached(artifact_id)
+            if cached:
+                self._hydrate_from_cache_entry(cached)
+                assert self._canonical_index is not None
+                return self._canonical_index
+            try:
+                canonical_index_bytes = (
+                    runtime.ensure_client().get_artifact_index_by_id(artifact_id)
+                )
+            except Exception as exc:  # noqa: BLE001
+                raise map_materialization_error(exc) from exc
+            canonical_index = canonical_index_from_bytes(canonical_index_bytes)
+            self._set_metadata(
+                canonical_index_bytes,
+                canonical_index,
+                generation=self._generation,
+                disk_path=self._disk_path_hint,
+            )
+            runtime.cache_artifact_index(
+                ArtifactCacheEntry(
+                    artifact_id=artifact_id,
+                    canonical_index_bytes=canonical_index_bytes,
+                    parsed_index=canonical_index,
+                    generation=self._generation,
+                    disk_path=self._disk_path_hint,
+                    expires_at=time.monotonic(),
+                )
+            )
+            return canonical_index
+
+    def _hydrate_from_cache_entry(self, entry: ArtifactCacheEntry) -> None:
+        self._set_metadata(
+            entry.canonical_index_bytes,
+            entry.parsed_index,
+            generation=entry.generation,
+            disk_path=entry.disk_path,
+        )
+
+    def _set_metadata(
+        self,
+        canonical_index_bytes: bytes,
+        canonical_index: CanonicalIndex,
+        *,
+        generation: int | None,
+        disk_path: str | None,
+    ) -> None:
+        self._canonical_index_bytes = canonical_index_bytes
+        self._canonical_index = canonical_index
+        self._generation = generation
+        if disk_path and not self._disk_path_hint:
+            self._disk_path_hint = disk_path
+        self._tensor_metas = {
+            entry.name: _meta_from_entry(entry) for entry in canonical_index.entries
+        }
+
+    def _update_metadata_from_payload(
+        self, payload, runtime: StoreRuntimeContext
+    ) -> None:
+        try:
+            canonical_index_bytes = payload.canonical_index_bytes
+        except Exception:  # noqa: BLE001
+            return
+        if not canonical_index_bytes:
+            return
+        canonical_index = canonical_index_from_bytes(canonical_index_bytes)
+        artifact_id = self._artifact_id
+        if not artifact_id:
+            return
+        with self._lock:
+            if self._canonical_index is None:
+                self._set_metadata(
+                    canonical_index_bytes,
+                    canonical_index,
+                    generation=getattr(payload, "generation", None),
+                    disk_path=getattr(payload, "disk_path", None),
+                )
+        runtime.cache_artifact_index(
+            ArtifactCacheEntry(
+                artifact_id=artifact_id,
+                canonical_index_bytes=canonical_index_bytes,
+                parsed_index=canonical_index,
+                generation=getattr(payload, "generation", None),
+                disk_path=getattr(payload, "disk_path", None),
+                expires_at=time.monotonic(),
+            )
+        )
+
+    @staticmethod
+    def _validate_tensor_names(
+        canonical_index: CanonicalIndex, names: Sequence[str] | None
+    ) -> tuple[str, ...] | None:
+        if names is None:
+            return None
+        available = {entry.name for entry in canonical_index.entries}
+        ordered: list[str] = []
+        seen: set[str] = set()
+        for name in names:
+            if name in seen:
+                continue
+            if name not in available:
+                raise ArtifactError(
+                    f"Tensor '{name}' not found in artifact",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            seen.add(name)
+            ordered.append(name)
+        return tuple(ordered)
+
+
+__all__ = ["Artifact", "ArtifactDescriptor", "TensorMeta"]

--- a/tensorcast/api/store/cache.py
+++ b/tensorcast/api/store/cache.py
@@ -1,0 +1,132 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, replace
+from typing import Mapping
+
+from tensorcast.api import _metrics as store_metrics
+from tensorcast.api.store.types import CanonicalIndex
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ArtifactCacheEntry:
+    artifact_id: str
+    canonical_index_bytes: bytes
+    parsed_index: CanonicalIndex
+    generation: int | None
+    disk_path: str | None
+    expires_at: float
+    hit_count: int = 0
+
+
+class ArtifactCache:
+    """Process-wide canonical index cache with TTL and LRU eviction."""
+
+    def __init__(
+        self,
+        *,
+        daemon_endpoint: str,
+        ttl_seconds: float,
+        max_entries: int,
+    ) -> None:
+        self._daemon_endpoint = daemon_endpoint
+        self._ttl_seconds = max(0.0, float(ttl_seconds))
+        self._max_entries = int(max_entries)
+        self._lock = threading.RLock()
+        self._entries: OrderedDict[str, ArtifactCacheEntry] = OrderedDict()
+
+    @property
+    def ttl_seconds(self) -> float:
+        return self._ttl_seconds
+
+    @property
+    def max_entries(self) -> int:
+        return self._max_entries
+
+    @property
+    def enabled(self) -> bool:
+        return self._ttl_seconds > 0 and self._max_entries > 0
+
+    @property
+    def size(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+    def get_artifact_index_cached(self, artifact_id: str) -> ArtifactCacheEntry | None:
+        if not self.enabled:
+            return None
+        now = time.monotonic()
+        with self._lock:
+            entry = self._entries.get(artifact_id)
+            if entry is None:
+                store_metrics.increment_artifact_cache_miss(self._daemon_endpoint)
+                return None
+            if entry.expires_at <= now:
+                del self._entries[artifact_id]
+                store_metrics.increment_artifact_cache_eviction(
+                    self._daemon_endpoint, reason="ttl"
+                )
+                store_metrics.increment_artifact_cache_miss(self._daemon_endpoint)
+                return None
+            entry.hit_count += 1
+            self._entries.move_to_end(artifact_id)
+            store_metrics.increment_artifact_cache_hit(self._daemon_endpoint)
+            return replace(entry)
+
+    def cache_artifact_index(self, entry: ArtifactCacheEntry) -> None:
+        if not self.enabled:
+            return
+        if not entry.artifact_id:
+            return
+        expires_at = time.monotonic() + self._ttl_seconds
+        cached = replace(entry, expires_at=expires_at, hit_count=0)
+        with self._lock:
+            if entry.artifact_id in self._entries:
+                del self._entries[entry.artifact_id]
+            self._entries[entry.artifact_id] = cached
+            self._entries.move_to_end(entry.artifact_id)
+            self._evict_lru_locked()
+
+    def invalidate_artifact(
+        self, artifact_id: str, *, reason: str | None = None
+    ) -> None:
+        if not artifact_id:
+            return
+        with self._lock:
+            removed = self._entries.pop(artifact_id, None)
+        if removed is not None:
+            store_metrics.increment_artifact_cache_invalidation(
+                self._daemon_endpoint, reason=reason or "explicit"
+            )
+
+    def _evict_lru_locked(self) -> None:
+        if self._max_entries <= 0:
+            return
+        while len(self._entries) > self._max_entries:
+            _, removed = self._entries.popitem(last=False)
+            store_metrics.increment_artifact_cache_eviction(
+                self._daemon_endpoint, reason="lru"
+            )
+            logger.debug(
+                "store.artifact_cache.evict",
+                extra={
+                    "tc.store.daemon": self._daemon_endpoint,
+                    "tc.artifact.id": removed.artifact_id,
+                    "tc.cache.reason": "lru",
+                },
+            )
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def to_debug_dict(self) -> Mapping[str, float]:
+        with self._lock:
+            return {key: entry.expires_at for key, entry in self._entries.items()}

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -722,13 +722,6 @@ class MaterializationPipeline:
             bool(fallback_opts.verify_checksums) if fallback_opts else True
         )
         requested_disk = False
-        if (view is not None or view_id is not None) and fallback_opts:
-            raise ArtifactError(
-                "Disk fallback is not supported for view materialization",
-                status_code="FAILED_PRECONDITION",
-                retryable=False,
-            )
-
         if fallback_opts and (
             fallback_opts.prefer_disk
             or fallback_opts.disk_path

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -179,6 +179,30 @@ class MaterializationPipeline:
             state = {name: state[name] for name in tensor_names}
         return state
 
+    def materialize_subset(
+        self,
+        *,
+        artifact_id: str | None,
+        key: str | None,
+        device: torch.device | str | None,
+        fallback: FallbackOptions | None,
+        tensor_names: Sequence[str] | None,
+        canonical_index_hint: bytes | None = None,
+        disk_path_hint: str | None = None,
+    ) -> tuple[MaterializationPayload, int]:
+        return self._perform_get_with_retry(
+            method="get",
+            artifact_id=artifact_id,
+            key=key,
+            device=device,
+            fallback=fallback,
+            cancel_event=None,
+            options_override=None,
+            canonical_index_hint=canonical_index_hint,
+            disk_path_hint=disk_path_hint,
+            tensor_names=tensor_names,
+        )
+
     def get_view(
         self,
         *,
@@ -861,6 +885,7 @@ class MaterializationPipeline:
                 canonical_index_bytes=canonical_bytes,
                 descriptors=filtered_descriptors,
                 payload_iter=_filtered_iter,
+                generation=base_payload.generation,
                 state_dict=state_dict,
                 replica_uuid=base_payload.replica_uuid,
                 disk_path=base_payload.disk_path,
@@ -995,6 +1020,10 @@ class MaterializationPipeline:
                     return materialized, device_id
                 except ArtifactError as error:
                     span.record_exception(error)
+                    if error.status_code in {"NOT_FOUND", "FAILED_PRECONDITION"}:
+                        self._runtime.invalidate_artifact(
+                            artifact_id, key=key, reason="materialize_error"
+                        )
                     should_retry_op = should_retry(
                         error=error,
                         attempt=attempt,
@@ -1045,6 +1074,10 @@ class MaterializationPipeline:
                 except Exception as exc:  # noqa: BLE001
                     error = map_materialization_error(exc)
                     span.record_exception(error)
+                    if error.status_code in {"NOT_FOUND", "FAILED_PRECONDITION"}:
+                        self._runtime.invalidate_artifact(
+                            artifact_id, key=key, reason="materialize_error"
+                        )
                     should_retry_op = should_retry(
                         error=error,
                         attempt=attempt,

--- a/tensorcast/api/store/registration.py
+++ b/tensorcast/api/store/registration.py
@@ -461,6 +461,9 @@ class RegistrationPipeline:
                         device_override=device_override,
                         view_registration=view_registration,
                     )
+                    self._runtime.invalidate_artifact(
+                        result.artifact_id, key=key, reason="registration"
+                    )
                     record_outcome("OK")
                     span.set_attribute("tc.store.retry.count", attempt)
                     span.set_attribute("tc.replica.type", result.replica.replica_type)

--- a/tensorcast/api/store/runtime.py
+++ b/tensorcast/api/store/runtime.py
@@ -19,6 +19,7 @@ from opentelemetry.trace import Span, SpanKind
 
 from tensorcast.api._register import RegisteredLease
 from tensorcast.api._runtime import require_runtime
+from tensorcast.api.store.cache import ArtifactCache, ArtifactCacheEntry
 from tensorcast.api.store.retry import build_retry_policies
 from tensorcast.api.store.types import (
     RetryPolicy,
@@ -96,6 +97,13 @@ class StoreRuntimeContext:
         self._key_cache_lock = threading.RLock()
         self._key_cache: dict[str, _KeyCacheEntry] = {}
         self._key_cache_ttl_seconds = self._configure_key_cache_ttl()
+        self._artifact_cache_ttl_seconds = self._configure_index_cache_ttl()
+        self._artifact_cache_max_entries = self._configure_index_cache_size()
+        self._artifact_cache = ArtifactCache(
+            daemon_endpoint=self._daemon_endpoint,
+            ttl_seconds=self._artifact_cache_ttl_seconds,
+            max_entries=self._artifact_cache_max_entries,
+        )
         self._closed = False
 
         self._init_session_record()
@@ -150,6 +158,36 @@ class StoreRuntimeContext:
         if value <= 0:
             return 0.0
         return value
+
+    def _configure_index_cache_ttl(self) -> float:
+        raw = os.getenv("TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS")
+        if raw is None or raw == "":
+            return 600.0
+        try:
+            value = float(raw)
+        except ValueError:
+            logger.warning(
+                "store.index_cache_ttl.invalid",
+                extra={"tc.store.daemon": self._daemon_endpoint, "ttl": raw},
+            )
+            return 600.0
+        if value <= 0:
+            return 0.0
+        return value
+
+    def _configure_index_cache_size(self) -> int:
+        raw = os.getenv("TENSORCAST_STORE_CACHE_MAX_ENTRIES")
+        if raw is None or raw == "":
+            return 1000
+        try:
+            value = int(raw)
+        except ValueError:
+            logger.warning(
+                "store.index_cache_size.invalid",
+                extra={"tc.store.daemon": self._daemon_endpoint, "size": raw},
+            )
+            return 1000
+        return max(0, value)
 
     def _active_lease_count(self) -> int:
         with self._leases_lock:
@@ -257,6 +295,33 @@ class StoreRuntimeContext:
         self.cache_key_mapping(key, artifact_id=resolved_id, disk_path=resolved_path)
         return resolved_id, resolved_path
 
+    def get_artifact_index_cached(self, artifact_id: str) -> ArtifactCacheEntry | None:
+        return self._artifact_cache.get_artifact_index_cached(artifact_id)
+
+    def cache_artifact_index(self, entry: ArtifactCacheEntry) -> None:
+        self._artifact_cache.cache_artifact_index(entry)
+
+    def invalidate_artifact(
+        self,
+        artifact_id: str | None,
+        *,
+        key: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        if artifact_id:
+            self._artifact_cache.invalidate_artifact(artifact_id, reason=reason)
+        with self._key_cache_lock:
+            keys_to_remove = []
+            for cached_key, cached_entry in self._key_cache.items():
+                matches_artifact = bool(
+                    artifact_id and cached_entry.artifact_id == artifact_id
+                )
+                matches_key = bool(key is not None and cached_key == key)
+                if matches_artifact or matches_key:
+                    keys_to_remove.append(cached_key)
+            for cached_key in keys_to_remove:
+                del self._key_cache[cached_key]
+
     def _record_session_start(self, capabilities: StoreCapabilities) -> None:
         attributes: dict[str, SpanAttributeValue] = {
             "tc.store.session_id": self._session_id,
@@ -362,6 +427,13 @@ class StoreRuntimeContext:
         self._key_cache_lock = threading.RLock()
         self._key_cache = {}
         self._key_cache_ttl_seconds = self._configure_key_cache_ttl()
+        self._artifact_cache_ttl_seconds = self._configure_index_cache_ttl()
+        self._artifact_cache_max_entries = self._configure_index_cache_size()
+        self._artifact_cache = ArtifactCache(
+            daemon_endpoint=self._daemon_endpoint,
+            ttl_seconds=self._artifact_cache_ttl_seconds,
+            max_entries=self._artifact_cache_max_entries,
+        )
         self._init_session_record()
 
     def ensure_client(self) -> DaemonCtl:
@@ -388,6 +460,7 @@ class StoreRuntimeContext:
         self._executor_handle.close()
         with self._key_cache_lock:
             self._key_cache.clear()
+        self._artifact_cache.clear()
         self._update_session_record(activity=True, closed=True)
 
     # ------------------------------------------------------------------

--- a/tensorcast/api/store/views.py
+++ b/tensorcast/api/store/views.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Mapping, Sequence
 
 from tensorcast.api._view_ops import (
@@ -12,6 +13,7 @@ from tensorcast.api._view_ops import (
     _coerce_slice_spec,
     build_view_spec,
 )
+from tensorcast.api.store.cache import ArtifactCacheEntry
 from tensorcast.api.store.common import canonical_index_from_bytes
 from tensorcast.api.store.runtime import StoreRuntimeContext
 from tensorcast.api.store.types import ArtifactError, CanonicalIndex
@@ -106,9 +108,9 @@ class ViewOrchestrator:
         transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
         view_id: str | None,
     ) -> ResolvedViewInputs:
-        client = self._runtime.ensure_client()
         resolved_artifact_id, resolved_key = self._resolve_identifiers(artifact_id, key)
         disk_path_hint: str | None = None
+        cached_entry: ArtifactCacheEntry | None = None
         if resolved_artifact_id is None:
             assert resolved_key is not None
             resolved_artifact_id, disk_path_hint = (
@@ -120,6 +122,10 @@ class ViewOrchestrator:
                     status_code="NOT_FOUND",
                     retryable=False,
                 )
+        if resolved_artifact_id:
+            cached_entry = self._runtime.get_artifact_index_cached(resolved_artifact_id)
+            if cached_entry and cached_entry.disk_path and not disk_path_hint:
+                disk_path_hint = cached_entry.disk_path
 
         if view_id is not None:
             if slices or transpose:
@@ -147,8 +153,29 @@ class ViewOrchestrator:
                 retryable=False,
             )
 
-        canonical_index_bytes = client.get_artifact_index_by_id(resolved_artifact_id)
-        canonical_index = canonical_index_from_bytes(canonical_index_bytes)
+        canonical_index_bytes = (
+            cached_entry.canonical_index_bytes if cached_entry else None
+        )
+        canonical_index: CanonicalIndex | None = (
+            cached_entry.parsed_index if cached_entry else None
+        )
+        if canonical_index_bytes is None:
+            client = self._runtime.ensure_client()
+            canonical_index_bytes = client.get_artifact_index_by_id(
+                resolved_artifact_id
+            )
+        if canonical_index is None:
+            canonical_index = canonical_index_from_bytes(canonical_index_bytes)
+        if cached_entry is None:
+            cache_entry = ArtifactCacheEntry(
+                artifact_id=resolved_artifact_id,
+                canonical_index_bytes=canonical_index_bytes,
+                parsed_index=canonical_index,
+                generation=None,
+                disk_path=disk_path_hint,
+                expires_at=time.monotonic(),
+            )
+            self._runtime.cache_artifact_index(cache_entry)
         build_result = self._build_view_spec(
             canonical_index=canonical_index,
             slices=slices,

--- a/tests/python/api/test_artifact_cache.py
+++ b/tests/python/api/test_artifact_cache.py
@@ -1,0 +1,61 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import time
+
+import torch
+
+from tensorcast.api.store.cache import ArtifactCache, ArtifactCacheEntry
+from tensorcast.api.store.types import CanonicalIndex, CanonicalIndexEntry
+
+
+def _make_entry(artifact_id: str) -> ArtifactCacheEntry:
+    entry = CanonicalIndexEntry(
+        name="x",
+        dtype=torch.float32,
+        shape=(1,),
+        stride=(1,),
+        storage_offset=0,
+        segment_offset=0,
+        size_bytes=4,
+    )
+    index = CanonicalIndex(entries=(entry,), total_size_bytes=4, avbs_hash="")
+    return ArtifactCacheEntry(
+        artifact_id=artifact_id,
+        canonical_index_bytes=b'{"x":[0,4,[1],[1],"float32",0]}',
+        parsed_index=index,
+        generation=None,
+        disk_path=None,
+        expires_at=time.monotonic(),
+    )
+
+
+def test_cache_hit_and_ttl_expiry():
+    cache = ArtifactCache(daemon_endpoint="daemon", ttl_seconds=0.01, max_entries=4)
+    cache.cache_artifact_index(_make_entry("a1"))
+    cached = cache.get_artifact_index_cached("a1")
+    assert cached is not None
+    assert cached.artifact_id == "a1"
+    assert cached.hit_count == 1
+    time.sleep(0.02)
+    assert cache.get_artifact_index_cached("a1") is None
+
+
+def test_cache_lru_eviction():
+    cache = ArtifactCache(daemon_endpoint="daemon", ttl_seconds=10, max_entries=2)
+    cache.cache_artifact_index(_make_entry("first"))
+    cache.cache_artifact_index(_make_entry("second"))
+    cache.cache_artifact_index(_make_entry("third"))
+
+    assert cache.get_artifact_index_cached("first") is None
+    assert cache.get_artifact_index_cached("second") is not None
+    assert cache.get_artifact_index_cached("third") is not None
+
+
+def test_cache_invalidate_removes_entry():
+    cache = ArtifactCache(daemon_endpoint="daemon", ttl_seconds=10, max_entries=2)
+    cache.cache_artifact_index(_make_entry("dead"))
+    assert cache.get_artifact_index_cached("dead") is not None
+    cache.invalidate_artifact("dead", reason="explicit")
+    assert cache.get_artifact_index_cached("dead") is None

--- a/tests/python/api/test_artifact_exists.py
+++ b/tests/python/api/test_artifact_exists.py
@@ -1,0 +1,95 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import json
+import weakref
+
+import torch
+
+from tensorcast.api.store.artifact import Artifact
+from tensorcast.api.store.cache import ArtifactCache
+from tensorcast.api.store.types import StoreOptions
+from tensorcast.api.store.retry import build_retry_policies
+
+
+def _canonical_index_bytes() -> bytes:
+    tensor = torch.ones(1)
+    meta = [0, int(tensor.element_size() * tensor.numel()), [1], [1], str(tensor.dtype), 0]
+    return json.dumps({"foo": meta}, separators=(",", ":")).encode("utf-8")
+
+
+class _ClientStub:
+    def __init__(self, canonical_index_bytes: bytes) -> None:
+        self.canonical_index_bytes = canonical_index_bytes
+        self.calls = 0
+
+    def get_artifact_index_by_id(self, artifact_id: str) -> bytes:
+        self.calls += 1
+        return self.canonical_index_bytes
+
+
+class _RuntimeStub:
+    def __init__(self, client: _ClientStub) -> None:
+        self.daemon_endpoint = "daemon"
+        self.session_id = "sess"
+        self.opts = StoreOptions()
+        self.retry_policies = build_retry_policies()
+        self._artifact_cache = ArtifactCache(
+            daemon_endpoint="daemon", ttl_seconds=5, max_entries=4
+        )
+        self._client = client
+        self._key_cache: dict[str, tuple[str | None, str | None]] = {}
+
+    def ensure_client(self) -> _ClientStub:
+        return self._client
+
+    def cache_artifact_index(self, entry) -> None:
+        self._artifact_cache.cache_artifact_index(entry)
+
+    def get_artifact_index_cached(self, artifact_id: str):
+        return self._artifact_cache.get_artifact_index_cached(artifact_id)
+
+    def invalidate_artifact(self, artifact_id: str | None, *, key=None, reason=None) -> None:
+        self._artifact_cache.invalidate_artifact(artifact_id or "", reason=reason)
+        if key and key in self._key_cache:
+            del self._key_cache[key]
+
+    def resolve_key_mapping_cached(
+        self, *, key: str
+    ) -> tuple[str | None, str | None]:
+        return self._key_cache.get(key, (None, None))
+
+    def cache_key_mapping(
+        self, key: str, *, artifact_id: str | None, disk_path: str | None, ttl_override=None
+    ) -> None:
+        self._key_cache[key] = (artifact_id, disk_path)
+
+
+class _StoreStub:
+    def __init__(self, runtime: _RuntimeStub) -> None:
+        self._runtime = runtime
+        self._materialization = None
+        self.closed = False
+
+
+def test_exists_false_when_key_unmapped():
+    runtime = _RuntimeStub(_ClientStub(_canonical_index_bytes()))
+    store = _StoreStub(runtime)
+    artifact = Artifact(store_ref=weakref.ref(store), key="missing")
+
+    assert artifact.exists() is False
+
+
+def test_exists_populates_cache_and_id():
+    canonical_bytes = _canonical_index_bytes()
+    runtime = _RuntimeStub(_ClientStub(canonical_bytes))
+    store = _StoreStub(runtime)
+    runtime.cache_key_mapping("mapped", artifact_id="aid", disk_path=None)
+    artifact = Artifact(store_ref=weakref.ref(store), key="mapped")
+
+    assert artifact.exists() is True
+    assert artifact.artifact_id == "aid"
+    cached = runtime.get_artifact_index_cached("aid")
+    assert cached is not None
+    assert cached.canonical_index_bytes == canonical_bytes

--- a/tests/python/api/test_artifact_handle.py
+++ b/tests/python/api/test_artifact_handle.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import json
 import weakref
+from typing import cast
 
 import pytest
 import torch
 
 from tensorcast.api._materialize import MaterializationPayload, TensorPayloadDescriptor
+from tensorcast.api.store import Store
 from tensorcast.api.store.artifact import Artifact
 from tensorcast.api.store.cache import ArtifactCache
-from tensorcast.api.store.types import ArtifactError, StoreOptions
+from tensorcast.api.store.types import ArtifactError, FallbackOptions, StoreOptions
 from tensorcast.api.store.retry import build_retry_policies
 
 
@@ -143,6 +145,11 @@ class _StoreStub:
         self.closed = False
 
 
+def _store_ref(store: _StoreStub) -> weakref.ReferenceType[Store]:
+    typed_store = cast(Store, store)
+    return weakref.ref(typed_store)
+
+
 def test_tensor_subset_materialization_and_release():
     canonical_bytes, payload = _build_payload(
         {"foo": torch.ones(1), "bar": torch.zeros(1)}
@@ -151,13 +158,13 @@ def test_tensor_subset_materialization_and_release():
     pipeline = _PipelineStub(payload)
     store = _StoreStub(runtime, pipeline)
     artifact = Artifact(
-        store_ref=weakref.ref(store),
+        store_ref=_store_ref(store),
         artifact_id="aid",
         canonical_index_bytes=canonical_bytes,
         generation=1,
     )
 
-    result = artifact.tensor_dict(device=0, names=["bar"])
+    result = artifact.tensor_dict(device="cpu", names=["bar"])
 
     assert set(result.keys()) == {"bar"}
     assert pipeline.calls and pipeline.calls[0]["tensor_names"] == ("bar",)
@@ -170,14 +177,14 @@ def test_release_blocks_materialization():
     pipeline = _PipelineStub(payload)
     store = _StoreStub(runtime, pipeline)
     artifact = Artifact(
-        store_ref=weakref.ref(store),
+        store_ref=_store_ref(store),
         artifact_id="aid",
         canonical_index_bytes=canonical_bytes,
     )
 
     artifact.release()
     with pytest.raises(ArtifactError) as excinfo:
-        artifact.tensor(name="foo", device=0)
+        artifact.tensor(name="foo", device="cpu")
     assert excinfo.value.status_code == "FAILED_PRECONDITION"
 
 
@@ -187,16 +194,51 @@ def test_to_dict_round_trip_preserves_metadata():
     pipeline = _PipelineStub(payload)
     store = _StoreStub(runtime, pipeline)
     artifact = Artifact(
-        store_ref=weakref.ref(store),
+        store_ref=_store_ref(store),
         artifact_id="aid",
         canonical_index_bytes=canonical_bytes,
         generation=5,
     )
 
     serialized = artifact.to_dict()
-    restored = Artifact.from_dict(serialized, store=store)
+    restored = Artifact.from_dict(serialized, store=cast(Store, store))
 
     assert restored.artifact_id == "aid"
     assert restored.tensor_names == ("foo",)
     assert restored.describe().generation == 5
     assert runtime._client.get_index_calls == 0
+
+
+def test_with_fallback_handles_multiple_identifiers():
+    canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
+    runtime = _RuntimeStub(_ClientStub(canonical_bytes))
+    runtime.cache_key_mapping("mapped", artifact_id="aid", disk_path=None)
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(store_ref=_store_ref(store), key="mapped")
+
+    assert artifact.artifact_id == "aid"
+    clone = artifact.with_fallback(
+        FallbackOptions(disk_path="/tmp/fallback", prefer_disk=True, allow_p2p=False)
+    )
+
+    assert clone.artifact_id == "aid"
+    assert clone.key == "mapped"
+    assert clone.tensor_names == ("foo",)
+
+
+def test_from_dict_accepts_key_and_artifact_id():
+    canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
+    runtime = _RuntimeStub(_ClientStub(canonical_bytes))
+    runtime.cache_key_mapping("mapped", artifact_id="aid", disk_path=None)
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(store_ref=_store_ref(store), key="mapped")
+    assert artifact.artifact_id == "aid"
+
+    serialized = artifact.to_dict()
+    restored = Artifact.from_dict(serialized, store=cast(Store, store))
+
+    assert restored.artifact_id == "aid"
+    assert restored.key == "mapped"
+    assert restored.tensor_names == ("foo",)

--- a/tests/python/api/test_artifact_handle.py
+++ b/tests/python/api/test_artifact_handle.py
@@ -1,0 +1,202 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import json
+import weakref
+
+import pytest
+import torch
+
+from tensorcast.api._materialize import MaterializationPayload, TensorPayloadDescriptor
+from tensorcast.api.store.artifact import Artifact
+from tensorcast.api.store.cache import ArtifactCache
+from tensorcast.api.store.types import ArtifactError, StoreOptions
+from tensorcast.api.store.retry import build_retry_policies
+
+
+def _build_payload(tensors: dict[str, torch.Tensor]) -> tuple[bytes, MaterializationPayload]:
+    descriptors: list[TensorPayloadDescriptor] = []
+    index: dict[str, list[object]] = {}
+    offset = 0
+    for name, tensor in tensors.items():
+        size_bytes = int(tensor.element_size() * tensor.numel())
+        shape = list(map(int, tensor.shape))
+        stride = list(map(int, tensor.stride()))
+        descriptors.append(
+            TensorPayloadDescriptor(
+                name=name,
+                dtype=str(tensor.dtype),
+                shape=tuple(shape),
+                stride=tuple(stride),
+                buffer_offset=offset,
+                byte_length=size_bytes,
+                storage_offset=0,
+            )
+        )
+        index[name] = [offset, size_bytes, shape, stride, str(tensor.dtype), 0]
+        offset += size_bytes
+    canonical_bytes = json.dumps(index, separators=(",", ":")).encode("utf-8")
+    payload = MaterializationPayload(
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+        descriptors=tuple(descriptors),
+        payload_iter=lambda: iter(()),
+        state_dict=tensors,
+        replica_uuid="replica-1",
+        generation=7,
+    )
+    return canonical_bytes, payload
+
+
+class _ClientStub:
+    def __init__(self, canonical_index_bytes: bytes) -> None:
+        self.canonical_index_bytes = canonical_index_bytes
+        self.unloaded: list[tuple[str, str]] = []
+        self.get_index_calls = 0
+
+    def get_artifact_index_by_id(self, artifact_id: str) -> bytes:
+        self.get_index_calls += 1
+        return self.canonical_index_bytes
+
+    def unload_replica(self, replica_uuid: str, *, disk_path: str = "") -> bool:
+        self.unloaded.append((replica_uuid, disk_path))
+        return True
+
+
+class _RuntimeStub:
+    def __init__(self, client: _ClientStub) -> None:
+        self.daemon_endpoint = "daemon"
+        self.session_id = "sess"
+        self.opts = StoreOptions()
+        self.retry_policies = build_retry_policies()
+        self._artifact_cache = ArtifactCache(
+            daemon_endpoint="daemon", ttl_seconds=10, max_entries=8
+        )
+        self._key_cache: dict[str, tuple[str | None, str | None]] = {}
+        self._client = client
+
+    def ensure_client(self) -> _ClientStub:
+        return self._client
+
+    def cache_artifact_index(self, entry) -> None:
+        self._artifact_cache.cache_artifact_index(entry)
+
+    def get_artifact_index_cached(self, artifact_id: str):
+        return self._artifact_cache.get_artifact_index_cached(artifact_id)
+
+    def invalidate_artifact(self, artifact_id: str | None, *, key=None, reason=None) -> None:
+        self._artifact_cache.invalidate_artifact(artifact_id or "", reason=reason)
+
+    def resolve_key_mapping_cached(
+        self, *, key: str
+    ) -> tuple[str | None, str | None]:
+        return self._key_cache.get(key, (None, None))
+
+    def cache_key_mapping(
+        self, key: str, *, artifact_id: str | None, disk_path: str | None, ttl_override=None
+    ) -> None:
+        self._key_cache[key] = (artifact_id, disk_path)
+
+
+class _PipelineStub:
+    def __init__(self, payload: MaterializationPayload) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, object]] = []
+        self.released: list[str] = []
+
+    def materialize_subset(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.payload, 0
+
+    def _payload_state_dict(self, payload: MaterializationPayload):
+        if payload.state_dict is not None:
+            return dict(payload.state_dict)
+        state: dict[str, torch.Tensor] = {}
+        for desc, tensor in payload.payload_iter():
+            state[desc.name] = tensor
+        return state
+
+    def _release_materialized(self, payload: MaterializationPayload, client: _ClientStub) -> None:
+        self.released.append(payload.replica_uuid)
+        client.unload_replica(payload.replica_uuid, disk_path=getattr(payload, "disk_path", "") or "")
+
+    def get_into(
+        self,
+        target: dict[str, torch.Tensor],
+        *,
+        artifact_id: str | None,
+        key: str | None,
+        device,
+        fallback,
+    ) -> None:
+        state = self._payload_state_dict(self.payload)
+        for name, tensor in state.items():
+            if name in target:
+                target[name].copy_(tensor)
+
+
+class _StoreStub:
+    def __init__(self, runtime: _RuntimeStub, pipeline: _PipelineStub) -> None:
+        self._runtime = runtime
+        self._materialization = pipeline
+        self.closed = False
+
+
+def test_tensor_subset_materialization_and_release():
+    canonical_bytes, payload = _build_payload(
+        {"foo": torch.ones(1), "bar": torch.zeros(1)}
+    )
+    runtime = _RuntimeStub(_ClientStub(canonical_bytes))
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(
+        store_ref=weakref.ref(store),
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+        generation=1,
+    )
+
+    result = artifact.tensor_dict(device=0, names=["bar"])
+
+    assert set(result.keys()) == {"bar"}
+    assert pipeline.calls and pipeline.calls[0]["tensor_names"] == ("bar",)
+    assert ("replica-1", "") in runtime._client.unloaded
+
+
+def test_release_blocks_materialization():
+    canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
+    runtime = _RuntimeStub(_ClientStub(canonical_bytes))
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(
+        store_ref=weakref.ref(store),
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+    )
+
+    artifact.release()
+    with pytest.raises(ArtifactError) as excinfo:
+        artifact.tensor(name="foo", device=0)
+    assert excinfo.value.status_code == "FAILED_PRECONDITION"
+
+
+def test_to_dict_round_trip_preserves_metadata():
+    canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
+    runtime = _RuntimeStub(_ClientStub(canonical_bytes))
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(
+        store_ref=weakref.ref(store),
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+        generation=5,
+    )
+
+    serialized = artifact.to_dict()
+    restored = Artifact.from_dict(serialized, store=store)
+
+    assert restored.artifact_id == "aid"
+    assert restored.tensor_names == ("foo",)
+    assert restored.describe().generation == 5
+    assert runtime._client.get_index_calls == 0

--- a/tests/python/api/test_artifact_tensor_subset.py
+++ b/tests/python/api/test_artifact_tensor_subset.py
@@ -1,0 +1,74 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import json
+import weakref
+
+import pytest
+import torch
+
+from tensorcast.api.store.artifact import Artifact
+from tensorcast.api.store.cache import ArtifactCache
+from tensorcast.api.store.common import canonical_index_from_bytes
+from tensorcast.api.store.types import ArtifactError, StoreOptions
+from tensorcast.api.store.retry import build_retry_policies
+
+
+def _canonical_index_bytes() -> bytes:
+    tensor = torch.ones(1)
+    meta = [0, int(tensor.element_size() * tensor.numel()), [1], [1], str(tensor.dtype), 0]
+    return json.dumps({"foo": meta}, separators=(",", ":")).encode("utf-8")
+
+
+class _RuntimeStub:
+    def __init__(self) -> None:
+        self.daemon_endpoint = "daemon"
+        self.session_id = "sess"
+        self.opts = StoreOptions()
+        self.retry_policies = build_retry_policies()
+        self._artifact_cache = ArtifactCache(
+            daemon_endpoint="daemon", ttl_seconds=5, max_entries=4
+        )
+        self._client = None
+
+    def ensure_client(self):
+        raise RuntimeError("should not be called")
+
+    def cache_artifact_index(self, entry) -> None:
+        self._artifact_cache.cache_artifact_index(entry)
+
+    def get_artifact_index_cached(self, artifact_id: str):
+        return self._artifact_cache.get_artifact_index_cached(artifact_id)
+
+    def invalidate_artifact(self, artifact_id: str | None, *, key=None, reason=None) -> None:
+        self._artifact_cache.invalidate_artifact(artifact_id or "", reason=reason)
+
+    def resolve_key_mapping_cached(
+        self, *, key: str
+    ) -> tuple[str | None, str | None]:
+        return None, None
+
+
+class _StoreStub:
+    def __init__(self, runtime: _RuntimeStub) -> None:
+        self._runtime = runtime
+        self._materialization = object()
+        self.closed = False
+
+
+def test_invalid_tensor_name_raises_before_materialization():
+    canonical_bytes = _canonical_index_bytes()
+    runtime = _RuntimeStub()
+    store = _StoreStub(runtime)
+    artifact = Artifact(
+        store_ref=weakref.ref(store),
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+        canonical_index=canonical_index_from_bytes(canonical_bytes),
+    )
+
+    with pytest.raises(ArtifactError) as excinfo:
+        artifact.tensor_dict(device=0, names=["missing"])
+
+    assert excinfo.value.status_code == "INVALID_ARGUMENT"

--- a/tests/python/api/test_materialization_pipeline_v2.py
+++ b/tests/python/api/test_materialization_pipeline_v2.py
@@ -106,6 +106,7 @@ def _make_payload(
     replica_uuid: str = "r1",
     gate: threading.Event | None = None,
     on_iter: Callable[[], None] | None = None,
+    generation: int | None = None,
 ) -> MaterializationPayload:
     descriptors: list[TensorPayloadDescriptor] = []
     index: dict[str, list[object]] = {}
@@ -150,6 +151,7 @@ def _make_payload(
         view_data_hash=None,
         source=None,
         device_uuid=None,
+        generation=generation,
     )
 
 
@@ -256,3 +258,22 @@ def test_disk_fallback_verify_flag_passed():
     runtime.close()
 
     assert captured["verify_checksums"] is False
+
+
+def test_materialize_subset_preserves_generation():
+    runtime = _RuntimeStub()
+    views = ViewOrchestrator(runtime)
+    pipeline = MaterializationPipeline(runtime, views)
+    payload = _make_payload({"a": torch.ones(1), "b": torch.zeros(1)}, generation=5)
+
+    pipeline.set_materialize_fn(lambda **_kwargs: payload)
+    materialized, _ = pipeline.materialize_subset(
+        artifact_id="aid",
+        key=None,
+        device=0,
+        fallback=None,
+        tensor_names=["a"],
+    )
+    runtime.close()
+
+    assert materialized.generation == 5

--- a/tests/python/test_store_pipelines_unit.py
+++ b/tests/python/test_store_pipelines_unit.py
@@ -82,6 +82,7 @@ class _DummyRuntime:
         self.leases: list[object] = []
         self.futures: list[object] = []
         self.client = _FakeClient()
+        self._key_cache: dict[str, tuple[str | None, str | None]] = {}
 
     def track_future(self, future: concurrent.futures.Future[object]) -> None:
         self.futures.append(future)
@@ -100,6 +101,19 @@ class _DummyRuntime:
         self, *, key: str
     ) -> tuple[str | None, str | None]:  # pragma: no cover - noop
         return self.client.resolve_key_mapping(key)
+
+    def invalidate_artifact(
+        self, artifact_id: str | None, *, key: str | None = None, reason: str | None = None
+    ) -> None:  # pragma: no cover - noop
+        # Mirror StoreRuntimeContext.invalidate_artifact enough for tests: clear cached key mappings.
+        keys_to_remove: list[str] = []
+        for cached_key, (cached_artifact, _disk_path) in self._key_cache.items():
+            matches_artifact = bool(artifact_id and cached_artifact == artifact_id)
+            matches_key = bool(key is not None and cached_key == key)
+            if matches_artifact or matches_key:
+                keys_to_remove.append(cached_key)
+        for cached_key in keys_to_remove:
+            del self._key_cache[cached_key]
 
     @contextmanager
     def operation_span(self, *_args, **_kwargs):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a lazy `Artifact` handle with selective tensor fetch and a TTL/LRU `ArtifactCache`, integrating cache/invalidations/metrics into runtime and pipelines, with docs and tests.
> 
> - **SDK/API**:
>   - Add `Artifact` handle (`tensorcast/api/store/artifact.py`) exposing lazy metadata (`tensor_names`, `describe`, `tensor_meta`), `tensor_dict(names=...)`/`tensor()`, `exists()`, `release()`, `with_fallback()`, and `to_dict`/`from_dict`.
>   - New factories: `Store.artifact(...)`, `tensorcast.artifact(...)`, plus `tensorcast.from_disk(...)` stub; exported in `tensorcast.api.store.__init__`.
> - **Runtime & Caching**:
>   - Implement `ArtifactCache` (TTL+LRU) with env tunables `TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS`, `TENSORCAST_STORE_CACHE_MAX_ENTRIES`; integrate into `StoreRuntimeContext` (get/cache/invalidate, fork/close handling).
>   - Add OTel metrics for cache hits/misses/evictions/invalidations (`_metrics.py`).
> - **Materialization & Views**:
>   - `MaterializationPipeline`: support subset materialization (`materialize_subset`), propagate `generation`, and invalidate caches on `NOT_FOUND`/`FAILED_PRECONDITION`.
>   - `ViewOrchestrator`: reuse `ArtifactCache` for canonical index lookups before daemon RPC.
> - **Store Ops**:
>   - Invalidate caches on `deregister_artifact` and after successful registrations.
> - **Docs**:
>   - Update Architecture Overview; add Phase 2/3 design docs and a plan; add `tensorcast/api/store/README.md`; update API README.
> - **Tests**:
>   - Add unit tests for cache TTL/LRU/invalidate, handle lifecycle/serialization/subset, `exists()`, materialization subset generation, and pipeline behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa8e82f8f9ed28c6edb950c52500ba9332e0553e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->