### PR TITLE
feat(api): introduce lazy artifact handle

### DIFF
--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -666,6 +666,24 @@ cc_test(
 )
 
 cc_test(
+    name = "resolve_artifact_from_disk_test",
+    srcs = ["resolve_artifact_from_disk_test.cc"],
+    deps = [
+        ":ipc_region_registry_lib",
+        ":lip_manager_lib",
+        ":materialization_controller_lib",
+        "//core/common:artifact_hash_lib",
+        "//core/store:store_engine",
+        "//core/testing:common",
+        "//proto/tensorcast/daemon/v2:daemon_grpc_cc",
+        "@abseil-cpp//absl/time:time",
+        "@abseil-cpp//absl/types:span",
+        "@catch2//:catch2_main",
+        "@nlohmann_json//:json",
+    ],
+)
+
+cc_test(
     name = "grpc_service_impl_status_test",
     srcs = ["grpc_service_impl_status_test.cc"],
     deps = [

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -62,6 +62,7 @@ flowchart TB
 
 - Loading: `MaterializeByKey` (preferred), `MaterializeReplica`, `ConfirmReplica`, `UnloadReplica`, `WaitReplicaVerification`.
 - Loading v2 (gated): `MaterializeByKey`/`MaterializeReplica` with descriptor payloads plus `GetMaterializeCapabilities` (SDK probe) under `StoreDaemonServiceV2`. Descriptors are derived from UMA view plans (offset/stride/byte-length) when a view is requested so the exported buffer layout matches the planner, and disk fallbacks stay daemon-owned via `DiskFallbackHint` (respecting `verify_checksums`).
+- Disk fallbacks honor `verify_checksums` on `DiskFallbackHint`/`MaterializeReplicaRequest` and propagate the flag into engine `MaterializeHints` so checksum/descriptor validation is enforced by default but can be disabled for local development.
 - Key mapping: `PublishReplicaKey`, `ResolveKeyMapping`, `GetArtifactIndexById`.
 - Status: `GetServerConfig`, `GetWorkerStatus`, `GetDetailedStatus`, `GetLoadedReplicasV2` (paginated).
 - Transport: `LockTransportChunks`, `UnlockTransportChunks`.

--- a/daemon/grpc_service_impl.cc
+++ b/daemon/grpc_service_impl.cc
@@ -188,6 +188,14 @@ Status StoreDaemonServiceV2Impl::MaterializeByKey(
   return materialization_controller_.materialize_by_key_v2(rctx, *req, *resp);
 }
 
+Status StoreDaemonServiceV2Impl::ResolveArtifactFromDisk(
+    grpc::ServerContext* ctx,
+    const v2::ResolveArtifactFromDiskRequest* req,
+    v2::ResolveArtifactFromDiskResponse* resp) {
+  RpcContext rctx{"ResolveArtifactFromDisk", *ctx, allow_high_card_attrs_};
+  return materialization_controller_.resolve_artifact_from_disk(rctx, *req, *resp);
+}
+
 Status StoreDaemonServiceV2Impl::GetMaterializeCapabilities(
     grpc::ServerContext* ctx,
     const v2::GetMaterializeCapabilitiesRequest* /*req*/,

--- a/daemon/grpc_service_impl.h
+++ b/daemon/grpc_service_impl.h
@@ -362,6 +362,11 @@ class StoreDaemonServiceV2Impl final : public v2::StoreDaemonService::Service {
       const v2::MaterializeByKeyRequest* req,
       v2::MaterializeByKeyResponse* resp) override;
 
+  grpc::Status ResolveArtifactFromDisk(
+      grpc::ServerContext* ctx,
+      const v2::ResolveArtifactFromDiskRequest* req,
+      v2::ResolveArtifactFromDiskResponse* resp) override;
+
   grpc::Status GetMaterializeCapabilities(
       grpc::ServerContext* ctx,
       const v2::GetMaterializeCapabilitiesRequest* req,

--- a/daemon/resolve_artifact_from_disk_test.cc
+++ b/daemon/resolve_artifact_from_disk_test.cc
@@ -1,0 +1,186 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "daemon/service/controllers/materialization_controller.h"
+
+#include <algorithm>
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "core/common/artifact_hash.h"
+#include "core/store/store_engine.h"
+#include "core/testing/common.h"
+#include "daemon/background_scheduler.h"
+#include "daemon/device_resolver.h"
+#include "daemon/ipc_region_registry.h"
+#include "daemon/lip_bridge.h"
+#include "daemon/lip_manager.h"
+#include "daemon/ref_tracker.h"
+#include "daemon/replica_session_manager.h"
+#include "daemon/rpc_context.h"
+#include "daemon/sessions_service.h"
+#include "daemon/verification_tracker.h"
+#include "grpcpp/server_context.h"
+#include "nlohmann/json.hpp"
+#include "tensorcast/daemon/v2/store_daemon.pb.h"
+
+namespace {
+
+using tensorcast::daemon::MaterializationController;
+using tensorcast::daemon::v2::ResolveArtifactFromDiskRequest;
+using tensorcast::daemon::v2::ResolveArtifactFromDiskResponse;
+
+std::filesystem::path test_tmpdir() {
+  const char* env = std::getenv("TEST_TMPDIR");
+  if (env && *env) {
+    return std::filesystem::path(env);
+  }
+  return std::filesystem::temp_directory_path() / "tensorcast_daemon_resolve_disk_test";
+}
+
+tensorcast::store::StoreEngineOptions make_opts() {
+  tensorcast::store::StoreEngineOptions opts;
+  opts.storage_path = (test_tmpdir() / "engine").string();
+  std::filesystem::create_directories(opts.storage_path);
+  opts.p2p_port = 47015;
+  opts.memory_pool_size = 32ULL << 20;
+  opts.tx_slice_bytes = 1ULL << 20;
+  opts.num_thread = 2;
+  opts.global_store_address.clear();
+  return opts;
+}
+
+uint64_t generation_from_bytes(const std::string& canonical_index_json) {
+  const auto digest = tensorcast::common::sha256_digest_bytes(
+      absl::Span<const uint8_t>(
+          reinterpret_cast<const uint8_t*>(canonical_index_json.data()), canonical_index_json.size()));
+  uint64_t value = 0;
+  const size_t limit = std::min<size_t>(8, digest.size());
+  for (size_t i = 0; i < limit; ++i) {
+    value = (value << 8) | static_cast<uint64_t>(digest[i]);
+  }
+  return value;
+}
+
+struct ResolveFixture {
+  std::shared_ptr<tensorcast::store::StoreEngine> engine;
+  tensorcast::daemon::RefTracker refs;
+  tensorcast::daemon::IpcRegionRegistry regions;
+  tensorcast::daemon::LipManager lip_mgr;
+  tensorcast::daemon::LipBridge lip_bridge;
+  tensorcast::daemon::ReplicaSessionManager session_mgr;
+  tensorcast::daemon::VerificationTracker verif_tracker;
+  tensorcast::daemon::BackgroundScheduler scheduler;
+  tensorcast::daemon::SessionsService sessions_svc;
+  tensorcast::daemon::DeviceResolver devices;
+  std::atomic<bool> shutting_down{false};
+  MaterializationController controller;
+
+  explicit ResolveFixture(std::vector<std::filesystem::path> whitelist = {})
+      : engine(std::make_shared<tensorcast::store::StoreEngine>(make_opts())),
+        regions(tensorcast::daemon::IpcRegionRegistry::Options{}),
+        lip_mgr(engine, &regions),
+        lip_bridge(lip_mgr),
+        session_mgr(std::chrono::seconds(60)),
+        verif_tracker(),
+        scheduler(),
+        sessions_svc(session_mgr, verif_tracker, &scheduler, /*lifecycle=*/nullptr, absl::Seconds(60)),
+        devices(tensorcast::store::DeviceRegistry::instance()),
+        controller(MaterializationController(
+            MaterializationController::Dep{
+                .engine = *engine,
+                .refs = refs,
+                .sessions = sessions_svc,
+                .lip = lip_bridge,
+                .devices = devices,
+                .is_shutting_down = shutting_down,
+                .lifecycle = nullptr,
+                .disk_path_whitelist = std::move(whitelist),
+            })) {}
+};
+
+} // namespace
+
+TEST_CASE(
+    "ResolveArtifactFromDisk returns canonical index bytes and generation for disk artifacts",
+    "[daemon][disk][resolve]") {
+  const auto artifact_dir = test_tmpdir() / "artifact_ok";
+  std::filesystem::remove_all(artifact_dir);
+  std::filesystem::create_directories(artifact_dir);
+  const auto data_path = artifact_dir / "tensor.data";
+  REQUIRE(tensorcast::testing::create_dummy_file(data_path, 64));
+  REQUIRE(tensorcast::testing::write_rfc0007_descriptor_for_standard_artifact_dir(artifact_dir).ok());
+
+  ResolveFixture fix;
+  grpc::ServerContext ctx;
+  tensorcast::daemon::RpcContext rctx{"ResolveArtifactFromDiskTest", ctx, /*allow_high_card_attrs=*/true};
+  ResolveArtifactFromDiskRequest req;
+  req.set_disk_path(artifact_dir.string());
+  req.set_verify_checksums(true);
+  ResolveArtifactFromDiskResponse resp;
+  auto status = fix.controller.resolve_artifact_from_disk(rctx, req, resp);
+
+  REQUIRE(status.ok());
+  REQUIRE_FALSE(resp.artifact_id().empty());
+  REQUIRE(resp.generation() == generation_from_bytes(resp.canonical_index_bytes()));
+  REQUIRE_FALSE(resp.canonical_index_bytes().empty());
+}
+
+TEST_CASE("ResolveArtifactFromDisk enforces whitelist and missing paths", "[daemon][disk][resolve]") {
+  const auto artifact_dir = test_tmpdir() / "artifact_denied";
+  std::filesystem::remove_all(artifact_dir);
+  std::filesystem::create_directories(artifact_dir);
+  ResolveFixture denied_fix({artifact_dir.parent_path() / "unrelated"});
+  grpc::ServerContext ctx;
+  tensorcast::daemon::RpcContext denied_rctx{"ResolveArtifactFromDiskTest", ctx, /*allow_high_card_attrs=*/true};
+  ResolveArtifactFromDiskRequest req;
+  req.set_disk_path(artifact_dir.string());
+  ResolveArtifactFromDiskResponse resp;
+  auto status = denied_fix.controller.resolve_artifact_from_disk(denied_rctx, req, resp);
+  REQUIRE_FALSE(status.ok());
+  REQUIRE(status.error_code() == grpc::StatusCode::INVALID_ARGUMENT);
+
+  ResolveFixture ok_fix({artifact_dir.parent_path()});
+  tensorcast::daemon::RpcContext ok_rctx{"ResolveArtifactFromDiskTest", ctx, /*allow_high_card_attrs=*/true};
+  ResolveArtifactFromDiskResponse missing_resp;
+  auto missing_status = ok_fix.controller.resolve_artifact_from_disk(ok_rctx, req, missing_resp);
+  REQUIRE_FALSE(missing_status.ok());
+  REQUIRE(missing_status.error_code() == grpc::StatusCode::NOT_FOUND);
+}
+
+TEST_CASE("ResolveArtifactFromDisk fails checksum validation when descriptor mismatches", "[daemon][disk][resolve]") {
+  const auto artifact_dir = test_tmpdir() / "artifact_checksum";
+  std::filesystem::remove_all(artifact_dir);
+  std::filesystem::create_directories(artifact_dir);
+  const auto data_path = artifact_dir / "tensor.data";
+  REQUIRE(tensorcast::testing::create_dummy_file(data_path, 32));
+  REQUIRE(tensorcast::testing::write_rfc0007_descriptor_for_standard_artifact_dir(artifact_dir).ok());
+
+  // Corrupt index_multihash to trigger checksum failure.
+  const auto descriptor_path = artifact_dir / "artifact_descriptor.json";
+  nlohmann::json descriptor = nlohmann::json::parse(std::ifstream(descriptor_path));
+  descriptor["index_multihash"] = "mh:corrupt";
+  {
+    std::ofstream out(descriptor_path, std::ios::trunc);
+    REQUIRE(out.is_open());
+    out << descriptor.dump(2);
+  }
+
+  ResolveFixture fix;
+  grpc::ServerContext ctx;
+  tensorcast::daemon::RpcContext rctx{"ResolveArtifactFromDiskTest", ctx, /*allow_high_card_attrs=*/true};
+  ResolveArtifactFromDiskRequest req;
+  req.set_disk_path(artifact_dir.string());
+  req.set_verify_checksums(true);
+  ResolveArtifactFromDiskResponse resp;
+  auto status = fix.controller.resolve_artifact_from_disk(rctx, req, resp);
+
+  REQUIRE_FALSE(status.ok());
+  REQUIRE(status.error_code() == grpc::StatusCode::FAILED_PRECONDITION);
+}

--- a/daemon/service/controllers/materialization_controller.cc
+++ b/daemon/service/controllers/materialization_controller.cc
@@ -9,6 +9,7 @@
 #include <future>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -17,6 +18,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
 #include "google/protobuf/util/time_util.h"
@@ -95,7 +97,26 @@ absl::Status ensure_tensor_index_present(const std::filesystem::path& artifact_d
   return absl::OkStatus();
 }
 
-absl::StatusOr<std::optional<std::string>> load_artifact_id_from_descriptor(const std::filesystem::path& artifact_dir) {
+void record_disk_resolution_outcome(std::string_view outcome) {
+  try {
+    static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+    static auto counter = meter->CreateUInt64Counter("tc_store_disk_path_resolve_total");
+    if (counter) {
+      counter->Add(1, {{"outcome", std::string(outcome)}});
+    }
+  } catch (...) {
+  }
+}
+
+struct DescriptorMetadata {
+  bool found{false};
+  std::optional<std::string> artifact_id;
+  std::optional<std::string> index_multihash;
+  std::optional<std::string> data_multihash;
+};
+
+absl::StatusOr<DescriptorMetadata> load_descriptor_metadata(const std::filesystem::path& artifact_dir) {
+  DescriptorMetadata metadata;
   const auto descriptor_path = artifact_dir / "artifact_descriptor.json";
   std::error_code ec;
   if (!std::filesystem::exists(descriptor_path, ec)) {
@@ -103,8 +124,9 @@ absl::StatusOr<std::optional<std::string>> load_artifact_id_from_descriptor(cons
       return absl::ErrnoToStatus(
           ec.value(), absl::StrCat("Failed to stat artifact_descriptor.json at ", descriptor_path.string()));
     }
-    return std::optional<std::string>{};
+    return metadata;
   }
+  metadata.found = true;
   std::ifstream in(descriptor_path);
   if (!in.is_open()) {
     return absl::PermissionDeniedError(
@@ -113,25 +135,60 @@ absl::StatusOr<std::optional<std::string>> load_artifact_id_from_descriptor(cons
   try {
     nlohmann::json j;
     in >> j;
-    if (!j.contains("artifact_id")) {
-      return absl::FailedPreconditionError(
-          absl::StrCat("artifact_descriptor.json missing artifact_id at ", descriptor_path.string()));
-    }
-    if (!j["artifact_id"].is_string()) {
-      return absl::InvalidArgumentError(
-          absl::StrCat("artifact_descriptor.json artifact_id must be string at ", descriptor_path.string()));
-    }
-    const std::string raw_artifact_id = j["artifact_id"].get<std::string>();
-    const std::string artifact_id = std::string(absl::StripAsciiWhitespace(raw_artifact_id));
-    if (artifact_id.empty()) {
-      return absl::InvalidArgumentError(
-          absl::StrCat("artifact_descriptor.json artifact_id empty at ", descriptor_path.string()));
-    }
-    return std::optional<std::string>(artifact_id);
+    const auto get_string = [&](const char* key) -> std::optional<std::string> {
+      auto it = j.find(key);
+      if (it == j.end() || it->is_null()) {
+        return std::optional<std::string>{};
+      }
+      if (!it->is_string()) {
+        throw std::invalid_argument(absl::StrCat(key, " must be a string"));
+      }
+      const std::string trimmed = std::string(absl::StripAsciiWhitespace(it->get<std::string>()));
+      if (trimmed.empty()) {
+        return std::optional<std::string>{};
+      }
+      return trimmed;
+    };
+    metadata.artifact_id = get_string("artifact_id");
+    metadata.index_multihash = get_string("index_multihash");
+    metadata.data_multihash = get_string("data_multihash");
   } catch (const std::exception& ex) {
     return absl::InvalidArgumentError(
         absl::StrCat("Failed to parse artifact_descriptor.json at ", descriptor_path.string(), ": ", ex.what()));
   }
+  return metadata;
+}
+
+absl::Status validate_descriptor_against_index(
+    const DescriptorMetadata& descriptor,
+    const store::loader::IndexInfo& index_info,
+    bool verify_checksums) {
+  if (!verify_checksums) {
+    return absl::OkStatus();
+  }
+  if (!descriptor.found) {
+    return absl::FailedPreconditionError("artifact_descriptor.json required when verify_checksums=true");
+  }
+  if (!descriptor.index_multihash.has_value() || descriptor.index_multihash->empty()) {
+    return absl::FailedPreconditionError("index_multihash missing from artifact_descriptor.json");
+  }
+  auto computed_or = common::compute_index_multihash(
+      std::optional<std::string>(index_info.canonical_index_json), /*index_key_hex=*/"");
+  if (!computed_or.ok()) {
+    return computed_or.status();
+  }
+  if (*descriptor.index_multihash != *computed_or) {
+    return absl::FailedPreconditionError("index_multihash mismatch for disk artifact");
+  }
+  if (descriptor.artifact_id.has_value() && descriptor.data_multihash.has_value() &&
+      !descriptor.data_multihash->empty()) {
+    const std::string expected_artifact_id =
+        absl::StrCat("mi2:", *descriptor.index_multihash, ":", *descriptor.data_multihash);
+    if (*descriptor.artifact_id != expected_artifact_id) {
+      return absl::FailedPreconditionError("artifact_id does not match descriptor multihashes");
+    }
+  }
+  return absl::OkStatus();
 }
 
 SourcePreference to_hint_preference(v1::SourcePreference preference) {
@@ -473,6 +530,9 @@ grpc::Status MaterializationController::materialize_replica(
   const v1::SourcePreference preference = req.preference();
   const bool prefer_disk = preference == v1::SourcePreference::SOURCE_PREFERENCE_PREFER_DISK;
   const bool prefer_p2p = preference == v1::SourcePreference::SOURCE_PREFERENCE_PREFER_P2P;
+  const bool verify_checksums = req.has_verify_checksums() ? req.verify_checksums() : true;
+
+  span->SetAttribute("tc.store.verify_checksums", verify_checksums);
 
   if (rctx.allow_high_card_attrs()) {
     span->SetAttribute("tc.device.uuid", req.device_uuid());
@@ -491,6 +551,8 @@ grpc::Status MaterializationController::materialize_replica(
   if (!request_has_artifact && !request_has_disk) {
     return {StatusCode::INVALID_ARGUMENT, "artifact_id or disk_path is required"};
   }
+
+  const auto dev = d_.devices.From(req.target_device_type(), req.device_uuid(), std::nullopt);
 
   std::optional<std::filesystem::path> normalized_disk_path;
   if (request_has_disk) {
@@ -522,33 +584,47 @@ grpc::Status MaterializationController::materialize_replica(
     }
   }
 
-  std::optional<std::string> descriptor_artifact_id;
+  DescriptorMetadata descriptor_meta;
+  std::optional<store::loader::IndexInfo> disk_index;
   if (normalized_disk_path.has_value()) {
-    auto artifact_id_or = load_artifact_id_from_descriptor(*normalized_disk_path);
-    if (!artifact_id_or.ok()) {
+    auto descriptor_or = load_descriptor_metadata(*normalized_disk_path);
+    if (!descriptor_or.ok()) {
       resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
-      return to_grpc_status(artifact_id_or.status());
+      return to_grpc_status(descriptor_or.status());
     }
-    descriptor_artifact_id = *artifact_id_or;
-    if (prefer_disk) {
+    descriptor_meta = *descriptor_or;
+    if (verify_checksums && !descriptor_meta.found) {
+      resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
+      return {StatusCode::FAILED_PRECONDITION, "artifact_descriptor.json required when verify_checksums=true"};
+    }
+    if (verify_checksums) {
+      auto index_or = store::loader::read_from_artifact_dir(*normalized_disk_path, dev.ordinal);
+      if (!index_or.ok()) {
+        resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
+        return to_grpc_status(index_or.status());
+      }
+      auto validation_status = validate_descriptor_against_index(descriptor_meta, *index_or, /*verify_checksums=*/true);
+      if (!validation_status.ok()) {
+        resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
+        return to_grpc_status(validation_status);
+      }
+      disk_index = std::move(*index_or);
+    } else if (prefer_disk) {
       auto idx_status = ensure_tensor_index_present(*normalized_disk_path);
       if (!idx_status.ok()) {
         resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
         return to_grpc_status(idx_status);
-      }
-      if (!descriptor_artifact_id.has_value()) {
-        resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
-        return {StatusCode::NOT_FOUND, "artifact_descriptor.json required when preference=PREFER_DISK"};
       }
     }
   }
 
   std::optional<std::string> artifact_id =
       request_has_artifact ? std::optional<std::string>(req.artifact_id()) : std::nullopt;
-  if (!artifact_id.has_value()) {
-    artifact_id = descriptor_artifact_id;
+  if (!artifact_id.has_value() && descriptor_meta.artifact_id.has_value()) {
+    artifact_id = descriptor_meta.artifact_id;
   }
-  if (artifact_id.has_value() && descriptor_artifact_id.has_value() && *artifact_id != *descriptor_artifact_id) {
+  if (artifact_id.has_value() && descriptor_meta.artifact_id.has_value() &&
+      *artifact_id != *descriptor_meta.artifact_id) {
     resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
     return {StatusCode::FAILED_PRECONDITION, "artifact_id mismatch between request and artifact_descriptor.json"};
   }
@@ -566,8 +642,6 @@ grpc::Status MaterializationController::materialize_replica(
     resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
     return {StatusCode::INVALID_ARGUMENT, "artifact_id is required when preference=PREFER_P2P"};
   }
-
-  const auto dev = d_.devices.From(req.target_device_type(), req.device_uuid(), std::nullopt);
 
   // View identity handling
   std::optional<ViewSpec> view_spec;
@@ -674,6 +748,8 @@ grpc::Status MaterializationController::materialize_replica(
   if (req.pinned_allocation_timeout_ms() > 0) {
     hints.pinned_timeout = std::chrono::milliseconds(req.pinned_allocation_timeout_ms());
   }
+  hints.verify = verify_checksums ? store::loading::MaterializeHints::Verify::CHECKSUM
+                                  : store::loading::MaterializeHints::Verify::NONE;
   hints.source_preference = to_hint_preference(preference);
   if (has_artifact)
     hints.artifact_id = resolved_artifact_id;
@@ -745,7 +821,9 @@ grpc::Status MaterializationController::materialize_replica(
   }
   if (resp.view_index_json().empty() && handle.source == store::loading::MaterializationSource::kDisk) {
     // Prefer disk-local canonical index to avoid Global Store dependency for disk loads.
-    if (normalized_disk_path.has_value()) {
+    if (disk_index.has_value()) {
+      resp.set_view_index_json(disk_index->canonical_index_json);
+    } else if (normalized_disk_path.has_value()) {
       auto local_index_or = store::loader::read_from_artifact_dir(*normalized_disk_path, dev.ordinal);
       if (local_index_or.ok()) {
         resp.set_view_index_json(local_index_or->canonical_index_json);
@@ -911,11 +989,13 @@ grpc::Status MaterializationController::materialize_replica_v2(
     const v2::MaterializeReplicaRequest& req,
     v2::MaterializeReplicaResponse& resp) {
   v1::MaterializeReplicaRequest v1_req;
+  v1_req.set_verify_checksums(true);
   if (req.has_artifact_id() && !req.artifact_id().empty()) {
     v1_req.set_artifact_id(req.artifact_id());
   }
   if (req.has_disk_fallback() && !req.disk_fallback().disk_path().empty()) {
     v1_req.set_disk_path(req.disk_fallback().disk_path());
+    v1_req.set_verify_checksums(req.disk_fallback().verify_checksums());
   }
   v1_req.set_replica_uuid(req.replica_uuid());
   v1_req.set_device_uuid(req.device_uuid());
@@ -1078,14 +1158,17 @@ grpc::Status MaterializationController::resolve_artifact_from_disk(
   auto& span = rctx.span();
   const bool verify_checksums = req.verify_checksums();
   if (req.disk_path().empty()) {
+    record_disk_resolution_outcome("invalid_argument");
     return {StatusCode::INVALID_ARGUMENT, "disk_path is required"};
   }
   if (d_.is_shutting_down.load()) {
+    record_disk_resolution_outcome("unavailable");
     return {StatusCode::UNAVAILABLE, "daemon is shutting down"};
   }
 
   auto normalized_or = normalize_disk_path(req.disk_path());
   if (!normalized_or.ok()) {
+    record_disk_resolution_outcome("invalid_argument");
     return to_grpc_status(normalized_or.status());
   }
   const auto& normalized = *normalized_or;
@@ -1100,6 +1183,7 @@ grpc::Status MaterializationController::resolve_artifact_from_disk(
     if (!allowed) {
       record_disk_path_denied();
       LOG(WARNING) << "disk_path not permitted by whitelist: " << normalized;
+      record_disk_resolution_outcome("whitelist_denied");
       return {StatusCode::INVALID_ARGUMENT, "disk_path not permitted by daemon whitelist"};
     }
   }
@@ -1109,21 +1193,55 @@ grpc::Status MaterializationController::resolve_artifact_from_disk(
   }
   span->SetAttribute("tc.store.verify_checksums", verify_checksums);
 
-  auto artifact_id_or = load_artifact_id_from_descriptor(normalized);
-  if (!artifact_id_or.ok()) {
-    return to_grpc_status(artifact_id_or.status());
+  auto descriptor_or = load_descriptor_metadata(normalized);
+  if (!descriptor_or.ok()) {
+    record_disk_resolution_outcome("invalid_descriptor");
+    return to_grpc_status(descriptor_or.status());
   }
-  if (artifact_id_or->has_value()) {
-    resp.set_artifact_id(**artifact_id_or);
-    span->SetAttribute("tc.artifact.id", **artifact_id_or);
+  const DescriptorMetadata& descriptor = *descriptor_or;
+  if (descriptor.artifact_id.has_value()) {
+    resp.set_artifact_id(*descriptor.artifact_id);
+    span->SetAttribute("tc.artifact.id", *descriptor.artifact_id);
+  }
+
+  auto index_presence_status = ensure_tensor_index_present(normalized);
+  if (!index_presence_status.ok()) {
+    record_disk_resolution_outcome("not_found");
+    return to_grpc_status(index_presence_status);
   }
 
   auto index_or = store::loader::read_from_artifact_dir(normalized, /*target_device_id=*/0);
   if (!index_or.ok()) {
+    record_disk_resolution_outcome("not_found");
     return to_grpc_status(index_or.status());
   }
+
+  auto validation_status = validate_descriptor_against_index(descriptor, *index_or, verify_checksums);
+  if (!validation_status.ok()) {
+    record_disk_resolution_outcome("checksum_failed");
+    return to_grpc_status(validation_status);
+  }
+
+  if (!resp.artifact_id().empty() && descriptor.artifact_id.has_value() &&
+      *descriptor.artifact_id != resp.artifact_id()) {
+    record_disk_resolution_outcome("checksum_failed");
+    return to_grpc_status(
+        absl::FailedPreconditionError("artifact_id mismatch between resolved descriptor and request"));
+  }
+  if (resp.artifact_id().empty() && descriptor.index_multihash.has_value() && descriptor.data_multihash.has_value() &&
+      !descriptor.index_multihash->empty() && !descriptor.data_multihash->empty()) {
+    const std::string artifact_id = absl::StrCat("mi2:", *descriptor.index_multihash, ":", *descriptor.data_multihash);
+    resp.set_artifact_id(artifact_id);
+    if (rctx.allow_high_card_attrs()) {
+      span->SetAttribute("tc.artifact.id", artifact_id);
+    }
+  }
+
   resp.set_canonical_index_bytes(index_or->canonical_index_json);
-  resp.set_generation(compute_generation_from_index(index_or->canonical_index_json));
+  const uint64_t generation = compute_generation_from_index(index_or->canonical_index_json);
+  resp.set_generation(generation);
+  span->SetAttribute("tc.artifact.generation", static_cast<int64_t>(generation));
+  record_disk_resolution_outcome("ok");
   rctx.mark_success();
   return Status::OK;
 }

--- a/daemon/service/controllers/materialization_controller.cc
+++ b/daemon/service/controllers/materialization_controller.cc
@@ -3,12 +3,14 @@
 #include "daemon/service/controllers/materialization_controller.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <future>
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/log.h"
@@ -16,9 +18,11 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_format.h"
+#include "absl/types/span.h"
 #include "google/protobuf/util/time_util.h"
 #include "opentelemetry/metrics/provider.h"
 
+#include "core/common/artifact_hash.h"
 #include "core/store/materialization/dataplane/metadata/index_reader.h"
 #include "core/store/materialization/dataplane/view/view_planner.h"
 #include "daemon/deadline_utils.h"
@@ -155,6 +159,21 @@ v1::MaterializationSource to_proto_source(MaterializationSource source) {
     default:
       return v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED;
   }
+}
+
+uint64_t compute_generation_from_index(std::string_view canonical_index_json) {
+  if (canonical_index_json.empty()) {
+    return 0;
+  }
+  const auto digest = common::sha256_digest_bytes(
+      absl::Span<const uint8_t>(
+          reinterpret_cast<const uint8_t*>(canonical_index_json.data()), canonical_index_json.size()));
+  uint64_t value = 0;
+  const size_t limit = std::min<size_t>(8, digest.size());
+  for (size_t i = 0; i < limit; ++i) {
+    value = (value << 8) | static_cast<uint64_t>(digest[i]);
+  }
+  return value;
 }
 
 absl::StatusOr<ViewSpec> convert_view_spec(const v1::ViewSpec& proto) {
@@ -935,14 +954,16 @@ grpc::Status MaterializationController::materialize_replica_v2(
     resp.mutable_mem_handle()->CopyFrom(v1_resp.mem_handle());
   }
   if (!v1_resp.view_index_json().empty()) {
-    resp.set_view_index_json(v1_resp.view_index_json());
+    resp.set_view_index_bytes(v1_resp.view_index_json());
   }
 
   auto layout_or = resolve_layout_json(v1_resp, req, d_.engine);
   if (!layout_or.ok()) {
     return to_grpc_status(layout_or.status());
   }
-  resp.set_canonical_index_json(*layout_or);
+  const uint64_t generation = compute_generation_from_index(*layout_or);
+  resp.set_canonical_index_bytes(*layout_or);
+  resp.set_generation(generation);
 
   std::optional<DescriptorBuildResult> desc_result;
   if (req.view_identity_case() == v2::MaterializeReplicaRequest::kView && v1_resp.view_index_json().empty()) {
@@ -1019,7 +1040,9 @@ grpc::Status MaterializationController::materialize_by_key_v2(
   if (!layout_or.ok()) {
     return to_grpc_status(layout_or.status());
   }
-  resp.set_canonical_index_json(*layout_or);
+  const uint64_t generation = compute_generation_from_index(*layout_or);
+  resp.set_canonical_index_bytes(*layout_or);
+  resp.set_generation(generation);
 
   auto desc_or = build_descriptors_from_index(*layout_or, req.tensor_names(), /*device_uuid=*/"");
   if (!desc_or.ok()) {
@@ -1043,9 +1066,66 @@ grpc::Status MaterializationController::materialize_by_key_v2(
     ticket->set_status(v1_resp.status());
     *ticket->mutable_created_at() = google::protobuf::util::TimeUtil::GetCurrentTime();
   }
-  // Fill view index JSON with resolved canonical to aid clients that expect a layout hint.
-  resp.set_view_index_json(*layout_or);
+  // Fill view index bytes with resolved canonical to aid clients that expect a layout hint.
+  resp.set_view_index_bytes(*layout_or);
   return status;
+}
+
+grpc::Status MaterializationController::resolve_artifact_from_disk(
+    RpcContext& rctx,
+    const v2::ResolveArtifactFromDiskRequest& req,
+    v2::ResolveArtifactFromDiskResponse& resp) {
+  auto& span = rctx.span();
+  const bool verify_checksums = req.verify_checksums();
+  if (req.disk_path().empty()) {
+    return {StatusCode::INVALID_ARGUMENT, "disk_path is required"};
+  }
+  if (d_.is_shutting_down.load()) {
+    return {StatusCode::UNAVAILABLE, "daemon is shutting down"};
+  }
+
+  auto normalized_or = normalize_disk_path(req.disk_path());
+  if (!normalized_or.ok()) {
+    return to_grpc_status(normalized_or.status());
+  }
+  const auto& normalized = *normalized_or;
+  if (whitelist_enforced_) {
+    bool allowed = false;
+    for (const auto& prefix : disk_path_whitelist_) {
+      if (path_has_prefix(normalized, prefix)) {
+        allowed = true;
+        break;
+      }
+    }
+    if (!allowed) {
+      record_disk_path_denied();
+      LOG(WARNING) << "disk_path not permitted by whitelist: " << normalized;
+      return {StatusCode::INVALID_ARGUMENT, "disk_path not permitted by daemon whitelist"};
+    }
+  }
+  resp.set_disk_path(normalized.string());
+  if (rctx.allow_high_card_attrs()) {
+    span->SetAttribute("tc.disk.path", normalized.string());
+  }
+  span->SetAttribute("tc.store.verify_checksums", verify_checksums);
+
+  auto artifact_id_or = load_artifact_id_from_descriptor(normalized);
+  if (!artifact_id_or.ok()) {
+    return to_grpc_status(artifact_id_or.status());
+  }
+  if (artifact_id_or->has_value()) {
+    resp.set_artifact_id(**artifact_id_or);
+    span->SetAttribute("tc.artifact.id", **artifact_id_or);
+  }
+
+  auto index_or = store::loader::read_from_artifact_dir(normalized, /*target_device_id=*/0);
+  if (!index_or.ok()) {
+    return to_grpc_status(index_or.status());
+  }
+  resp.set_canonical_index_bytes(index_or->canonical_index_json);
+  resp.set_generation(compute_generation_from_index(index_or->canonical_index_json));
+  rctx.mark_success();
+  return Status::OK;
 }
 
 grpc::Status MaterializationController::get_artifact_index_by_id(

--- a/daemon/service/controllers/materialization_controller.h
+++ b/daemon/service/controllers/materialization_controller.h
@@ -54,6 +54,11 @@ class MaterializationController {
       const v2::MaterializeByKeyRequest& req,
       v2::MaterializeByKeyResponse& resp);
 
+  grpc::Status resolve_artifact_from_disk(
+      RpcContext& rctx,
+      const v2::ResolveArtifactFromDiskRequest& req,
+      v2::ResolveArtifactFromDiskResponse& resp);
+
   grpc::Status get_artifact_index_by_id(
       RpcContext& rctx,
       const v1::GetArtifactIndexByIdRequest& req,

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -81,6 +81,15 @@ graph TD
   (default TTL 600s, max 1000 entries) to avoid repeated daemon lookups.
   Tunables: `TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS`,
   `TENSORCAST_STORE_CACHE_MAX_ENTRIES`.
+- **View Composition**: `.view()/.subset()/.slice()` derive child handles via a
+  pure composer (no daemon RPCs) with per-handle view-index caches so repeated
+  calls avoid recomputing planners.
+- **Batching & Async**: `BatchContext` batches sync fetches; async
+  `.tensor_async()`/`.tensor_dict_async()` coalesce via `MaterializationBatcher`
+  on the store event loop.
+- **Prefetch Tickets**: `prefetch(wait_for_completion=False)` returns replica
+  tickets propagated through `FallbackOptions.replica_uuid` to reuse staged
+  replicas without reloading.
 
 ## Key Design Principles
 

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -77,6 +77,12 @@ graph TD
   exposes metadata (`tensor_names`, `describe`) and selective tensor fetch
   without changing the eager `get*` APIs. Handles surface
   `FAILED_PRECONDITION` if used after `Store.close()`.
+- **Disk-backed Handles**: `tensorcast.from_disk(path)` routes through the
+  daemon (`ResolveArtifactFromDisk`) so disk paths stay daemon-owned. The RPC
+  enforces whitelist entries, validates descriptor multihashes when requested
+  (`verify_checksums=true`), returns canonical index bytes + generation, and
+  seeds the SDK cache with `{artifact_id, disk_path}` for reuse across
+  materialization, views, and unloads.
 - **Metadata Cache**: A process-wide `ArtifactCache` stores canonical indices
   (default TTL 600s, max 1000 entries) to avoid repeated daemon lookups.
   Tunables: `TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS`,

--- a/docs/designs/0036-01-materialization-pipeline-v2.md
+++ b/docs/designs/0036-01-materialization-pipeline-v2.md
@@ -77,11 +77,19 @@ We introduce the following protobuf changes under a new `tensorcast.proto.daemon
   - `string replica_uuid` (explicit, reused by prefetch later)
 - `MaterializeReplicaResponse`
   - `repeated TensorPayloadDescriptor payloads`
-  - `bytes canonical_index_json`
+  - `bytes canonical_index_bytes`
+  - `bytes view_index_bytes`
+  - `uint64 generation`
   - `ViewSubset view_subset` (optional, used when the server applies slicing)
   - `ReplicaTicket ticket` (populated when `wait_for_completion=false`)
+- `ResolveArtifactFromDisk` (new RPC)
+  - `string disk_path`
+  - `bool verify_checksums`
+  - returns `{artifact_id, canonical_index_bytes, generation}` for cache hydration without materializing
 
-`TensorPayloadDescriptor` is a thin schema containing `{ string name, uint32 dtype, string device_uuid, uint64 buffer_offset, uint64 byte_length, repeated uint64 stride }`. The daemon uses UMA layout information to only emit descriptors for requested tensors and writes contiguous slices into the exported IPC buffer. Disk loaders use the same message to describe byte ranges in POSIX files.
+Canonical index fields are standardized as `canonical_index_bytes` / `view_index_bytes` (never `*_json`) and always paired with `generation` so caches and disk resolution stay in sync across SDK layers.
+
+`TensorPayloadDescriptor` is a thin schema containing `{ string name, string dtype, string device_uuid, uint64 buffer_offset, uint64 byte_length, uint64 storage_offset, repeated int64 shape, repeated int64 stride }`. The daemon uses UMA layout information to only emit descriptors for requested tensors and writes contiguous slices into the exported IPC buffer. Disk loaders use the same message to describe byte ranges in POSIX files.
 
 The daemon keeps the existing v1 RPCs alive until all SDKs upgrade, but the Python client switches entirely to v2 because the new iterator contract depends on descriptors.
 
@@ -143,7 +151,8 @@ gRPC: MaterializeReplicaRequest(
         ▼
 MaterializeReplicaResponse(
     payloads=[TensorPayloadDescriptor, ...],
-    canonical_index_json=...,
+    canonical_index_bytes=...,
+    generation=...,
 )
         │
         ▼
@@ -215,4 +224,3 @@ All newly introduced Python names follow the SDK naming rules in `AGENTS.md`. Pr
 - `core/store/materialization/dataplane/sources/file_partition_source.h`
 - `core/store/materialization/dataplane/view/view_plan_source.h`
 - `core/store/materialization/contracts/view/view_plan.h` — `SelectionPlan` definition
-

--- a/docs/designs/0036-02-artifact-handle-core.md
+++ b/docs/designs/0036-02-artifact-handle-core.md
@@ -99,7 +99,7 @@ Phase 2 adds `ArtifactCache` alongside the key cache so metadata can be reused a
 - `Store.artifact(...) -> Artifact`
 - `tensorcast.from_disk(path) -> Artifact` (convenience wrapper, see Phase 4)
 
-Factories require at least one of `key`, `artifact_id`, or `disk_path`. Multiple identifiers may be provided; handles keep all known hints so cloning/serialization works even after resolution. When `disk_path` is provided, the factory calls the daemon to resolve the artifact identity from the disk path (the daemon reads `tensor_index.json` and computes/verifies the artifact ID). All construction paths return the same `Artifact` type—there is no special subclass for disk-backed artifacts. They capture a `weakref.ref[Store]` to avoid keeping the Store alive indefinitely.
+Factories require at least one of `key`, `artifact_id`, or `disk_path`. Multiple identifiers may be provided; handles keep all known hints so cloning/serialization works even after resolution. When `disk_path` is provided, the factory issues the daemon RPC `ResolveArtifactFromDisk` to return `{artifact_id, canonical_index_bytes, generation}` and hydrates the process `ArtifactCache` with that result. All construction paths return the same `Artifact` type—there is no special subclass for disk-backed artifacts. They capture a `weakref.ref[Store]` to avoid keeping the Store alive indefinitely.
 
 > **Note**: The `disk_path=` parameter and `from_disk()` function are defined here for completeness but are fully implemented in Phase 4 (`0036-04-disk-artifact-variant.md`).
 
@@ -209,6 +209,7 @@ flowchart TB
 #### Cache behavior
 
 - Process-wide `ArtifactCache` stores `{artifact_id, disk_path, canonical_index_bytes, parsed_index, generation, expires_at}`.
+- Canonical metadata always flows through the v2 surfaces as `canonical_index_bytes` (and optional `view_index_bytes`), paired with a `generation` counter. Handles and caches treat missing generation as `None` but preserve any non-zero value returned by the daemon.
 - Entries expire after `TENSORCAST_STORE_INDEX_CACHE_TTL_SECONDS` (default 600s) or when `StoreRuntimeContext.invalidate_artifact()` is called.
 - Maximum entries default to 1000 (`TENSORCAST_STORE_CACHE_MAX_ENTRIES`), evicted via LRU on insert.
 - Fork handling: `_after_fork_child()` rebuilds the cache to avoid inheriting stale mutexes.
@@ -263,7 +264,7 @@ All three construction paths (`key=`, `artifact_id=`, `disk_path=`) converge to 
 - `exists()`: shallow existence probe without tensor transfer.
   - `key` handle → check `_key_cache`, then `resolve_key_mapping_cached`; on miss, RPC to daemon.
   - `artifact_id` handle → try `ArtifactCache`; on miss, call `get_artifact_index_by_id` (lightweight metadata RPC). Cache the result on success.
-  - `disk_path` handle → read local `tensor_index.json` to compute/verify artifact id (Phase 4 full path), fallback to daemon lookup in Phase 2 if local parse fails.
+  - `disk_path` handle → call `ResolveArtifactFromDisk` to return `{artifact_id, canonical_index_bytes, generation}`, hydrate `ArtifactCache`, and reuse the cached bytes for materialization.
   - Errors bubble as `ArtifactError` with retryable flag based on daemon response; NOT_FOUND invalidates caches for that id/key.
 - `release()`: idempotent; marks handle invalid for future materialization but leaves cached metadata readable for diagnostics. `exists()` still works post-release (metadata-only).
 

--- a/docs/designs/0036-03-lazy-artifact-handle.md
+++ b/docs/designs/0036-03-lazy-artifact-handle.md
@@ -83,8 +83,8 @@ See `0036-02-artifact-handle-core.md` for the base handle + store binding diagra
 Phase 1 already introduced the v2 selective-materialization RPC. Phase 3 adds two incremental capabilities required for prefetch tickets and explicit source policies:
 
 - **Replica Tickets** – `MaterializeReplicaResponse` now carries an optional `ReplicaTicket { string replica_uuid, string device_uuid, google.protobuf.Timestamp expires_at, LoadStatus status }` whenever `wait_for_completion=false`. The SDK surfaces that via `Artifact.prefetch()` and later passes the `replica_uuid` back through `Materialize*` requests. Two lightweight RPCs are added:
-  - `QueryReplicaStatus(ReplicaTicket)` – returns `{status, expires_at}` so the SDK can await readiness without reissuing a materialize call.
-  - `ReleaseReplica(ReplicaTicket)` – allows explicit cleanup when the ticket is abandoned before consumption.
+  - `QueryReplicaStatus(QueryReplicaStatusRequest)` – accepts a request wrapper containing the `ReplicaTicket` and returns `{status, expires_at}` so the SDK can await readiness without reissuing a materialize call.
+  - `ReleaseReplica(ReleaseReplicaRequest)` – accepts the same wrapper pattern to allow explicit cleanup when the ticket is abandoned before consumption.
 - **Source Preferences** – `SourcePreference preference` and `DiskFallbackHint` (disk path + checksum policy) become first-class request fields. They are wired directly from the extended `FallbackOptions` documented below so that daemon-side schedulers can differentiate `local_only`, `disk-first`, or `p2p` requests without relying on heuristics.
 
 All other protocol changes (tensor-name subsets, descriptor iterators) remain as defined in `0036-01`.
@@ -174,7 +174,7 @@ SliceSpec = slice | tuple[int, slice]
 
 > **See Phase 4**: The `tc.from_disk(path)` entry point is fully specified in [0036-04-disk-artifact-variant.md](./0036-04-disk-artifact-variant.md).
 
-**Summary**: `tc.from_disk(path)` returns a standard `Artifact` (not a special subclass) by going through the same Store session / daemon gRPC flow. The view composition, batching, and prefetch APIs defined in this document work identically with disk-backed artifacts.
+**Summary**: `tc.from_disk(path)` returns a standard `Artifact` (not a special subclass) by going through the same Store session / daemon gRPC flow. The daemon RPC `ResolveArtifactFromDisk` returns `{artifact_id, canonical_index_bytes, generation}` and the SDK hydrates `ArtifactCache` with those bytes so metadata access avoids a second fetch. Materialization then flows through `MaterializeReplica` with `SourcePreference=DISK` and the same descriptor schema (`{name, shape, stride, buffer_offset, byte_length, storage_offset, dtype, device_uuid}`) used for P2P artifacts. The view composition, batching, and prefetch APIs defined in this document work identically with disk-backed artifacts.
 
 ### Extended FallbackOptions
 

--- a/docs/designs/0036-04-disk-artifact-variant.md
+++ b/docs/designs/0036-04-disk-artifact-variant.md
@@ -1,0 +1,285 @@
+---
+slug: 0036-disk-artifact-variant
+title: Lazy Artifact Handle Phase 4 – Disk Artifact Variant
+areas: ["sdk", "daemon"]
+related_code:
+  - tensorcast/api/store/artifact.py
+  - tensorcast/api/store/materialization.py
+  - tensorcast/api/_io_disk.py
+  - daemon/grpc_service_impl.cc
+  - core/store/materialization/dataplane/loaders/disk_loader.h
+links:
+  predecessor: ./0036-03-lazy-artifact-handle.md
+  phase1: ./0036-01-materialization-pipeline-v2.md
+  phase2: ./0036-02-artifact-handle-core.md
+  phase3: ./0036-03-lazy-artifact-handle.md
+---
+
+# Summary
+
+Phase 4 introduces the `tc.from_disk(path)` entry point that constructs an `Artifact` from a local disk path. This completes the lazy artifact handle program by enabling disk-backed artifacts to participate in the same unified flow as key-resolved and artifact_id-based artifacts.
+
+**Design principle**: `tc.from_disk(path)` returns a standard `Artifact` object, not a special subclass. All artifacts—whether constructed via `key=`, `artifact_id=`, or `disk_path=`—share identical interfaces and go through the same Store session / daemon gRPC flow. The disk path is merely a construction hint that influences how the daemon resolves and materializes the artifact.
+
+Resolution returns canonical index bytes (not JSON) plus an optional `generation` counter so the SDK can hydrate `ArtifactCache` immediately and keep metadata aligned with the v2 materialization fields (`canonical_index_bytes`, `view_index_bytes`).
+
+```python
+# All three return the same Artifact type with identical behavior
+artifact1 = tc.artifact(key="model:v1")
+artifact2 = tc.artifact(artifact_id="mi2:...")
+artifact3 = tc.from_disk("/mnt/checkpoints/model")
+
+# Identical API surface
+artifact3.tensor_names          # metadata access
+artifact3.tensor_dict(device="cuda:0")  # materialization
+artifact3.view(slices={...})    # view composition (from Phase 3)
+```
+
+# Goals / Non-Goals
+
+## Goals
+
+1. **`tc.from_disk(path)` entry point** — Convenience function that constructs an `Artifact` from a local disk path via daemon gRPC.
+2. **Daemon disk resolution RPC** — Dedicated RPC that inspects a disk path and returns `{artifact_id, canonical_index_bytes, generation}` for cache hydration.
+3. **Unified Artifact type** — No `DiskArtifact` subclass; disk-backed artifacts are indistinguishable from other artifacts at the API level.
+4. **Implicit fallback binding** — The constructed `Artifact` carries `_disk_path_hint` so subsequent materialization automatically uses the disk path.
+5. **Backward compatibility** — Document that `tc.from_disk()` always routes through the daemon, matching the daemon-only invariant defined in [0038-daemon-only-disk-materialization](./0038-daemon-only-disk-materialization.md).
+
+## Non-Goals
+
+- Changing the `Artifact` class definition (already covered in Phase 2).
+- View composition or batching (covered in Phase 3).
+- Offline disk loading without daemon (legacy `restore_tensors_from_disk()` API remains for this).
+
+# Architecture & Interfaces
+
+## Construction Flow
+
+```
+tc.from_disk("/mnt/checkpoints/model")
+        │
+        ▼
+Store.from_disk(path) / Store.artifact(disk_path=path)
+        │
+        ▼
+┌───────────────────────────────────────────────────────────────┐
+│  gRPC: ResolveArtifactFromDisk(disk_path)                      │
+└───────────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌───────────────────────────────────────────────────────────────┐
+│  Daemon:                                                       │
+│  1. Validate disk_path exists and contains tensor_index.json   │
+│  2. Parse tensor_index.json → canonical_index_bytes            │
+│  3. Compute artifact_id from index (or read from descriptor)   │
+│  4. Return {artifact_id, canonical_index_bytes, generation, disk_path}     │
+└───────────────────────────────────────────────────────────────┘
+        │
+        ▼
+Artifact(
+    artifact_id=resolved_id,
+    canonical_index_bytes=index_bytes,
+    generation=generation,
+    disk_path_hint=path,
+    store_ref=weakref(store),
+)
+```
+
+## Materialization Flow
+
+When `artifact.tensor_dict()` is called on a disk-backed artifact:
+
+```
+artifact.tensor_dict(device="cuda:0", names=["layer.0.weight"])
+        │
+        ▼
+MaterializationPipeline._materialize(
+    artifact_id=...,
+    fallback=FallbackOptions.for_disk(artifact._disk_path_hint),
+    tensor_names=["layer.0.weight"],
+)
+        │
+        ▼
+┌───────────────────────────────────────────────────────────────┐
+│  gRPC: MaterializeReplicaRequest(                              │
+│    artifact_id=...,                                            │
+│    preference=DISK,                                            │
+│    disk_fallback=DiskFallbackHint(                             │
+│      disk_path="/mnt/checkpoints/model",                       │
+│      verify_checksums=true                                     │
+│    ),                                                          │
+│    tensor_names=["layer.0.weight"],                            │
+│  )                                                             │
+└───────────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌───────────────────────────────────────────────────────────────┐
+│  Daemon DiskLoader (C++ infrastructure)                        │
+│  DiskLoader → FilePartitionSource → pread/mmap                 │
+│  ViewPlanSource applies SelectionPlan for selective loading    │
+└───────────────────────────────────────────────────────────────┘
+        │
+        ▼
+MaterializeReplicaResponse(payloads=[...], ...)
+        │
+        ▼
+SDK maps CUDA IPC handles → torch.Tensor dict
+```
+
+## Public API
+
+### Entry Points
+
+```python
+# Primary entry point
+def from_disk(path: str | os.PathLike) -> Artifact:
+    """Construct an Artifact from a local disk path.
+    
+    The artifact identity is resolved via daemon gRPC by inspecting
+    the disk path's tensor_index.json. Subsequent materialization
+    automatically uses the disk path as the data source.
+    
+    Args:
+        path: Path to artifact directory containing tensor_index.json
+              and tensor.data_* files.
+    
+    Returns:
+        Standard Artifact object (not a special subclass).
+    
+    Raises:
+        ArtifactError: If path is invalid or daemon cannot resolve.
+    """
+    store = get_default_store()
+    return store.from_disk(path)
+
+# Also available on Store
+class Store:
+    def from_disk(self, path: str | os.PathLike) -> Artifact:
+        """Construct an Artifact from a local disk path."""
+        return self.artifact(disk_path=str(path))
+    
+    def artifact(
+        self,
+        *,
+        key: str | None = None,
+        artifact_id: str | None = None,
+        disk_path: str | None = None,
+        fallback: FallbackOptions | None = None,
+    ) -> Artifact:
+        """Construct an Artifact from key, artifact_id, or disk_path."""
+        # Exactly one of key, artifact_id, disk_path must be provided
+        ...
+```
+
+### Artifact Internal State
+
+Phase 2 already defined `_disk_path_hint`. This phase uses it:
+
+```python
+class Artifact:
+    # ... existing fields from Phase 2 ...
+    _disk_path_hint: str | None  # Set when constructed via disk_path=
+    
+    def tensor_dict(
+        self,
+        *,
+        device: torch.device | str,
+        names: Sequence[str] | None = None,
+    ) -> dict[str, torch.Tensor]:
+        # If disk_path_hint is set, use it as fallback
+        fallback = self._fallback
+        if self._disk_path_hint and fallback is None:
+            fallback = FallbackOptions.for_disk(self._disk_path_hint)
+        
+        return self._materialize(
+            names=names,
+            device=device,
+            fallback=fallback,
+        )
+```
+
+## Daemon RPC Extensions (chosen)
+
+```protobuf
+// In tensorcast.proto.daemon.v2
+
+message ResolveArtifactFromDiskRequest {
+  string disk_path = 1;
+  bool verify_checksums = 2;
+}
+
+message ResolveArtifactFromDiskResponse {
+  string artifact_id = 1;
+  bytes canonical_index_bytes = 2;  // canonical index bytes, not JSON
+  string disk_path = 3;             // echoed back for confirmation
+  uint64 generation = 4;            // propagated to ArtifactCache
+}
+
+service StoreDaemon {
+  // ... existing RPCs ...
+  rpc ResolveArtifactFromDisk(ResolveArtifactFromDiskRequest)
+      returns (ResolveArtifactFromDiskResponse);
+}
+```
+
+## Backward Compatibility
+
+Production flows always go through the daemon; there is no SDK code path that reads disk directly.
+
+## State Machine Extension
+
+Phase 2 defined the state machine with `UnresolvedDisk` state. This phase implements it:
+
+```mermaid
+stateDiagram-v2
+    [*] --> UnresolvedKey: key= ctor
+    [*] --> UnresolvedDisk: disk_path= ctor
+    [*] --> Identified: artifact_id= ctor
+    
+    UnresolvedKey --> Identified: gRPC resolve key
+    UnresolvedDisk --> Identified: gRPC ResolveArtifactFromDisk
+    
+    Identified --> Indexed: fetch canonical index (if not cached)
+    Indexed --> Indexed: tensor_dict() calls
+    Indexed --> Released: release()
+    
+    UnresolvedDisk --> Failed: disk path invalid / not found
+```
+
+**Note**: For disk-backed artifacts, the daemon returns `canonical_index_bytes` during resolution, so the `Identified → Indexed` transition happens immediately.
+
+# Trade-offs & Risks
+
+| Risk | Mitigation |
+|------|------------|
+| **Daemon dependency** | All disk operations require a running daemon. This is intentional for unified observability. Legacy `restore_tensors_from_disk()` remains for offline scenarios. |
+| **Disk path validation** | Daemon validates path existence and structure. SDK receives clear error if path is invalid. |
+| **Stale disk data** | If disk data changes after artifact construction, subsequent materialization may fail or return inconsistent data. Document that artifacts are snapshots. |
+| **Performance overhead** | Additional gRPC round-trip for resolution. Mitigated by caching in `ArtifactCache`. |
+
+# Compatibility & Acceptance Criteria
+
+1. **Basic from_disk test**: `tc.from_disk(path).tensor_dict()` returns the same tensors as the canonical on-disk artifact.
+2. **Selective loading test**: `tc.from_disk(path).tensor_dict(names=["a"])` only loads tensor "a".
+3. **View composition test**: `tc.from_disk(path).view(slices={...})` works with Phase 3 view APIs.
+4. **Error handling test**: Invalid disk path raises `ArtifactError(status_code="NOT_FOUND")`.
+5. **Daemon RPC test**: `bazel test //daemon:resolve_artifact_from_disk_test --define=use_fake_cuda=true`.
+6. **Metadata caching test**: Repeated `from_disk(path)` calls reuse cached metadata.
+7. **Type identity test**: `isinstance(tc.from_disk(path), Artifact)` returns `True` (no subclass).
+
+# Naming Compliance
+
+| Symbol | Kind | Compliance |
+|--------|------|------------|
+| `from_disk()` | Function | snake_case |
+| `ResolveArtifactFromDisk` | Proto RPC | PascalCase |
+| `ResolveArtifactFromDiskRequest` | Proto message | PascalCase |
+| `_disk_path_hint` | Private field | snake_case with underscore prefix |
+
+# References
+
+- `docs/designs/0036-01-materialization-pipeline-v2.md` — Disk loading via daemon
+- `docs/designs/0036-02-artifact-handle-core.md` — Artifact class and state machine
+- `docs/designs/0036-03-lazy-artifact-handle.md` — View composition (uses same Artifact)
+- `core/store/materialization/dataplane/loaders/disk_loader.h` — C++ DiskLoader
+- `tensorcast/api/_io_disk.py` — Legacy disk loading API

--- a/docs/plans/0036-03-lazy-artifact-handle.md
+++ b/docs/plans/0036-03-lazy-artifact-handle.md
@@ -1,0 +1,84 @@
+---
+slug: 0036-lazy-artifact-handle
+title: Plan – Lazy Artifact Handle Phase 3 (Views, Batching, Prefetch)
+links:
+  design: ../designs/0036-03-lazy-artifact-handle.md
+areas: ["sdk"]
+related_code:
+  - tensorcast/api/store/artifact.py
+  - tensorcast/api/store/views.py
+  - tensorcast/api/store/materialization.py
+  - tensorcast/api/store/runtime.py
+  - tensorcast/api/store/async_ops.py
+  - tensorcast/api/store/cache.py
+  - tensorcast/api/store/common.py
+  - tensorcast/api/store/README.md
+  - tensorcast/api/store/view_composer.py
+  - tensorcast/api/store/batch_context.py
+  - tests/python/api/test_artifact_handle.py
+  - tests/python/api/test_artifact_cache.py
+  - tests/python/api/test_artifact_tensor_subset.py
+  - tests/python/api/test_materialization_pipeline_v2.py
+---
+
+# Objective
+
+Deliver the Phase 3 lazy handle capabilities—view composition, batching/async materialization, and prefetch tickets—on top of the Phase 1/2 pipeline + handle foundation while keeping eager `get*` APIs stable and preparing for the Phase 4 disk variant.
+
+# Current State & Grounding
+- `tensorcast/api/store/artifact.py` implements lazy handles (metadata, selective tensor fetch, serialization) with double-checked locking; there are no `view/subset/batch/prefetch` surfaces, async tensor APIs, or per-view metadata caches. Disk-backed handles are rejected with `ArtifactError(UNIMPLEMENTED)`, and `FallbackOptions` only exposes `prefer_disk`/`allow_p2p` booleans.
+- `tensorcast/api/store/views.py` resolves slices/transpose and view_id for `get_view`/registration using daemon lookups; it re-fetches canonical indices on cache miss and does not compose chained views or cache view-derived metadata per handle.
+- `tensorcast/api/store/materialization.py` supports `tensor_names` filtering and streaming v2 payloads; async paths are executor-wrapped sync calls with no batching/coalescing, no replica ticket handling, and no view-spec awareness for handles beyond the resolver inputs.
+- `tensorcast/api/store/runtime.py` owns `ArtifactCache` + key cache with TTL/LRU and per-daemon metrics; async infra is a single-thread `ThreadPoolExecutor` via `TrackedExecutor` with no asyncio loop or batcher thread. There is no replica ticket lifecycle, and cache invalidation does not track view metadata.
+- `tensorcast/api/store/__init__.py` exports `from_disk()` but the handle path fails for disk identities; there is no `artifact_async` export or async handle factory. `FallbackOptions` lacks the `prefer` enum/`replica_uuid` wiring described in the design.
+- Protos: `proto/tensorcast/daemon/v2/store_daemon.proto` includes `ReplicaTicket` fields on materialization responses but has no `QueryReplicaStatus` / `ReleaseReplica` RPCs; daemon client wrappers and Python stubs do not expose ticket polling or release.
+- Tests: `tests/python/api/test_artifact_handle.py`, `test_artifact_cache.py`, and `test_artifact_tensor_subset.py` cover metadata, subset materialization, and cache TTL/LRU. There is no coverage for view composition chains, batch contexts, async coroutine APIs, prefetch tickets, or replica-aware fallback policies. `tensorcast/api/store/README.md` documents Phase 2 cache/env vars only.
+
+# Phases & Milestones
+
+- [x] **Phase 1: View composition surfaces**
+  - [x] Add `view_composer.py` with `ViewSpecComposer`, `ViewBuilder`, and per-handle `ViewMetadataCache`; reuse `_view_ops` for validation and enforce depth/placement rules from the design.
+  - [x] Extend `Artifact` with `.view()/.subset()/.slice()`/`.view_builder()` entry points that clone immutable identity/fallback state, compose view specs, and keep parent/child metadata independence while sharing canonical index bytes when available.
+  - [x] Integrate view composition into `MaterializationPipeline` inputs and `Store` exports so `tc.artifact(...).view(...)` flows through the existing view resolver without duplicating daemon index fetches; document behavior deltas in `tensorcast/api/store/README.md`.
+
+- [x] **Phase 2: Batching and async materialization**
+  - [x] Implement `batch_context.py` with `BatchContext` (sync context manager) and `MaterializationBatcher` (daemon dispatch thread + coalescing window) matching the design’s threading model; ensure RPC dispatch uses the store event loop and avoids `StoreRuntimeContext._executor` contention.
+  - [x] Add handle APIs `tensor_async`, `tensor_dict_async`, `artifact_async` factory, and `Artifact.batch()` that reuse selective fetch + validation, support view specs, and preserve eager `get*` semantics unchanged.
+  - [x] Wire batch/async metrics (hits, coalesced count, window latency) via `store_metrics`; add cancellation/shutdown hooks so batcher threads stop on `Store.close()`/fork.
+
+- [ ] **Phase 3: Prefetch tickets and fallback policy expansion**
+  - [x] Extend `FallbackOptions` and RPC translation to include `prefer` enum, `disk` preference, checksum toggle, and `replica_uuid` plumbing; keep `prefer_disk` compatibility shim.
+  - [x] Surface `Artifact.prefetch()` returning `PrefetchTicket` (with `wait_for_completion=false`) and pass tickets through subsequent materialization requests; add ticket expiry/error handling that invalidates cache + key mappings on `FAILED_PRECONDITION`/`NOT_FOUND`.
+  - [x] Introduce daemon client methods for `QueryReplicaStatus`/`ReleaseReplica` (per design) and propagate to `MaterializationPipeline` so async/sync paths can poll or release prefetched replicas; gate disk-path reuse until Phase 4.
+  - [x] Add proto/RPC definitions for ticket polling/release in `proto/tensorcast/daemon/v2/store_daemon.proto`, update Bazel + Buf config, and regenerate stubs via `bash tools/build_proto_python.sh`.
+
+- [ ] **Phase 4: Validation, docs, and rollout readiness**
+  - [x] Add tests for view chaining and invariants (depth limit, parent/child lifecycle), batch/async coalescing, prefetch ticket reuse/expiry, and replica-aware fallback resolution; extend existing suites instead of adding ad-hoc stubs.
+  - [x] Update docs: `tensorcast/api/store/README.md`, `docs/architecture/architecture-overview.md`, and cross-links from `docs/designs/0036-03-lazy-artifact-handle.md` to reflect new APIs, env vars, and metrics; add examples for view chaining + batch usage.
+  - [x] Define rollout/backout toggles (env flags or feature knobs) for batcher/prefetch paths and document operational checks (metrics/telemetry) required before enabling by default.
+
+# Tasks
+- Ground view composition in existing `ViewOrchestrator` by adding a pure composer that consumes cached canonical indices from `ArtifactCache` when available; avoid duplicate daemon RPCs for repeated view derivations.
+- Create per-handle view metadata cache structs and ensure `Artifact.describe()`/`tensor_names` on derived views avoid planner recomputation while respecting `_released`/store-closed checks.
+- Build batcher event-loop scaffolding (asyncio loop + dispatch thread) within `StoreRuntimeContext` or adjacent helper, ensuring fork safety and clean shutdown; plumb device/view-spec keys into batch grouping.
+- Extend `FallbackOptions` + daemon request builders to support `prefer` enum and `replica_uuid`; add translation layer that preserves legacy kwargs and raises structured `ArtifactError` on invalid combinations.
+- Add prefetch lifecycle helpers (issue ticket, poll, reuse, cancel) with metrics + logging, and ensure cache/key invalidation triggers fire on stale tickets or daemon-side failures; add client/daemon RPCs and regenerate Buf/Bazel outputs.
+- Expand tests under `tests/python/api/` for view builder, batch/async fetch, and prefetch ticket flows; add fixture helpers for ReplicaTicket-aware stubs to keep suites daemon-independent.
+- Refresh SDK docs and examples to highlight lazy handle workflows, batching, and prefetch; note compatibility with existing eager APIs and Phase 4 disk parity dependency.
+
+# Acceptance Checks
+- [ ] View composition APIs produce deterministic `ViewSpec` hashes and respect depth/placement invariants; parent/child lifecycle independence tested.
+- [ ] Batcher coalesces concurrent async calls and sync context manager emits single RPC per context; shutdown/fork safety verified.
+- [ ] Prefetch tickets round-trip through new RPCs and fallback policies; stale/expired tickets trigger invalidation and retry without ticket.
+- [ ] Doc sync: `tensorcast/api/store/README.md` and `docs/architecture/architecture-overview.md` reflect new APIs, env/metrics, and feature flags; design cross-links updated.
+- [ ] All new/updated tests (`uv run pytest tests/python/api/...`) pass and Buf/Bazel proto generation is refreshed after RPC additions.
+# Test / Rollout / Backout
+- **Unit/Integration**: `uv run pytest tests/python/api/test_artifact_handle.py`, `uv run pytest tests/python/api/test_artifact_tensor_subset.py`, `uv run pytest tests/python/api/test_materialization_pipeline_v2.py`, plus new suites for view builder/batch/prefetch (e.g., `uv run pytest tests/python/api/test_artifact_views.py`, `test_artifact_batching.py`, `test_artifact_prefetch.py`).
+- **Rollout**: Keep eager `get*` as default; guard batcher/prefetch enabling with feature flags/env vars, monitor cache + batcher metrics, and soak in staging before turning on async exports in docs/examples.
+- **Backout**: Disable batcher/prefetch flags to fall back to existing executor-based async path and selective fetch; remove new exports from `tensorcast/api/store/__init__.py` if needed while retaining handle metadata APIs. Invalidate caches on rollback to avoid ticket reuse.
+
+# Risks & Tracking
+- **Concurrency and shutdown**: Batcher threads/event loops must not race with `Store.close()`/fork; add lifecycle hooks and tests for clean teardown.
+- **Cache coherence**: View-derived metadata and replica tickets risk staleness; ensure invalidation hooks fire on registration/deregistration/materialization errors and when tickets expire.
+- **API churn/compatibility**: Extending `FallbackOptions` and adding async factories must preserve current eager callers; provide shims and doc updates to avoid breaking downstream code.
+- **Telemetry noise**: New metrics for batcher/prefetch could inflate cardinality; cap label sets and sample where needed.

--- a/docs/plans/0036-04-disk-artifact-variant.md
+++ b/docs/plans/0036-04-disk-artifact-variant.md
@@ -1,0 +1,68 @@
+---
+slug: 0036-disk-artifact-variant
+title: Plan – Lazy Artifact Handle Phase 4 (Disk Variant)
+links:
+  design: ../designs/0036-04-disk-artifact-variant.md
+areas: ["sdk", "daemon"]
+related_code:
+  - tensorcast/api/store/__init__.py
+  - tensorcast/api/store/artifact.py
+  - tensorcast/api/store/materialization.py
+  - tensorcast/api/store/runtime.py
+  - tensorcast/api/store/README.md
+  - tensorcast/daemon_ctl.py
+  - daemon/service/controllers/materialization_controller.cc
+  - proto/tensorcast/daemon/v2/store_daemon.proto
+  - tests/python/api/test_artifact_handle.py
+---
+
+# Objective
+
+Ship the disk-backed `Artifact` variant (`tc.from_disk`) defined in the design so disk paths resolve through the daemon, hydrate `ArtifactCache` with canonical metadata + generation, and materialize via the unified iterator pipeline with disk-first source selection and view/subset parity.
+
+# Current State & Grounding
+- `Store.from_disk` and `Artifact` already accept `disk_path` hints and default to `FallbackOptions.for_disk`; `Artifact._ensure_identified()` calls `resolve_artifact_from_disk_v2` and seeds `ArtifactCache` with canonical bytes/generation/disk_path on success (tensorcast/api/store/artifact.py).
+- `MaterializationPipeline.materialize_subset()` threads `disk_path_hint` and fallback through selective materialization/view inputs and unloads, but does not validate the canonical index format returned by the disk resolver or enforce checksum policy (tensorcast/api/store/materialization.py).
+- Daemon `ResolveArtifactFromDisk` returns `{artifact_id, canonical_index_bytes, generation}` using JSON index bytes from `read_from_artifact_dir`; whitelist gating exists, but `verify_checksums` is unused and no Bazel test covers the RPC (daemon/service/controllers/materialization_controller.cc, proto/tensorcast/daemon/v2/store_daemon.proto).
+- Client wrapper `DaemonCtl.resolve_artifact_from_disk_v2` is present and used by Python tests; coverage is limited to stubbed resolution/cache seeding (`tests/python/api/test_artifact_handle.py::test_from_disk_resolves_once_and_caches_generation`) with no daemon-backed integration or view/materialization cases.
+- Docs mention `from_disk` and cache seeding in tensorcast/api/store/README.md, but architecture docs and rollout/backout levers for disk-path materialization are not yet captured.
+
+# Phases & Milestones
+
+- [x] Phase 1: RPC correctness and proto hygiene
+  - [x] Ensure `ResolveArtifactFromDisk` emits canonical index bytes in the v2 format (not JSON), propagates `generation`, honors `verify_checksums`, and records whitelist/validation telemetry.
+  - [x] Add daemon/Bazel coverage for success, whitelist rejection, bad path, checksum failure, and generation computation; regenerate Buf/Python stubs after proto/build rule updates.
+
+- [x] Phase 2: SDK resolution, caching, and materialization parity
+  - [x] Harden `Artifact` disk-path construction and cache seeding: single resolution per path, TTL/LRU alignment with `ArtifactCache`, and invalidation when generation/disk path mismatch is detected.
+  - [x] Ensure `MaterializationPipeline` always threads `disk_path_hint`/`FallbackOptions.prefer="disk"` through selective fetch, view materialization, batch/prefetch release, and unload calls.
+
+- [x] Phase 3: Validation, docs, and rollout
+  - [x] Add Python tests covering `from_disk` end-to-end (resolution, subset materialization, view composition, release/unload) and cache reuse; include regression cases for stale paths and checksum toggle.
+  - [x] Update docs (`tensorcast/api/store/README.md`, `docs/architecture/architecture-overview.md`, design cross-links) and define rollout/backout toggles with metrics to monitor disk-path usage; publish verification steps.
+
+# Tasks
+- Align `ResolveArtifactFromDisk` implementation with the design: use canonical index bytes, enforce checksum flag in the loader, surface whitelist/validation errors with structured status codes, and add tracing/metrics tags for disk paths (bounded cardinality).
+- Update proto/service definitions if new fields are required (e.g., `view_index_bytes` hint) and regenerate artifacts via `bash tools/build_proto_python.sh`; adjust Bazel deps for any new includes.
+- Strengthen `Artifact` disk-path resolution: debounce repeated RPCs, hydrate `ArtifactCache` with generation/disk_path, reconcile cache entries when disk path differs from the hint, and ensure serialization (`to_dict`) preserves disk hints.
+- Ensure `MaterializationPipeline`/`FallbackResolver` prefer disk automatically when `_disk_path_hint` is set, propagate `verify_checksums`, and pass disk_path to replica unload paths to keep daemon cleanup deterministic.
+- Expand Python tests under `tests/python/api/` for disk flows (resolution, selective materialization, view, release/unload, cache TTL/LRU, checksum flag) and add a Bazel daemon test for `ResolveArtifactFromDisk`; keep tests GPU-free using fake CUDA.
+- Document behavior and operational knobs (env flags, whitelist expectations, metrics) and outline rollout/backout steps for enabling disk-path materialization in production.
+
+# Acceptance Checks
+- [x] `ResolveArtifactFromDisk` returns canonical index bytes + generation in v2 format, respects whitelist/checksum flags, and is covered by `bazel test //daemon:resolve_artifact_from_disk_test --define=use_fake_cuda=true`.
+- [x] `tc.from_disk(path)` resolves once, seeds `ArtifactCache` with `{artifact_id, canonical_index_bytes, generation, disk_path}`, and subsequent `tensor_dict(names=...)` calls use `SourcePreference=DISK` with correct unload calls (validated via Python tests).
+- [x] View/batch/prefetch flows operate identically for disk-backed artifacts (tensor subset, view index hints) without extra daemon index RPCs; cache invalidation triggers on NOT_FOUND/FAILED_PRECONDITION for disk paths.
+- [x] Docs updated and linked (store README, architecture overview, design), and rollout/backout instructions captured; metrics/telemetry validated for disk-path usage.
+- [x] Test suite passes: `uv run pytest tests/python/api/test_artifact_handle.py -k disk`, `uv run pytest tests/python/api/test_materialization_pipeline_v2.py`, and relevant new cases; proto/stub regeneration executed if definitions change.
+
+# Test / Rollout / Backout
+- **Unit/Integration**: `uv run pytest tests/python/api/test_artifact_handle.py -k disk`, `uv run pytest tests/python/api/test_materialization_pipeline_v2.py`, plus new disk/view/batch prefetched cases. For daemon RPC coverage run `bazel test //daemon:resolve_artifact_from_disk_test --define=use_fake_cuda=true`. Regenerate protos with `bash tools/build_proto_python.sh` if proto files change.
+- **Rollout**: Keep `tc.from_disk` behind default enablement but validate in staging with disk whitelist configured; monitor disk resolution/materialization metrics and cache hit/miss counters before enabling broadly.
+- **Backout**: Disable disk-path materialization by removing disk_path hints (force standard artifact_id/key flows) or tightening whitelist entries; invalidate `ArtifactCache` entries for disk artifacts to avoid stale metadata, and fall back to P2P/local replicas.
+
+# Risks & Tracking
+- Disk contents drifting after caching could produce stale metadata; mitigate with generation validation and cache invalidation hooks.
+- Checksum enforcement and whitelist gating may block previously working paths; provide clear errors and an opt-out toggle for development.
+- Canonical index format mismatch (JSON vs. binary) could break the iterator pipeline; add assertions/tests to lock format.
+- Disk-path cardinality in telemetry could explode; sanitize/hash labels and sample where necessary.

--- a/proto/tensorcast/daemon/v1/store_daemon.proto
+++ b/proto/tensorcast/daemon/v1/store_daemon.proto
@@ -167,6 +167,10 @@ message MaterializeReplicaRequest {
   optional string artifact_id = 9; // Content-addressed ID (mi2:...)
   optional string disk_path = 10; // On-disk path for legacy/disk loads
 
+  // When true, enforce descriptor/index checksum validation for disk-backed
+  // artifacts. Defaults to true for backward compatibility.
+  optional bool verify_checksums = 12;
+
   // Note: legacy field disk_path = 1 removed in favor of unified disk_path = 10
 
   string replica_uuid = 2;

--- a/proto/tensorcast/daemon/v2/store_daemon.proto
+++ b/proto/tensorcast/daemon/v2/store_daemon.proto
@@ -9,7 +9,10 @@ import "tensorcast/daemon/v1/store_daemon.proto";
 service StoreDaemonService {
   rpc MaterializeReplica(MaterializeReplicaRequest) returns (MaterializeReplicaResponse) {}
   rpc MaterializeByKey(MaterializeByKeyRequest) returns (MaterializeByKeyResponse) {}
+  rpc ResolveArtifactFromDisk(ResolveArtifactFromDiskRequest) returns (ResolveArtifactFromDiskResponse) {}
   rpc GetMaterializeCapabilities(GetMaterializeCapabilitiesRequest) returns (GetMaterializeCapabilitiesResponse) {}
+  rpc QueryReplicaStatus(QueryReplicaStatusRequest) returns (QueryReplicaStatusResponse) {}
+  rpc ReleaseReplica(ReleaseReplicaRequest) returns (ReleaseReplicaResponse) {}
 }
 
 message DiskFallbackHint {
@@ -37,6 +40,8 @@ message ReplicaTicket {
   string replica_uuid = 1;
   tensorcast.daemon.v1.MaterializeReplicaStatus status = 2;
   google.protobuf.Timestamp created_at = 3;
+  string device_uuid = 4;
+  google.protobuf.Timestamp expires_at = 5;
 }
 
 message MaterializeReplicaRequest {
@@ -73,11 +78,12 @@ message MaterializeReplicaResponse {
   tensorcast.daemon.v1.MemCopyHandle mem_handle = 3;
   tensorcast.daemon.v1.MaterializeReplicaStatus status = 4;
   tensorcast.daemon.v1.MaterializationSource source = 5;
-  bytes canonical_index_json = 6;
+  bytes canonical_index_bytes = 6;
   ViewSubset view_subset = 7;
   repeated TensorPayloadDescriptor payloads = 8;
   ReplicaTicket ticket = 9;
-  bytes view_index_json = 10;
+  bytes view_index_bytes = 10;
+  uint64 generation = 11;
 }
 
 message MaterializeByKeyRequest {
@@ -101,15 +107,44 @@ message MaterializeByKeyResponse {
   string used_disk_path = 3;
   tensorcast.daemon.v1.MemCopyHandle mem_handle = 4;
   tensorcast.daemon.v1.MaterializationSource source = 5;
-  bytes canonical_index_json = 6;
+  bytes canonical_index_bytes = 6;
   ViewSubset view_subset = 7;
   repeated TensorPayloadDescriptor payloads = 8;
   ReplicaTicket ticket = 9;
-  bytes view_index_json = 10;
+  bytes view_index_bytes = 10;
+  uint64 generation = 11;
+}
+
+message ResolveArtifactFromDiskRequest {
+  string disk_path = 1;
+  bool verify_checksums = 2;
+}
+
+message ResolveArtifactFromDiskResponse {
+  string artifact_id = 1;
+  string disk_path = 2;
+  bytes canonical_index_bytes = 3;
+  uint64 generation = 4;
 }
 
 message GetMaterializeCapabilitiesRequest {}
 
 message GetMaterializeCapabilitiesResponse {
   bool supports_view_subset_hash = 1;
+}
+
+message QueryReplicaStatusResponse {
+  ReplicaTicket ticket = 1;
+}
+
+message QueryReplicaStatusRequest {
+  ReplicaTicket ticket = 1;
+}
+
+message ReleaseReplicaRequest {
+  ReplicaTicket ticket = 1;
+}
+
+message ReleaseReplicaResponse {
+  bool released = 1;
 }

--- a/tensorcast/__init__.py
+++ b/tensorcast/__init__.py
@@ -125,6 +125,7 @@ from tensorcast.api import (  # noqa: E402
     save_dict,
 )
 from tensorcast.api.store import (  # noqa: E402
+    from_disk,
     get,
     get_async,
     get_into,
@@ -157,6 +158,7 @@ __all__ = [
     "GetArtifactOptions",
     "calculate_tensor_device_offsets",
     "build_indices_from_safetensors",
+    "from_disk",
     "ArtifactDescriptor",
     "store",
     "register",

--- a/tensorcast/api/_materialize.py
+++ b/tensorcast/api/_materialize.py
@@ -55,6 +55,7 @@ class MaterializationPayload:
     ticket_replica_uuid: str | None = None
     ticket_status: store_daemon_pb2.MaterializeReplicaStatus | None = None
     ticket_created_at_ts: float | None = None
+    ticket_expires_at_ts: float | None = None
 
 
 def _tensor_payload_from_proto(
@@ -91,6 +92,10 @@ def materialize_artifact_v2(
     preference: store_daemon_pb2.SourcePreference | None = None,
     tensor_names: Sequence[str] | None = None,
     verify_checksums: bool = True,
+    view_subset_hash: bytes | None = None,
+    replica_uuid: str | None = None,
+    view_index_hint: bytes | None = None,
+    generation_hint: int | None = None,
 ) -> MaterializationPayload:
     if artifact_id is not None and key is not None:
         raise ValueError("Exactly one of artifact_id or key must be provided")
@@ -122,7 +127,7 @@ def materialize_artifact_v2(
         wait_for_completion=wait_for_completion,
     )
 
-    replica_uuid = new_uuid()
+    replica_uuid_value = replica_uuid or new_uuid()
     disk_path: str | None = disk_path_hint
     view_index_bytes: bytes | None = None
     materialized_source: store_daemon_pb2.MaterializationSource | None = None
@@ -142,7 +147,7 @@ def materialize_artifact_v2(
         if artifact_id is not None:
             response = client.materialize_by_artifact_id_v2(
                 artifact_id=artifact_id,
-                replica_uuid=replica_uuid,
+                replica_uuid=replica_uuid_value,
                 device_uuid=device_uuid_for(dev_id),
                 pinned_allocation_timeout_ms=opts.pinned_allocation_timeout_ms,
                 wait_for_completion=opts.wait_for_completion,
@@ -154,6 +159,7 @@ def materialize_artifact_v2(
                 preference=preference_value,
                 tensor_names=tensor_names,
                 verify_checksums=verify_checksums,
+                view_subset_hash=view_subset_hash,
             )
             if not isinstance(response, store_daemon_v2_pb2.MaterializeReplicaResponse):
                 raise DaemonUnavailable(
@@ -164,12 +170,13 @@ def materialize_artifact_v2(
         elif key is not None:
             response = client.materialize_by_key_v2(
                 key=key or "",
-                replica_uuid=replica_uuid,
+                replica_uuid=replica_uuid_value,
                 device_id=int(dev_id),
                 pinned_allocation_timeout_ms=opts.pinned_allocation_timeout_ms,
                 wait_for_completion=opts.wait_for_completion,
                 return_response=True,
                 tensor_names=tensor_names,
+                view_subset_hash=view_subset_hash,
             )
             if not isinstance(response, store_daemon_v2_pb2.MaterializeByKeyResponse):
                 raise DaemonUnavailable(
@@ -182,7 +189,7 @@ def materialize_artifact_v2(
             # The daemon loads directly from disk via DiskFallbackHint.
             response = client.materialize_by_artifact_id_v2(
                 artifact_id="",
-                replica_uuid=replica_uuid,
+                replica_uuid=replica_uuid_value,
                 device_uuid=device_uuid_for(dev_id),
                 pinned_allocation_timeout_ms=opts.pinned_allocation_timeout_ms,
                 wait_for_completion=opts.wait_for_completion,
@@ -194,6 +201,7 @@ def materialize_artifact_v2(
                 preference=store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK,
                 tensor_names=tensor_names,
                 verify_checksums=verify_checksums,
+                view_subset_hash=view_subset_hash,
             )
             if not isinstance(response, store_daemon_v2_pb2.MaterializeReplicaResponse):
                 raise DaemonUnavailable(
@@ -209,6 +217,7 @@ def materialize_artifact_v2(
     ticket_replica_uuid: str | None = None
     ticket_status: store_daemon_pb2.MaterializeReplicaStatus | None = None
     ticket_created_at_ts: float | None = None
+    ticket_expires_at_ts: float | None = None
     if response.HasField("ticket"):
         ticket_replica_uuid = response.ticket.replica_uuid or None
         ticket_status = response.ticket.status
@@ -216,6 +225,13 @@ def materialize_artifact_v2(
             ticket_created_at_ts = response.ticket.created_at.ToDatetime().timestamp()
         except Exception:  # noqa: BLE001
             ticket_created_at_ts = None
+        try:
+            if response.ticket.HasField("expires_at"):
+                ticket_expires_at_ts = (
+                    response.ticket.expires_at.ToDatetime().timestamp()
+                )
+        except Exception:  # noqa: BLE001
+            ticket_expires_at_ts = None
 
     handle_bytes = b""
     if response.HasField("mem_handle"):
@@ -225,24 +241,47 @@ def materialize_artifact_v2(
             "Daemon returned empty mem_handle for materialization v2"
         )
 
+    view_data_hash: str | None = None
+    try:
+        subset_hash_bytes = (
+            bytes(response.view_subset.subset_hash)
+            if hasattr(response, "view_subset")
+            else b""
+        )
+        if subset_hash_bytes:
+            view_data_hash = subset_hash_bytes.hex()
+    except Exception:  # noqa: BLE001
+        view_data_hash = None
+    if view_data_hash is None and view_subset_hash:
+        view_data_hash = view_subset_hash.hex()
+
     canonical_index_bytes = (
-        bytes(response.canonical_index_json)
-        if hasattr(response, "canonical_index_json")
+        bytes(response.canonical_index_bytes)
+        if hasattr(response, "canonical_index_bytes")
         else b""
     )
+    raw_generation = int(getattr(response, "generation", 0))
+    generation_value: int | None = raw_generation if raw_generation != 0 else None
+    if generation_value is None and generation_hint is not None:
+        generation_value = generation_hint
     if canonical_index_bytes:
         resolved_artifact_id = response.artifact_id or artifact_id or key or ""
     else:
-        if canonical_index_hint is not None:
-            canonical_index_bytes = canonical_index_hint
+        fallback_hint = canonical_index_hint or view_index_hint
+        if fallback_hint is not None:
+            canonical_index_bytes = fallback_hint
             resolved_artifact_id = artifact_id or key or ""
+            if generation_value is None and generation_hint is not None:
+                generation_value = generation_hint
         else:
             raise IndexParseError(
                 f"Failed to fetch canonical index for artifact_id={artifact_id or key or ''}"
             )
 
-    if hasattr(response, "view_index_json") and response.view_index_json:
-        view_index_bytes = bytes(response.view_index_json)
+    if hasattr(response, "view_index_bytes") and response.view_index_bytes:
+        view_index_bytes = bytes(response.view_index_bytes)
+    elif view_index_hint is not None:
+        view_index_bytes = view_index_hint
 
     # Translate descriptors from proto into SDK form.
     device_uuid: str | None
@@ -292,7 +331,7 @@ def materialize_artifact_v2(
             args=(
                 client,
                 artifact_id or key or "",
-                replica_uuid,
+                replica_uuid_value,
                 verification_timeout_ms,
             ),
             daemon=True,
@@ -304,15 +343,17 @@ def materialize_artifact_v2(
         canonical_index_bytes=canonical_index_bytes,
         descriptors=tuple(descriptors),
         payload_iter=_iter,
-        replica_uuid=replica_uuid,
+        replica_uuid=replica_uuid_value,
         disk_path=disk_path,
         view_index_bytes=view_index_bytes,
-        view_data_hash=None,
+        view_data_hash=view_data_hash,
         source=materialized_source,
         device_uuid=device_uuid,
         ticket_replica_uuid=ticket_replica_uuid,
         ticket_status=ticket_status,
         ticket_created_at_ts=ticket_created_at_ts,
+        ticket_expires_at_ts=ticket_expires_at_ts,
+        generation=generation_value,
     )
 
 

--- a/tensorcast/api/_materialize.py
+++ b/tensorcast/api/_materialize.py
@@ -255,11 +255,7 @@ def materialize_artifact_v2(
     if view_data_hash is None and view_subset_hash:
         view_data_hash = view_subset_hash.hex()
 
-    canonical_index_bytes = (
-        bytes(response.canonical_index_bytes)
-        if hasattr(response, "canonical_index_bytes")
-        else b""
-    )
+    canonical_index_bytes = bytes(response.canonical_index_bytes)
     raw_generation = int(getattr(response, "generation", 0))
     generation_value: int | None = raw_generation if raw_generation != 0 else None
     if generation_value is None and generation_hint is not None:

--- a/tensorcast/api/_metrics.py
+++ b/tensorcast/api/_metrics.py
@@ -31,6 +31,10 @@ class _MeterState:
         self._cache_misses: _Counter | None = None
         self._cache_evictions: _Counter | None = None
         self._cache_invalidations: _Counter | None = None
+        self._batch_hits: _Counter | None = None
+        self._batch_coalesced: _Counter | None = None
+        self._batch_latency: _Histogram | None = None
+        self._prefetch_events: _Counter | None = None
         self._disabled = False
 
     @property
@@ -96,6 +100,26 @@ class _MeterState:
                     unit="1",
                     description="Artifact cache invalidations in the TensorCast Store client.",
                 )
+                self._batch_hits = meter.create_counter(
+                    name="tc_store_batch_hits_total",
+                    unit="1",
+                    description="Count of batcher-served tensor fetches.",
+                )
+                self._batch_coalesced = meter.create_counter(
+                    name="tc_store_batch_coalesced_total",
+                    unit="1",
+                    description="Count of coalesced batch RPCs.",
+                )
+                self._batch_latency = meter.create_histogram(
+                    name="tc_store_batch_window_seconds",
+                    unit="s",
+                    description="Observed batch coalescing window durations.",
+                )
+                self._prefetch_events = meter.create_counter(
+                    name="tc_store_prefetch_events_total",
+                    unit="1",
+                    description="Prefetch ticket lifecycle events.",
+                )
             except Exception as exc:  # noqa: BLE001
                 self._disabled = True
                 self._latency = None
@@ -105,6 +129,10 @@ class _MeterState:
                 self._cache_misses = None
                 self._cache_evictions = None
                 self._cache_invalidations = None
+                self._batch_hits = None
+                self._batch_coalesced = None
+                self._batch_latency = None
+                self._prefetch_events = None
                 _logger.debug("Failed to initialise store OTel metrics", exc_info=exc)
                 return False
         return True
@@ -236,6 +264,51 @@ class _MeterState:
                 "Failed to increment cache invalidation counter", exc_info=True
             )
 
+    def increment_batch_hit(self, daemon: str, *, coalesced: bool) -> None:
+        if not self.ensure():
+            return
+        if self._batch_hits is None:
+            return
+        attrs = {"daemon": daemon, "coalesced": coalesced}
+        try:
+            self._batch_hits.add(1, attributes=attrs)
+        except Exception:  # noqa: BLE001
+            _logger.debug("Failed to increment batch hit counter", exc_info=True)
+
+    def increment_batch_coalesced(self, daemon: str) -> None:
+        if not self.ensure():
+            return
+        if self._batch_coalesced is None:
+            return
+        try:
+            self._batch_coalesced.add(1, attributes={"daemon": daemon})
+        except Exception:  # noqa: BLE001
+            _logger.debug("Failed to increment batch coalesced counter", exc_info=True)
+
+    def record_batch_latency(self, daemon: str, duration_s: float) -> None:
+        if not self.ensure():
+            return
+        if self._batch_latency is None:
+            return
+        try:
+            self._batch_latency.record(
+                max(duration_s, 0.0), attributes={"daemon": daemon}
+            )
+        except Exception:  # noqa: BLE001
+            _logger.debug("Failed to record batch latency", exc_info=True)
+
+    def record_prefetch_event(self, daemon: str, status: str) -> None:
+        if not self.ensure():
+            return
+        if self._prefetch_events is None:
+            return
+        try:
+            self._prefetch_events.add(
+                1, attributes={"daemon": daemon, "status": status}
+            )
+        except Exception:  # noqa: BLE001
+            _logger.debug("Failed to record prefetch event", exc_info=True)
+
 
 _METRICS = _MeterState()
 
@@ -290,3 +363,19 @@ def increment_artifact_cache_eviction(daemon: str, *, reason: str | None) -> Non
 
 def increment_artifact_cache_invalidation(daemon: str, *, reason: str | None) -> None:
     _METRICS.increment_cache_invalidation(daemon, reason=reason)
+
+
+def increment_batch_hit(daemon: str, *, coalesced: bool) -> None:
+    _METRICS.increment_batch_hit(daemon, coalesced=coalesced)
+
+
+def increment_batch_coalesced(daemon: str) -> None:
+    _METRICS.increment_batch_coalesced(daemon)
+
+
+def record_batch_latency(daemon: str, duration_s: float) -> None:
+    _METRICS.record_batch_latency(daemon, duration_s)
+
+
+def record_prefetch_event(daemon: str, status: str) -> None:
+    _METRICS.record_prefetch_event(daemon, status)

--- a/tensorcast/api/store/README.md
+++ b/tensorcast/api/store/README.md
@@ -16,12 +16,56 @@ managing clients manually.
   rehydrating a handle, but resolved handles may keep both `artifact_id` and
   `key` so cloning (`with_fallback`) and serialization (`to_dict`/`from_dict`)
   continue to work.
+- `tensorcast.from_disk(path)` / `Store.from_disk(path)` resolve disk-backed
+  artifacts via the daemon `ResolveArtifactFromDisk` RPC, seeding
+  `ArtifactCache` with `canonical_index_bytes` + `generation` and binding a
+  disk-first `FallbackOptions` so materialization prefers the local files
+  without re-fetching metadata.
 - Handles are tied to the originating `Store` lifecycle. After `Store.close()`
   (or `release()` on the handle), materialization raises
   `ArtifactError(status_code="FAILED_PRECONDITION")` while cached metadata
   remains readable for debugging.
 - `with_fallback(...)` clones a handle with different fallback hints; eager
   `get*` APIs remain unchanged.
+
+## View Composition
+
+- `artifact.view(...)`, `.subset(...)`, and `.slice(...)` return derived
+  handles with composed view specs. Parent/child handles keep independent locks
+  and metadata caches so repeated calls avoid daemon lookups.
+- `artifact.view_builder()` exposes a fluent builder for chaining multiple view
+  operations before building a child handle.
+
+## Batching, Async, and Prefetch
+
+- Use `with artifact.batch(device="cuda:0")` to coalesce multiple tensor fetches
+  into a single RPC while keeping sync semantics.
+- Async consumers can `await artifact.tensor_async(...)` or
+  `await artifact.tensor_dict_async(...)`; calls are coalesced by the process
+  `MaterializationBatcher` (1ms window) on the store event loop.
+- `artifact.prefetch(device=...)` issues background materialization
+  (`wait_for_completion=False`) and returns a `PrefetchTicket`; the handle
+  carries the ticket’s `replica_uuid` via `FallbackOptions` for the next fetch.
+
+## Fallback Preferences
+
+`FallbackOptions` now supports explicit source preferences:
+
+- `prefer="auto"` (default) — daemon chooses optimal source
+- `prefer="local"` — disallow P2P; prefer an existing local replica
+- `prefer="p2p"` — allow remote transfer
+- `prefer="disk"` — prioritize disk fallback; pass `disk_path` or rely on key→path
+  mapping
+
+Compatibility flags `prefer_disk` and `allow_p2p` continue to work; setting
+`replica_uuid` hints the daemon to reuse a prefetched replica.
+
+## Feature Toggles
+
+- `TENSORCAST_STORE_ENABLE_BATCHER` (default: enabled) — disable to bypass the
+  async batcher and route `tensor_async` through direct fetches.
+- `TENSORCAST_STORE_ENABLE_PREFETCH` (default: enabled) — disable to prevent
+  `Artifact.prefetch()` from issuing background materialization.
 
 ## Metadata Cache
 
@@ -39,3 +83,6 @@ managing clients manually.
 - Invalidation hooks run after registration, deregistration, and materialization
   errors (`NOT_FOUND`/`FAILED_PRECONDITION`) to keep key→artifact mappings and
   cached indices consistent.
+- Disk resolution (`ResolveArtifactFromDisk`) seeds the cache with
+  `canonical_index_bytes`, `generation`, and `disk_path` so repeated
+  `from_disk` calls avoid extra daemon RPCs and preserve generation metadata.

--- a/tensorcast/api/store/README.md
+++ b/tensorcast/api/store/README.md
@@ -17,10 +17,14 @@ managing clients manually.
   `key` so cloning (`with_fallback`) and serialization (`to_dict`/`from_dict`)
   continue to work.
 - `tensorcast.from_disk(path)` / `Store.from_disk(path)` resolve disk-backed
-  artifacts via the daemon `ResolveArtifactFromDisk` RPC, seeding
-  `ArtifactCache` with `canonical_index_bytes` + `generation` and binding a
-  disk-first `FallbackOptions` so materialization prefers the local files
-  without re-fetching metadata.
+  artifacts via the daemon `ResolveArtifactFromDisk` RPC. The daemon validates
+  descriptor multihashes when `verify_checksums=True`, returns canonical
+  `canonical_index_bytes` + `generation`, and seeds `ArtifactCache` while
+  binding a disk-first `FallbackOptions` so materialization prefers the local
+  files without extra resolver RPCs.
+  Set `verify_checksums=False` on `FallbackOptions.for_disk(...)` to allow
+  descriptor-free local development; checksum validation (and descriptor
+  requirements) remain the default in production.
 - Handles are tied to the originating `Store` lifecycle. After `Store.close()`
   (or `release()` on the handle), materialization raises
   `ArtifactError(status_code="FAILED_PRECONDITION")` while cached metadata
@@ -35,6 +39,9 @@ managing clients manually.
   and metadata caches so repeated calls avoid daemon lookups.
 - `artifact.view_builder()` exposes a fluent builder for chaining multiple view
   operations before building a child handle.
+- Nested slice operations are collapsed into a single narrow so storage offsets
+  are computed exactly once in the derived view (no double-application of the
+  parent slice).
 
 ## Batching, Async, and Prefetch
 
@@ -52,7 +59,8 @@ managing clients manually.
 `FallbackOptions` now supports explicit source preferences:
 
 - `prefer="auto"` (default) — daemon chooses optimal source
-- `prefer="local"` — disallow P2P; prefer an existing local replica
+- `prefer="local"` — disallow P2P; prefer an existing local replica without
+  requiring a disk fallback path
 - `prefer="p2p"` — allow remote transfer
 - `prefer="disk"` — prioritize disk fallback; pass `disk_path` or rely on key→path
   mapping
@@ -83,6 +91,12 @@ Compatibility flags `prefer_disk` and `allow_p2p` continue to work; setting
 - Invalidation hooks run after registration, deregistration, and materialization
   errors (`NOT_FOUND`/`FAILED_PRECONDITION`) to keep key→artifact mappings and
   cached indices consistent.
+- Disk lookups honor cache entries keyed by `disk_path` (not just
+  `artifact_id`) to bypass resolver RPCs; mismatched `disk_path` or `generation`
+  values trigger cache invalidation and a fresh daemon fetch.
 - Disk resolution (`ResolveArtifactFromDisk`) seeds the cache with
   `canonical_index_bytes`, `generation`, and `disk_path` so repeated
   `from_disk` calls avoid extra daemon RPCs and preserve generation metadata.
+- Metadata hydration (`_ensure_metadata`) applies `_set_metadata` while holding
+  the artifact’s reentrant lock so concurrent callers never observe partially
+  populated canonical metadata.

--- a/tensorcast/api/store/__init__.py
+++ b/tensorcast/api/store/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import threading
 import weakref
 from collections.abc import Callable, Mapping, Sequence
@@ -25,6 +26,11 @@ from tensorcast.api._register import RegistrationResult, _register_artifact_core
 from tensorcast.api._runtime import require_runtime
 from tensorcast.api.store.artifact import Artifact, ArtifactDescriptor, TensorMeta
 from tensorcast.api.store.async_ops import ArtifactFuture
+from tensorcast.api.store.batch_context import (
+    BatchContext,
+    MaterializationBatcher,
+    PrefetchTicket,
+)
 from tensorcast.api.store.handles import RegisteredArtifact
 from tensorcast.api.store.materialization import MaterializationPipeline
 from tensorcast.api.store.registration import RegistrationPipeline
@@ -78,6 +84,20 @@ class Store:
             self._runtime,
             self._views,
             materialize_fn=materialize_fn or materialize_artifact_v2,
+        )
+        self._enable_batcher = os.getenv(
+            "TENSORCAST_STORE_ENABLE_BATCHER", "1"
+        ).lower() not in ("0", "false", "no")
+        self._enable_prefetch = os.getenv(
+            "TENSORCAST_STORE_ENABLE_PREFETCH", "1"
+        ).lower() not in ("0", "false", "no")
+        self._batcher: MaterializationBatcher | None = (
+            MaterializationBatcher(
+                self._runtime,
+                self._materialization,
+            )
+            if self._enable_batcher
+            else None
         )
 
     def set_register_fn(self, register_fn: Callable[..., RegistrationResult]) -> None:
@@ -198,13 +218,38 @@ class Store:
         disk_path: str | None = None,
         fallback: FallbackOptions | None = None,
     ) -> Artifact:
+        effective_fallback = fallback
+        if disk_path and fallback is None:
+            effective_fallback = FallbackOptions.for_disk(disk_path)
         return Artifact(
             store_ref=weakref.ref(self),
             artifact_id=artifact_id,
             key=key,
             disk_path=disk_path,
+            fallback=effective_fallback,
+        )
+
+    async def artifact_async(
+        self,
+        *,
+        artifact_id: str | None = None,
+        key: str | None = None,
+        disk_path: str | None = None,
+        fallback: FallbackOptions | None = None,
+    ) -> Artifact:
+        return self.artifact(
+            artifact_id=artifact_id,
+            key=key,
+            disk_path=disk_path,
             fallback=fallback,
         )
+
+    def from_disk(
+        self, path: str, *, fallback: FallbackOptions | None = None
+    ) -> Artifact:
+        disk_path = os.fspath(path)
+        effective_fallback = fallback or FallbackOptions.for_disk(str(disk_path))
+        return self.artifact(disk_path=str(disk_path), fallback=effective_fallback)
 
     def get(
         self,
@@ -405,7 +450,16 @@ class Store:
     def closed(self) -> bool:
         return self._runtime.closed
 
+    @property
+    def batcher(self) -> MaterializationBatcher:
+        if self._batcher is None:
+            raise RuntimeError("Materialization batcher is disabled")
+        return self._batcher
+
     def close(self) -> None:
+        with contextlib.suppress(Exception):
+            if self._batcher is not None:
+                self._batcher.close()
         self._runtime.close()
 
 
@@ -778,11 +832,23 @@ def artifact(
     )
 
 
-def from_disk(path: str, *, fallback: FallbackOptions | None = None) -> Artifact:
-    effective_fallback = fallback or FallbackOptions(
-        disk_path=path, prefer_disk=True, allow_p2p=False
+async def artifact_async(
+    *,
+    artifact_id: str | None = None,
+    key: str | None = None,
+    disk_path: str | None = None,
+    fallback: FallbackOptions | None = None,
+) -> Artifact:
+    return await _coerce_store().artifact_async(
+        artifact_id=artifact_id,
+        key=key,
+        disk_path=disk_path,
+        fallback=fallback,
     )
-    return _coerce_store().artifact(disk_path=path, fallback=effective_fallback)
+
+
+def from_disk(path: str, *, fallback: FallbackOptions | None = None) -> Artifact:
+    return _coerce_store().from_disk(path, fallback=fallback)
 
 
 __all__ = [
@@ -796,6 +862,8 @@ __all__ = [
     "FallbackOptions",
     "LeaseHandle",
     "MaterializationPayload",
+    "MaterializationBatcher",
+    "PrefetchTicket",
     "RegisteredArtifact",
     "ReplicaInfo",
     "RetryPolicy",
@@ -806,9 +874,11 @@ __all__ = [
     "TensorDict",
     "TransformPlacement",
     "artifact",
+    "artifact_async",
     "from_disk",
     "store",
     "shutdown_process_store",
+    "BatchContext",
     "register",
     "register_async",
     "put",

--- a/tensorcast/api/store/artifact.py
+++ b/tensorcast/api/store/artifact.py
@@ -461,7 +461,8 @@ class Artifact:
             raise
         cached = runtime.get_artifact_index_cached(artifact_id)
         if cached:
-            self._hydrate_from_cache_entry(cached)
+            with self._lock:
+                self._hydrate_from_cache_entry(cached)
             return True
         try:
             canonical_index_bytes = runtime.ensure_client().get_artifact_index_by_id(
@@ -476,12 +477,14 @@ class Artifact:
                 return False
             raise error from exc
         canonical_index = canonical_index_from_bytes(canonical_index_bytes)
-        self._set_metadata(
-            canonical_index_bytes,
-            canonical_index,
-            generation=self._generation,
-            disk_path=self._disk_path_hint,
-        )
+        with self._lock:
+            if self._canonical_index is None or self._canonical_index_bytes is None:
+                self._set_metadata(
+                    canonical_index_bytes,
+                    canonical_index,
+                    generation=self._generation,
+                    disk_path=self._disk_path_hint,
+                )
         runtime.cache_artifact_index(
             ArtifactCacheEntry(
                 artifact_id=artifact_id,
@@ -606,6 +609,11 @@ class Artifact:
                 self._artifact_id = artifact_id
                 return artifact_id
             if self._disk_path_hint:
+                cached = runtime.get_artifact_index_by_disk_path(self._disk_path_hint)
+                if cached and cached.artifact_id:
+                    self._artifact_id = cached.artifact_id
+                    self._hydrate_from_cache_entry(cached)
+                    return cached.artifact_id
                 verify_checksums = True
                 if self._fallback is not None:
                     verify_checksums = bool(self._fallback.verify_checksums)
@@ -674,6 +682,10 @@ class Artifact:
                 retryable=False,
             )
         artifact_id = self._ensure_identified()
+        cache_generation: int | None = None
+        cache_disk_path: str | None = None
+        generation_hint: int | None = None
+        disk_path_hint: str | None = None
         with self._lock:
             if (
                 self._canonical_index is not None
@@ -682,33 +694,71 @@ class Artifact:
                 return self._canonical_index
             cached = runtime.get_artifact_index_cached(artifact_id)
             if cached:
-                self._hydrate_from_cache_entry(cached)
-                assert self._canonical_index is not None
-                return self._canonical_index
-            try:
-                canonical_index_bytes = (
-                    runtime.ensure_client().get_artifact_index_by_id(artifact_id)
+                has_disk_mismatch = bool(
+                    self._disk_path_hint
+                    and cached.disk_path
+                    and cached.disk_path != self._disk_path_hint
                 )
-            except Exception as exc:  # noqa: BLE001
-                raise map_materialization_error(exc) from exc
-            canonical_index = canonical_index_from_bytes(canonical_index_bytes)
-        self._set_metadata(
-            canonical_index_bytes,
-            canonical_index,
-            generation=self._generation,
-            disk_path=self._disk_path_hint,
-        )
+                has_generation_mismatch = bool(
+                    self._generation is not None
+                    and cached.generation is not None
+                    and cached.generation != self._generation
+                )
+                if has_disk_mismatch or has_generation_mismatch:
+                    runtime.invalidate_artifact(
+                        artifact_id,
+                        reason="disk_path_mismatch"
+                        if has_disk_mismatch
+                        else "generation_mismatch",
+                    )
+                else:
+                    self._hydrate_from_cache_entry(cached)
+                    assert self._canonical_index is not None
+                    return self._canonical_index
+            generation_hint = self._generation
+            disk_path_hint = self._disk_path_hint
+        try:
+            canonical_index_bytes = runtime.ensure_client().get_artifact_index_by_id(
+                artifact_id
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise map_materialization_error(exc) from exc
+        canonical_index = canonical_index_from_bytes(canonical_index_bytes)
+        with self._lock:
+            if (
+                self._canonical_index is not None
+                and self._canonical_index_bytes is not None
+            ):
+                result_index = self._canonical_index
+                cache_bytes = self._canonical_index_bytes or canonical_index_bytes
+                cache_generation = self._generation
+                cache_disk_path = self._disk_path_hint
+            else:
+                generation_value = self._generation
+                if generation_value is None:
+                    generation_value = generation_hint
+                disk_path_value = self._disk_path_hint or disk_path_hint
+                self._set_metadata(
+                    canonical_index_bytes,
+                    canonical_index,
+                    generation=generation_value,
+                    disk_path=disk_path_value,
+                )
+                result_index = canonical_index
+                cache_bytes = canonical_index_bytes
+                cache_generation = self._generation
+                cache_disk_path = self._disk_path_hint
         runtime.cache_artifact_index(
             ArtifactCacheEntry(
                 artifact_id=artifact_id,
-                canonical_index_bytes=canonical_index_bytes,
-                parsed_index=canonical_index,
-                generation=self._generation,
-                disk_path=self._disk_path_hint,
+                canonical_index_bytes=cache_bytes,
+                parsed_index=result_index,
+                generation=cache_generation,
+                disk_path=cache_disk_path,
                 expires_at=time.monotonic(),
             )
         )
-        return canonical_index
+        return result_index
 
     def _effective_index(self) -> CanonicalIndex:
         base_index = self._ensure_metadata()

--- a/tensorcast/api/store/artifact.py
+++ b/tensorcast/api/store/artifact.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import threading
 import time
 import weakref
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Mapping, Sequence, cast
 
 import torch
 
+from tensorcast.api._view_ops import (
+    SliceSpec,
+    ViewSpecBuildResult,
+    _coerce_slice_spec,
+    build_view_spec,
+)
 from tensorcast.api.store.cache import ArtifactCacheEntry
 from tensorcast.api.store.common import canonical_index_from_bytes
 from tensorcast.api.store.materialization import MaterializationPipeline
@@ -21,9 +28,15 @@ from tensorcast.api.store.types import (
     CanonicalIndexEntry,
     FallbackOptions,
 )
+from tensorcast.api.store.view_composer import (
+    ViewBuilder,
+    ViewMetadataCache,
+    ViewSpecComposer,
+)
 
 if TYPE_CHECKING:
     from tensorcast.api.store import Store
+    from tensorcast.api.store.batch_context import BatchContext, PrefetchTicket
     from tensorcast.api.store.runtime import StoreRuntimeContext
 
 
@@ -50,23 +63,35 @@ def _fallback_to_dict(fallback: FallbackOptions | None) -> dict[str, object] | N
     if fallback is None:
         return None
     return {
+        "prefer": fallback.prefer,
         "disk_path": fallback.disk_path,
-        "prefer_disk": bool(fallback.prefer_disk),
+        "prefer_disk": (
+            bool(fallback.prefer_disk) if fallback.prefer_disk is not None else None
+        ),
         "allow_p2p": bool(fallback.allow_p2p),
         "verify_checksums": bool(fallback.verify_checksums),
+        "replica_uuid": fallback.replica_uuid,
     }
 
 
 def _fallback_from_dict(data: Mapping[str, object] | None) -> FallbackOptions | None:
     if data is None:
         return None
+    prefer_value = data.get("prefer")
+    prefer = prefer_value if isinstance(prefer_value, str) else "auto"
     disk_path_value = data.get("disk_path")
     disk_path = disk_path_value if isinstance(disk_path_value, str) else None
+    prefer_disk_raw = data.get("prefer_disk")
+    prefer_disk = prefer_disk_raw if isinstance(prefer_disk_raw, bool) else None
+    replica_uuid_value = data.get("replica_uuid")
+    replica_uuid = replica_uuid_value if isinstance(replica_uuid_value, str) else None
     return FallbackOptions(
+        prefer=prefer,  # pyright: ignore[reportArgumentType]
         disk_path=disk_path,
-        prefer_disk=bool(data.get("prefer_disk", False)),
+        prefer_disk=prefer_disk,
         allow_p2p=bool(data.get("allow_p2p", True)),
         verify_checksums=bool(data.get("verify_checksums", True)),
+        replica_uuid=replica_uuid,
     )
 
 
@@ -95,6 +120,9 @@ class Artifact:
         canonical_index_bytes: bytes | None = None,
         canonical_index: CanonicalIndex | None = None,
         generation: int | None = None,
+        view_spec: ViewSpecBuildResult | None = None,
+        view_metadata: ViewMetadataCache | None = None,
+        view_depth: int = 0,
     ) -> None:
         identifiers = [bool(artifact_id), bool(key), bool(disk_path)]
         if sum(identifiers) == 0:
@@ -110,9 +138,17 @@ class Artifact:
         self._canonical_index_bytes = canonical_index_bytes
         self._canonical_index = canonical_index
         self._tensor_metas: dict[str, TensorMeta] | None = None
-        if canonical_index is not None:
+        self._view_spec = view_spec
+        self._view_metadata = view_metadata
+        self._view_depth = max(0, int(view_depth))
+        effective_index = (
+            view_metadata.canonical_index
+            if view_metadata is not None
+            else canonical_index
+        )
+        if effective_index is not None:
             self._tensor_metas = {
-                entry.name: _meta_from_entry(entry) for entry in canonical_index.entries
+                entry.name: _meta_from_entry(entry) for entry in effective_index.entries
             }
         self._generation = generation
         self._store_ref = store_ref
@@ -132,11 +168,11 @@ class Artifact:
 
     @property
     def tensor_names(self) -> tuple[str, ...]:
-        canonical_index = self._ensure_metadata()
+        canonical_index = self._effective_index()
         return tuple(entry.name for entry in canonical_index.entries)
 
     def tensor_meta(self, name: str) -> TensorMeta:
-        canonical_index = self._ensure_metadata()
+        canonical_index = self._effective_index()
         metas = self._tensor_metas or {}
         if name in metas:
             return metas[name]
@@ -153,7 +189,7 @@ class Artifact:
         )
 
     def describe(self) -> ArtifactDescriptor:
-        canonical_index = self._ensure_metadata()
+        canonical_index = self._effective_index()
         metas = self._tensor_metas or {
             entry.name: _meta_from_entry(entry) for entry in canonical_index.entries
         }
@@ -172,17 +208,30 @@ class Artifact:
         device: torch.device | str,
         names: Sequence[str] | None = None,
     ) -> dict[str, torch.Tensor]:
-        canonical_index = self._ensure_metadata()
-        requested_names = self._validate_tensor_names(canonical_index, names)
+        artifact_id = self._ensure_identified()
+        effective_index = self._effective_index()
+        requested_names = self._validate_tensor_names(effective_index, names)
         store, runtime, pipeline = self._require_components()
+        view_spec_proto = self._view_spec.proto if self._view_spec else None
+        view_data_hash = (
+            self._view_metadata.view_data_hash if self._view_metadata else None
+        )
+        view_index_hint = (
+            self._view_metadata.view_index_bytes if self._view_metadata else None
+        )
+        replica_uuid = self._fallback.replica_uuid if self._fallback else None
         payload, _ = pipeline.materialize_subset(
-            artifact_id=self._artifact_id,
+            artifact_id=artifact_id,
             key=None,
             device=device,
             fallback=self._fallback,
             tensor_names=requested_names,
             canonical_index_hint=self._canonical_index_bytes,
             disk_path_hint=self._disk_path_hint,
+            view_spec=view_spec_proto,
+            view_data_hash=view_data_hash,
+            view_index_hint=view_index_hint,
+            replica_uuid=replica_uuid,
         )
         try:
             self._update_metadata_from_payload(payload, runtime)
@@ -216,15 +265,164 @@ class Artifact:
         *,
         device: torch.device | str | None = None,
     ) -> None:
-        canonical_index = self._ensure_metadata()
-        _ = self._validate_tensor_names(canonical_index, None)
+        artifact_id = self._ensure_identified()
+        effective_index = self._effective_index()
+        _ = self._validate_tensor_names(effective_index, None)
         _, _, pipeline = self._require_components()
+        view_spec_proto = self._view_spec.proto if self._view_spec else None
+        view_data_hash = (
+            self._view_metadata.view_data_hash if self._view_metadata else None
+        )
+        view_index_hint = (
+            self._view_metadata.view_index_bytes if self._view_metadata else None
+        )
+        replica_uuid = self._fallback.replica_uuid if self._fallback else None
         pipeline.get_into(
             target,
-            artifact_id=self._artifact_id,
+            artifact_id=artifact_id,
             key=None,
             device=device,
             fallback=self._fallback,
+            view_spec=view_spec_proto,
+            view_data_hash=view_data_hash,
+            view_index_hint=view_index_hint,
+            replica_uuid=replica_uuid,
+        )
+
+    def view(
+        self,
+        *,
+        slices: Mapping[str, Sequence[object]] | None = None,
+        transpose: Mapping[str, Sequence[tuple[int, int]]] | None = None,
+        names: Sequence[str] | None = None,
+    ) -> Artifact:
+        return self._derive_view(
+            slices=slices,
+            transpose=transpose,
+            subset=list(names) if names is not None else None,
+            composer=ViewSpecComposer(),
+        )
+
+    def subset(self, names: Sequence[str]) -> Artifact:
+        return self.view(names=names)
+
+    def slice(self, slices: Mapping[str, Sequence[object]]) -> Artifact:
+        return self.view(slices=slices)
+
+    def view_builder(self) -> ViewBuilder:
+        return ViewBuilder(artifact_ref=weakref.ref(self), composer=ViewSpecComposer())
+
+    def batch(self, *, device: torch.device | str) -> "BatchContext":
+        from tensorcast.api.store.batch_context import BatchContext
+
+        return BatchContext(self, device=device)
+
+    async def tensor_async(
+        self, name: str, *, device: torch.device | str
+    ) -> torch.Tensor:
+        store = self._store_ref() if self._store_ref is not None else None
+        if store is None or store.closed or self._released:
+            raise ArtifactError(
+                "Artifact handle is released or store is closed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        self._ensure_identified()
+        loop = asyncio.get_running_loop()
+        view_hash = None
+        if self._view_metadata is not None:
+            view_hash = self._view_metadata.view_data_hash
+        elif self._view_spec is not None:
+            view_hash = ViewSpecComposer.hash_view_spec(self._view_spec)
+        batcher = getattr(store, "_batcher", None)
+        if batcher is None:
+            return await loop.run_in_executor(
+                None, lambda: self.tensor(name, device=device)
+            )
+        future = batcher.submit(
+            self,
+            name,
+            device=device,
+            view_hash=view_hash,
+            target_loop=loop,
+        )
+        return await future
+
+    async def tensor_dict_async(
+        self,
+        *,
+        device: torch.device | str,
+        names: Sequence[str] | None = None,
+    ) -> dict[str, torch.Tensor]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self.tensor_dict(device=device, names=names)
+        )
+
+    def prefetch(self, *, device: torch.device | str) -> "PrefetchTicket":
+        from tensorcast.api._config import GetArtifactOptions
+
+        artifact_id = self._ensure_identified()
+        store, runtime, pipeline = self._require_components()
+        if getattr(store, "_enable_prefetch", True) is False:
+            raise ArtifactError(
+                "Prefetch is disabled",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        view_spec_proto = self._view_spec.proto if self._view_spec else None
+        view_data_hash = (
+            self._view_metadata.view_data_hash if self._view_metadata else None
+        )
+        view_index_hint = (
+            self._view_metadata.view_index_bytes if self._view_metadata else None
+        )
+        opts = GetArtifactOptions(wait_for_completion=False, enable_verification=False)
+        replica_uuid = self._fallback.replica_uuid if self._fallback else None
+        payload, _ = pipeline.materialize_subset(
+            artifact_id=artifact_id,
+            key=None,
+            device=device,
+            fallback=self._fallback,
+            tensor_names=None,
+            canonical_index_hint=self._canonical_index_bytes,
+            disk_path_hint=self._disk_path_hint,
+            view_spec=view_spec_proto,
+            view_data_hash=view_data_hash,
+            view_index_hint=view_index_hint,
+            replica_uuid=replica_uuid,
+            options=opts,
+        )
+        replica = (
+            payload.ticket_replica_uuid or payload.replica_uuid or replica_uuid or ""
+        )
+        expires_at: float | None = payload.ticket_expires_at_ts
+        if expires_at is None and payload.ticket_created_at_ts is not None:
+            expires_at = payload.ticket_created_at_ts + 30.0
+        from tensorcast.api.store.batch_context import PrefetchTicket
+
+        fallback_with_ticket = (
+            replace(self._fallback, replica_uuid=replica)
+            if self._fallback is not None
+            else FallbackOptions(replica_uuid=replica)
+        )
+        self._fallback = fallback_with_ticket
+        try:
+            from tensorcast.api import _metrics as store_metrics
+
+            store_metrics.record_prefetch_event(
+                runtime.daemon_endpoint, status="issued"
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        return PrefetchTicket(
+            replica_uuid=replica,
+            artifact_id=artifact_id,
+            device=torch.device(device),
+            expires_at=expires_at,
+            started_at=time.monotonic(),
+            view_hash=view_data_hash,
+            runtime_ref=weakref.ref(runtime),
         )
 
     def with_fallback(self, fallback: FallbackOptions) -> Artifact:
@@ -237,6 +435,9 @@ class Artifact:
             canonical_index_bytes=self._canonical_index_bytes,
             canonical_index=self._canonical_index,
             generation=self._generation,
+            view_spec=self._view_spec,
+            view_metadata=self._view_metadata,
+            view_depth=self._view_depth,
         )
         clone._released = self._released
         clone._tensor_metas = dict(self._tensor_metas or {})
@@ -405,11 +606,54 @@ class Artifact:
                 self._artifact_id = artifact_id
                 return artifact_id
             if self._disk_path_hint:
-                raise ArtifactError(
-                    "Disk-backed artifact handles are not supported yet",
-                    status_code="UNIMPLEMENTED",
-                    retryable=False,
+                verify_checksums = True
+                if self._fallback is not None:
+                    verify_checksums = bool(self._fallback.verify_checksums)
+                try:
+                    resolved = runtime.ensure_client().resolve_artifact_from_disk_v2(
+                        disk_path=self._disk_path_hint,
+                        verify_checksums=verify_checksums,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    raise map_materialization_error(exc) from exc
+                artifact_id = getattr(resolved, "artifact_id", "") or None
+                if not artifact_id:
+                    raise ArtifactError(
+                        f"Failed to resolve artifact from disk path '{self._disk_path_hint}'",
+                        status_code="NOT_FOUND",
+                        retryable=False,
+                    )
+                disk_path = getattr(resolved, "disk_path", "") or self._disk_path_hint
+                canonical_index_bytes = bytes(
+                    getattr(resolved, "canonical_index_bytes", b"") or b""
                 )
+                generation_raw = getattr(resolved, "generation", 0)
+                generation = int(generation_raw) if generation_raw else None
+                canonical_index = None
+                if canonical_index_bytes:
+                    canonical_index = canonical_index_from_bytes(canonical_index_bytes)
+                    self._set_metadata(
+                        canonical_index_bytes,
+                        canonical_index,
+                        generation=generation,
+                        disk_path=disk_path,
+                    )
+                    runtime.cache_artifact_index(
+                        ArtifactCacheEntry(
+                            artifact_id=artifact_id,
+                            canonical_index_bytes=canonical_index_bytes,
+                            parsed_index=canonical_index,
+                            generation=generation,
+                            disk_path=disk_path,
+                            expires_at=time.monotonic(),
+                        )
+                    )
+                elif generation is not None and self._generation is None:
+                    self._generation = generation
+                self._artifact_id = artifact_id
+                if disk_path and not self._disk_path_hint:
+                    self._disk_path_hint = disk_path
+                return artifact_id
             raise ArtifactError(
                 "Artifact handle missing identity",
                 status_code="FAILED_PRECONDITION",
@@ -448,23 +692,121 @@ class Artifact:
             except Exception as exc:  # noqa: BLE001
                 raise map_materialization_error(exc) from exc
             canonical_index = canonical_index_from_bytes(canonical_index_bytes)
-            self._set_metadata(
-                canonical_index_bytes,
-                canonical_index,
+        self._set_metadata(
+            canonical_index_bytes,
+            canonical_index,
+            generation=self._generation,
+            disk_path=self._disk_path_hint,
+        )
+        runtime.cache_artifact_index(
+            ArtifactCacheEntry(
+                artifact_id=artifact_id,
+                canonical_index_bytes=canonical_index_bytes,
+                parsed_index=canonical_index,
                 generation=self._generation,
                 disk_path=self._disk_path_hint,
+                expires_at=time.monotonic(),
             )
-            runtime.cache_artifact_index(
-                ArtifactCacheEntry(
-                    artifact_id=artifact_id,
-                    canonical_index_bytes=canonical_index_bytes,
-                    parsed_index=canonical_index,
-                    generation=self._generation,
-                    disk_path=self._disk_path_hint,
-                    expires_at=time.monotonic(),
-                )
+        )
+        return canonical_index
+
+    def _effective_index(self) -> CanonicalIndex:
+        base_index = self._ensure_metadata()
+        if self._view_metadata is not None:
+            return self._view_metadata.canonical_index
+        return base_index
+
+    @staticmethod
+    def _normalize_view_inputs(
+        *,
+        slices: Mapping[str, Sequence[object]] | None,
+        transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
+    ) -> tuple[
+        Mapping[str, SliceSpec] | None, Mapping[str, Sequence[tuple[int, int]]] | None
+    ]:
+        if slices is not None and not isinstance(slices, Mapping):
+            raise ArtifactError(
+                "Slice spec must be a mapping of tensor name to slice",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
             )
-            return canonical_index
+        if transpose is not None and not isinstance(transpose, Mapping):
+            raise ArtifactError(
+                "Transpose spec must be a mapping of tensor name to dim pairs",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+
+        typed_slices: dict[str, SliceSpec] | None = None
+        if slices:
+            typed_slices = {}
+            for name, spec_seq in slices.items():
+                if not isinstance(spec_seq, Sequence) or not spec_seq:
+                    raise ArtifactError(
+                        f"Slice spec for '{name}' must be a non-empty sequence",
+                        status_code="INVALID_ARGUMENT",
+                        retryable=False,
+                    )
+                typed_slices[name] = _coerce_slice_spec(spec_seq)
+
+        if transpose:
+            for name, ops in transpose.items():
+                if not isinstance(ops, Sequence) or not ops:
+                    raise ArtifactError(
+                        f"Transpose spec for '{name}' must be a non-empty sequence",
+                        status_code="INVALID_ARGUMENT",
+                        retryable=False,
+                    )
+        return typed_slices, transpose
+
+    def _derive_view(
+        self,
+        *,
+        slices: Mapping[str, Sequence[object]] | None,
+        transpose: Mapping[str, Sequence[tuple[int, int]]] | None,
+        subset: Sequence[str] | None,
+        composer: ViewSpecComposer,
+    ) -> Artifact:
+        if self._released:
+            raise ArtifactError(
+                "Artifact handle is released",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        self._ensure_metadata()
+        typed_slices, normalized_transpose = self._normalize_view_inputs(
+            slices=slices,
+            transpose=transpose,
+        )
+        base_index = self._effective_index()
+        entry_shapes = {entry.name: tuple(entry.shape) for entry in base_index.entries}
+        child_spec: ViewSpecBuildResult | None = None
+        if typed_slices or normalized_transpose:
+            child_spec = build_view_spec(
+                entry_shapes=entry_shapes,
+                slices=typed_slices,
+                transpose=normalized_transpose,
+            )
+        composed_spec, view_cache, depth = composer.compose(
+            canonical_index=base_index,
+            parent_spec=self._view_spec,
+            child_spec=child_spec,
+            parent_depth=self._view_depth,
+            subset_names=subset,
+        )
+        return Artifact(
+            store_ref=self._store_ref,
+            artifact_id=self._artifact_id,
+            key=self._key_hint,
+            disk_path=self._disk_path_hint,
+            fallback=self._fallback,
+            canonical_index_bytes=self._canonical_index_bytes,
+            canonical_index=self._canonical_index,
+            generation=self._generation,
+            view_spec=composed_spec,
+            view_metadata=view_cache,
+            view_depth=depth,
+        )
 
     def _hydrate_from_cache_entry(self, entry: ArtifactCacheEntry) -> None:
         self._set_metadata(
@@ -487,41 +829,70 @@ class Artifact:
         self._generation = generation
         if disk_path and not self._disk_path_hint:
             self._disk_path_hint = disk_path
-        self._tensor_metas = {
-            entry.name: _meta_from_entry(entry) for entry in canonical_index.entries
-        }
+        effective_index = (
+            self._view_metadata.canonical_index
+            if self._view_metadata is not None
+            else canonical_index
+        )
+        if effective_index is not None:
+            self._tensor_metas = {
+                entry.name: _meta_from_entry(entry) for entry in effective_index.entries
+            }
 
     def _update_metadata_from_payload(
         self, payload, runtime: StoreRuntimeContext
     ) -> None:
-        try:
-            canonical_index_bytes = payload.canonical_index_bytes
-        except Exception:  # noqa: BLE001
-            return
-        if not canonical_index_bytes:
-            return
-        canonical_index = canonical_index_from_bytes(canonical_index_bytes)
         artifact_id = self._artifact_id
         if not artifact_id:
             return
-        with self._lock:
-            if self._canonical_index is None:
-                self._set_metadata(
-                    canonical_index_bytes,
-                    canonical_index,
-                    generation=getattr(payload, "generation", None),
-                    disk_path=getattr(payload, "disk_path", None),
+        canonical_index_bytes = getattr(payload, "canonical_index_bytes", b"") or b""
+        view_index_bytes = getattr(payload, "view_index_bytes", b"") or b""
+        generation = getattr(payload, "generation", None)
+        disk_path = getattr(payload, "disk_path", None)
+
+        if canonical_index_bytes:
+            canonical_index = canonical_index_from_bytes(canonical_index_bytes)
+            with self._lock:
+                if self._canonical_index is None:
+                    self._set_metadata(
+                        canonical_index_bytes,
+                        canonical_index,
+                        generation=generation,
+                        disk_path=disk_path,
+                    )
+            runtime.cache_artifact_index(
+                ArtifactCacheEntry(
+                    artifact_id=artifact_id,
+                    canonical_index_bytes=canonical_index_bytes,
+                    parsed_index=canonical_index,
+                    generation=generation,
+                    disk_path=disk_path,
+                    expires_at=time.monotonic(),
                 )
-        runtime.cache_artifact_index(
-            ArtifactCacheEntry(
-                artifact_id=artifact_id,
-                canonical_index_bytes=canonical_index_bytes,
-                parsed_index=canonical_index,
-                generation=getattr(payload, "generation", None),
-                disk_path=getattr(payload, "disk_path", None),
-                expires_at=time.monotonic(),
             )
-        )
+
+        if view_index_bytes:
+            view_index = canonical_index_from_bytes(view_index_bytes)
+            view_hash = getattr(payload, "view_data_hash", None)
+            subset_names = tuple(entry.name for entry in view_index.entries)
+            if view_hash is None:
+                view_hash = ViewSpecComposer.hash_view_spec(
+                    self._view_spec, subset=subset_names
+                )
+            view_cache = ViewMetadataCache(
+                view_id=str(view_hash),
+                view_index_bytes=view_index_bytes,
+                view_data_hash=str(view_hash),
+                tensor_names=subset_names,
+                nbytes=sum(entry.size_bytes for entry in view_index.entries),
+                canonical_index=view_index,
+            )
+            with self._lock:
+                self._view_metadata = view_cache
+                self._view_depth = max(self._view_depth, 1)
+                self._tensor_metas = {
+                    entry.name: _meta_from_entry(entry) for entry in view_index.entries
+                }
 
     @staticmethod
     def _validate_tensor_names(

--- a/tensorcast/api/store/batch_context.py
+++ b/tensorcast/api/store/batch_context.py
@@ -1,0 +1,341 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+# Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import queue
+import threading
+import time
+import weakref
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Mapping
+
+import torch
+
+from tensorcast.api import _metrics as store_metrics
+from tensorcast.api.store.types import ArtifactError
+from tensorcast.proto.daemon.v2 import store_daemon_pb2 as store_daemon_v2_pb2
+
+if TYPE_CHECKING:
+    from tensorcast.api.store.artifact import Artifact
+    from tensorcast.api.store.materialization import MaterializationPipeline
+    from tensorcast.api.store.runtime import StoreRuntimeContext
+
+
+@dataclass(slots=True)
+class PendingFetch:
+    artifact_ref: weakref.ReferenceType["Artifact"]
+    tensor_name: str
+    device: torch.device | str
+    target_loop: asyncio.AbstractEventLoop
+    future: asyncio.Future[torch.Tensor]
+    batch_key: tuple[str, str, str]
+    submitted_at: float
+
+
+@dataclass(slots=True)
+class _BatchGroup:
+    key: tuple[str, str, str]
+    fetches: list[PendingFetch]
+    deadline: float
+
+
+class BatchContext:
+    """Synchronous batching context manager for grouped tensor fetches."""
+
+    def __init__(self, artifact: "Artifact", *, device: torch.device | str) -> None:
+        self._artifact_ref = weakref.ref(artifact)
+        self._device = device
+        self._names: list[str] = []
+        self._materialized: dict[str, torch.Tensor] | None = None
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def __enter__(self) -> "BatchContext":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._closed = True
+        if exc_type is None:
+            self._ensure_materialized()
+
+    def add(self, name: str) -> None:
+        if self._closed:
+            raise ArtifactError(
+                "BatchContext is closed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        self._names.append(name)
+
+    def _ensure_materialized(self) -> None:
+        with self._lock:
+            if self._materialized is not None:
+                return
+        artifact = self._artifact_ref()
+        if artifact is None:
+            raise ArtifactError(
+                "Artifact no longer available",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        tensors = artifact.tensor_dict(device=self._device, names=self._names or None)
+        with self._lock:
+            self._materialized = tensors
+
+    def get(self, name: str) -> torch.Tensor:
+        self._ensure_materialized()
+        assert self._materialized is not None
+        if name not in self._materialized:
+            raise ArtifactError(
+                f"Tensor '{name}' not found in batch result",
+                status_code="NOT_FOUND",
+                retryable=False,
+            )
+        return self._materialized[name]
+
+    @property
+    def tensors(self) -> Mapping[str, torch.Tensor]:
+        self._ensure_materialized()
+        assert self._materialized is not None
+        return dict(self._materialized)
+
+
+class MaterializationBatcher:
+    """Coalesces async tensor fetches within a short dispatch window."""
+
+    def __init__(
+        self,
+        runtime: "StoreRuntimeContext",
+        pipeline: "MaterializationPipeline",
+        *,
+        window_ms: float = 1.0,
+    ) -> None:
+        self._runtime = runtime
+        self._pipeline_ref = weakref.ref(pipeline)
+        self._window_ms = max(0.1, float(window_ms))
+        self._pending_queue: queue.Queue[PendingFetch] = queue.Queue()
+        self._groups: dict[tuple[str, str, str], _BatchGroup] = {}
+        self._group_lock = threading.Lock()
+        self._shutdown = threading.Event()
+        self._dispatch_thread = threading.Thread(
+            target=self._dispatch_loop,
+            daemon=True,
+            name="MaterializationBatcher-Dispatch",
+        )
+        self._dispatch_thread.start()
+
+    def close(self) -> None:
+        if self._shutdown.is_set():
+            return
+        self._shutdown.set()
+        self._dispatch_thread.join(timeout=1.0)
+
+    @staticmethod
+    def _device_key(device: torch.device | str) -> str:
+        dev = torch.device(device)
+        if dev.type == "cuda":
+            return f"cuda:{dev.index or 0}"
+        return str(dev)
+
+    def submit(
+        self,
+        artifact: "Artifact",
+        tensor_name: str,
+        *,
+        device: torch.device | str,
+        view_hash: str | None,
+        target_loop: asyncio.AbstractEventLoop,
+    ) -> asyncio.Future[torch.Tensor]:
+        artifact_id = artifact.artifact_id
+        future: asyncio.Future[torch.Tensor] = target_loop.create_future()
+        batch_key = (artifact_id, view_hash or "", self._device_key(device))
+        fetch = PendingFetch(
+            artifact_ref=weakref.ref(artifact),
+            tensor_name=tensor_name,
+            device=device,
+            target_loop=target_loop,
+            future=future,
+            batch_key=batch_key,
+            submitted_at=time.monotonic(),
+        )
+        self._pending_queue.put_nowait(fetch)
+        return future
+
+    def _dispatch_loop(self) -> None:
+        while not self._shutdown.is_set():
+            try:
+                fetch = self._pending_queue.get(timeout=self._window_ms / 1000.0)
+                self._assign(fetch)
+            except queue.Empty:
+                pass
+            self._flush_ready()
+
+    def _assign(self, fetch: PendingFetch) -> None:
+        with self._group_lock:
+            group = self._groups.get(fetch.batch_key)
+            if group is None:
+                deadline = time.monotonic() + self._window_ms / 1000.0
+                group = _BatchGroup(
+                    key=fetch.batch_key,
+                    fetches=[],
+                    deadline=deadline,
+                )
+                self._groups[fetch.batch_key] = group
+            group.fetches.append(fetch)
+
+    def _flush_ready(self) -> None:
+        now = time.monotonic()
+        ready: list[_BatchGroup] = []
+        with self._group_lock:
+            expired_keys = [
+                key for key, grp in self._groups.items() if grp.deadline <= now
+            ]
+            ready.extend(self._groups.pop(key) for key in expired_keys)
+        for group in ready:
+            self._dispatch_group(group)
+
+    def _dispatch_group(self, group: _BatchGroup) -> None:
+        loop = self._runtime.event_loop
+        start_time = min(fetch.submitted_at for fetch in group.fetches)
+        window = max(0.0, time.monotonic() - start_time)
+        store_metrics.record_batch_latency(self._runtime.daemon_endpoint, window)
+        if len(group.fetches) > 1:
+            store_metrics.increment_batch_coalesced(self._runtime.daemon_endpoint)
+        coro = self._materialize_group(group)
+        asyncio.run_coroutine_threadsafe(coro, loop)
+
+    def _set_result(
+        self, fetch: PendingFetch, tensor: torch.Tensor | None, error: Exception | None
+    ) -> None:
+        if fetch.future.cancelled() or fetch.future.done():
+            return
+        if error is not None:
+            fetch.target_loop.call_soon_threadsafe(fetch.future.set_exception, error)
+            return
+        if tensor is None:
+            err = ArtifactError(
+                f"Tensor '{fetch.tensor_name}' missing from batch result",
+                status_code="NOT_FOUND",
+                retryable=False,
+            )
+            fetch.target_loop.call_soon_threadsafe(fetch.future.set_exception, err)
+            return
+        fetch.target_loop.call_soon_threadsafe(fetch.future.set_result, tensor)
+
+    async def _materialize_group(self, group: _BatchGroup) -> None:
+        fetches = group.fetches
+        if not fetches:
+            return
+        artifact = fetches[0].artifact_ref()
+        if artifact is None:
+            for fetch in fetches:
+                self._set_result(
+                    fetch,
+                    None,
+                    ArtifactError(
+                        "Artifact no longer available",
+                        status_code="FAILED_PRECONDITION",
+                        retryable=False,
+                    ),
+                )
+            return
+        names = [fetch.tensor_name for fetch in fetches]
+        device = fetches[0].device
+        try:
+            tensors = await asyncio.to_thread(
+                artifact.tensor_dict,
+                device=device,
+                names=names,
+            )
+        except Exception as exc:  # noqa: BLE001
+            for fetch in fetches:
+                self._set_result(fetch, None, exc)
+            return
+
+        for fetch in fetches:
+            self._set_result(fetch, tensors.get(fetch.tensor_name), None)
+            store_metrics.increment_batch_hit(
+                self._runtime.daemon_endpoint, coalesced=len(fetches) > 1
+            )
+
+
+@dataclass(slots=True)
+class PrefetchTicket:
+    replica_uuid: str
+    artifact_id: str
+    device: torch.device
+    expires_at: float | None
+    started_at: float
+    view_hash: str | None
+    runtime_ref: weakref.ReferenceType["StoreRuntimeContext"]
+
+    @property
+    def is_expired(self) -> bool:
+        return bool(self.expires_at is not None and time.monotonic() > self.expires_at)
+
+    def _runtime(self) -> "StoreRuntimeContext":
+        runtime = self.runtime_ref()
+        if runtime is None or runtime.closed:
+            raise ArtifactError(
+                "Store runtime is closed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        return runtime
+
+    def wait(self, timeout: float | None = None) -> bool:
+        if self.is_expired:
+            store_metrics.record_prefetch_event(
+                self._runtime().daemon_endpoint, status="expired"
+            )
+            return False
+        runtime = self._runtime()
+        client = runtime.ensure_client()
+        ticket = store_daemon_v2_pb2.ReplicaTicket(replica_uuid=self.replica_uuid)
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            if deadline is not None and time.monotonic() > deadline:
+                store_metrics.record_prefetch_event(
+                    runtime.daemon_endpoint, status="timeout"
+                )
+                return False
+            if self.is_expired:
+                store_metrics.record_prefetch_event(
+                    runtime.daemon_endpoint, status="expired"
+                )
+                return False
+            try:
+                resp = client.query_replica_status(ticket)
+                status = (
+                    resp.ticket.status if resp and resp.HasField("ticket") else None
+                )
+                if status not in (
+                    store_daemon_v2_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_ALLOCATED,
+                    store_daemon_v2_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_UNSPECIFIED,
+                ):
+                    store_metrics.record_prefetch_event(
+                        runtime.daemon_endpoint, status="ready"
+                    )
+                    return True
+            except Exception:
+                return False
+            time.sleep(0.05)
+
+    def cancel(self) -> None:
+        runtime = self.runtime_ref()
+        if runtime is None or runtime.closed:
+            return
+        client = runtime.ensure_client()
+        ticket = store_daemon_v2_pb2.ReplicaTicket(replica_uuid=self.replica_uuid)
+        with contextlib.suppress(Exception):
+            client.release_replica(ticket)
+            store_metrics.record_prefetch_event(
+                runtime.daemon_endpoint, status="released"
+            )
+
+
+__all__ = ["BatchContext", "MaterializationBatcher", "PrefetchTicket"]

--- a/tensorcast/api/store/batch_context.py
+++ b/tensorcast/api/store/batch_context.py
@@ -17,6 +17,7 @@ import torch
 
 from tensorcast.api import _metrics as store_metrics
 from tensorcast.api.store.types import ArtifactError
+from tensorcast.proto.daemon.v1 import store_daemon_pb2
 from tensorcast.proto.daemon.v2 import store_daemon_pb2 as store_daemon_v2_pb2
 
 if TYPE_CHECKING:
@@ -314,8 +315,8 @@ class PrefetchTicket:
                     resp.ticket.status if resp and resp.HasField("ticket") else None
                 )
                 if status not in (
-                    store_daemon_v2_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_ALLOCATED,
-                    store_daemon_v2_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_UNSPECIFIED,
+                    store_daemon_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_ALLOCATED,
+                    store_daemon_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_UNSPECIFIED,
                 ):
                     store_metrics.record_prefetch_event(
                         runtime.daemon_endpoint, status="ready"

--- a/tensorcast/api/store/cache.py
+++ b/tensorcast/api/store/cache.py
@@ -80,6 +80,30 @@ class ArtifactCache:
             store_metrics.increment_artifact_cache_hit(self._daemon_endpoint)
             return replace(entry)
 
+    def get_artifact_index_by_disk_path(
+        self, disk_path: str
+    ) -> ArtifactCacheEntry | None:
+        if not self.enabled or not disk_path:
+            return None
+        now = time.monotonic()
+        with self._lock:
+            for artifact_id, entry in list(self._entries.items()):
+                if entry.disk_path != disk_path:
+                    continue
+                if entry.expires_at <= now:
+                    del self._entries[artifact_id]
+                    store_metrics.increment_artifact_cache_eviction(
+                        self._daemon_endpoint, reason="ttl"
+                    )
+                    store_metrics.increment_artifact_cache_miss(self._daemon_endpoint)
+                    return None
+                entry.hit_count += 1
+                self._entries.move_to_end(artifact_id)
+                store_metrics.increment_artifact_cache_hit(self._daemon_endpoint)
+                return replace(entry)
+        store_metrics.increment_artifact_cache_miss(self._daemon_endpoint)
+        return None
+
     def cache_artifact_index(self, entry: ArtifactCacheEntry) -> None:
         if not self.enabled:
             return

--- a/tensorcast/api/store/common.py
+++ b/tensorcast/api/store/common.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import Mapping
+from typing import Mapping, Sequence
 
 import torch
 
@@ -78,6 +78,28 @@ def canonical_index_from_bytes(
         total_size_bytes=total,
         avbs_hash=avbs_hash,
     )
+
+
+def canonical_index_to_bytes(
+    canonical_index: CanonicalIndex, names: Sequence[str] | None = None
+) -> bytes:
+    selected = canonical_index.entries
+    if names is not None:
+        requested = set(names)
+        selected = tuple(
+            entry for entry in canonical_index.entries if entry.name in requested
+        )
+    data: dict[str, tuple[int, int, list[int], list[int], str, int]] = {}
+    for entry in selected:
+        data[entry.name] = (
+            int(entry.segment_offset),
+            int(entry.size_bytes),
+            list(entry.shape),
+            list(entry.stride),
+            str(entry.dtype),
+            int(entry.storage_offset),
+        )
+    return json.dumps(data, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 def canonical_index_from_result(result: RegistrationResult) -> CanonicalIndex:
@@ -201,6 +223,7 @@ def validate_targets(
 
 __all__ = [
     "canonical_index_from_bytes",
+    "canonical_index_to_bytes",
     "canonical_index_from_result",
     "dtype_from_string",
     "lease_handle_from_result",

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -78,6 +78,12 @@ class FallbackResolver:
                 status_code="INVALID_ARGUMENT",
                 retryable=False,
             )
+        if fallback and fallback.prefer not in {"auto", "local", "p2p", "disk"}:
+            raise ArtifactError(
+                f"Unknown fallback preference '{fallback.prefer}'",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
 
     def resolve_disk_path(
         self,
@@ -189,6 +195,11 @@ class MaterializationPipeline:
         tensor_names: Sequence[str] | None,
         canonical_index_hint: bytes | None = None,
         disk_path_hint: str | None = None,
+        view_spec: store_daemon_pb2.ViewSpec | None = None,
+        view_data_hash: str | None = None,
+        view_index_hint: bytes | None = None,
+        replica_uuid: str | None = None,
+        options: GetArtifactOptions | None = None,
     ) -> tuple[MaterializationPayload, int]:
         return self._perform_get_with_retry(
             method="get",
@@ -197,10 +208,14 @@ class MaterializationPipeline:
             device=device,
             fallback=fallback,
             cancel_event=None,
-            options_override=None,
+            options_override=options,
             canonical_index_hint=canonical_index_hint,
             disk_path_hint=disk_path_hint,
             tensor_names=tensor_names,
+            view=view_spec,
+            view_data_hash=view_data_hash,
+            view_index_hint=view_index_hint,
+            replica_uuid=replica_uuid,
         )
 
     def get_view(
@@ -327,6 +342,10 @@ class MaterializationPipeline:
         fallback: FallbackOptions | None = None,
         options: GetArtifactOptions | None = None,
         tensor_names: Sequence[str] | None = None,
+        view_spec: store_daemon_pb2.ViewSpec | None = None,
+        view_data_hash: str | None = None,
+        view_index_hint: bytes | None = None,
+        replica_uuid: str | None = None,
     ) -> None:
         payload, device_id = self._perform_get_with_retry(
             artifact_id=artifact_id,
@@ -337,6 +356,10 @@ class MaterializationPipeline:
             cancel_event=None,
             options_override=options,
             tensor_names=tensor_names,
+            view=view_spec,
+            view_data_hash=view_data_hash,
+            view_index_hint=view_index_hint,
+            replica_uuid=replica_uuid,
         )
         try:
             layout_bytes = payload.view_index_bytes or payload.canonical_index_bytes
@@ -678,6 +701,9 @@ class MaterializationPipeline:
         canonical_index_hint: bytes | None = None,
         disk_path_hint: str | None = None,
         tensor_names: Sequence[str] | None = None,
+        view_data_hash: str | None = None,
+        view_index_hint: bytes | None = None,
+        replica_uuid: str | None = None,
     ) -> MaterializationPayload:
         return self._materialize_payload(
             artifact_id=artifact_id,
@@ -693,6 +719,9 @@ class MaterializationPipeline:
             canonical_index_hint=canonical_index_hint,
             disk_path_hint=disk_path_hint,
             tensor_names=tensor_names,
+            view_data_hash=view_data_hash,
+            view_index_hint=view_index_hint,
+            replica_uuid=replica_uuid,
         )
 
     def _materialize_payload(
@@ -711,22 +740,42 @@ class MaterializationPipeline:
         canonical_index_hint: bytes | None = None,
         disk_path_hint: str | None = None,
         tensor_names: Sequence[str] | None = None,
+        view_data_hash: str | None = None,
+        view_index_hint: bytes | None = None,
+        replica_uuid: str | None = None,
     ) -> MaterializationPayload:
         client = self._runtime.ensure_client()
         disk_error: Exception | None = None
         disk_path: str | None = disk_path_hint
         resolved_artifact_id = artifact_id
+        canonical_hint: bytes | None = canonical_index_hint
+        generation_hint: int | None = None
         fallback_opts = fallback
-        preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO
         verify_checksums = (
             bool(fallback_opts.verify_checksums) if fallback_opts else True
         )
-        requested_disk = False
-        if fallback_opts and (
-            fallback_opts.prefer_disk
-            or fallback_opts.disk_path
-            or not fallback_opts.allow_p2p
+        effective_prefer = fallback_opts.prefer if fallback_opts else "auto"
+        if (
+            fallback_opts
+            and fallback_opts.prefer_disk is not None
+            and effective_prefer == "auto"
+            and fallback_opts.prefer_disk
         ):
+            effective_prefer = "disk"
+        allow_p2p = True if fallback_opts is None else bool(fallback_opts.allow_p2p)
+        if effective_prefer == "local":
+            allow_p2p = False
+        requested_disk = effective_prefer == "disk" or bool(
+            fallback_opts and fallback_opts.disk_path
+        )
+
+        preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO
+        if effective_prefer == "p2p":
+            preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_P2P
+        elif effective_prefer == "disk":
+            preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
+
+        if fallback_opts and (requested_disk or not allow_p2p):
             disk_path, resolved_artifact_id, disk_error = (
                 self._fallback.resolve_disk_path(
                     fallback=fallback_opts,
@@ -737,9 +786,10 @@ class MaterializationPipeline:
             )
             if disk_path:
                 requested_disk = True
-                preference = (
-                    store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
-                )
+                if effective_prefer == "disk":
+                    preference = (
+                        store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
+                    )
                 self._fallback.record_event(
                     mode="disk",
                     artifact_id=resolved_artifact_id,
@@ -759,21 +809,44 @@ class MaterializationPipeline:
                         },
                     )
                 resolved_artifact_id = resolved_artifact_id or artifact_id
-            if fallback_opts and not fallback_opts.allow_p2p:
+            if not allow_p2p and not disk_path:
                 if disk_error is not None:
                     raise ArtifactError(
                         f"Disk fallback lookup failed: {disk_error}",
                         status_code="UNAVAILABLE",
                         retryable=True,
                     ) from disk_error
-                if not disk_path:
-                    raise ArtifactError(
-                        "Disk fallback required but disk_path unavailable",
-                        status_code="NOT_FOUND",
-                        retryable=False,
-                    )
+                raise ArtifactError(
+                    "Disk fallback required but disk_path unavailable",
+                    status_code="NOT_FOUND",
+                    retryable=False,
+                )
+        if requested_disk and disk_path and canonical_hint is None:
+            try:
+                disk_meta = client.resolve_artifact_from_disk_v2(
+                    disk_path=disk_path,
+                    verify_checksums=verify_checksums,
+                )
+                canonical_hint = bytes(disk_meta.canonical_index_bytes)
+                if disk_meta.artifact_id:
+                    resolved_artifact_id = disk_meta.artifact_id
+                if getattr(disk_meta, "generation", 0):
+                    generation_hint = int(disk_meta.generation)
+            except Exception as exc:  # noqa: BLE001
+                if not allow_p2p:
+                    raise map_materialization_error(exc) from exc
+                logger.info(
+                    "store.materialize.disk.resolve_failed",
+                    extra={
+                        "tc.store.daemon": self._runtime.daemon_endpoint,
+                        "tc.store.disk_path": disk_path,
+                    },
+                    exc_info=exc,
+                )
 
         request_artifact_id = resolved_artifact_id or artifact_id
+        view_subset_hash = view_data_hash.encode("utf-8") if view_data_hash else None
+        index_hint = view_index_hint or canonical_hint
         result = self._materialize_fn(
             client=client,
             daemon_address=self._runtime.daemon_endpoint,
@@ -784,22 +857,29 @@ class MaterializationPipeline:
             view=view,
             view_id=view_id,
             placement=placement,
-            canonical_index_hint=canonical_index_hint,
+            canonical_index_hint=index_hint,
             disk_path_hint=disk_path,
             preference=preference,
             tensor_names=tensor_names,
             verify_checksums=verify_checksums,
+            view_subset_hash=view_subset_hash,
+            replica_uuid=replica_uuid,
+            view_index_hint=view_index_hint,
+            generation_hint=generation_hint,
         )
-        if fallback_opts and not fallback_opts.allow_p2p:
+        if fallback_opts and not allow_p2p:
             disallowed_sources = {
-                store_daemon_pb2.MaterializationSource.MATERIALIZATION_SOURCE_P2P,
-                store_daemon_pb2.MaterializationSource.MATERIALIZATION_SOURCE_LOCAL_REPLICA,
+                store_daemon_pb2.MaterializationSource.MATERIALIZATION_SOURCE_P2P
             }
+            if requested_disk:
+                disallowed_sources.add(
+                    store_daemon_pb2.MaterializationSource.MATERIALIZATION_SOURCE_LOCAL_REPLICA
+                )
             if result.source in disallowed_sources:
                 source_label = _source_label(result.source) or "non-disk"
                 self._release_materialized(result, client)
                 raise ArtifactError(
-                    f"Disk-only fallback requested but daemon served from {source_label}",
+                    f"Materialization source {source_label} not allowed by fallback policy",
                     status_code="FAILED_PRECONDITION",
                     retryable=False,
                 )
@@ -809,8 +889,8 @@ class MaterializationPipeline:
             artifact_id=result.artifact_id or request_artifact_id,
             key=key,
             detail={
-                "disk_requested": bool(fallback and fallback.prefer_disk),
-                "allow_p2p": bool(fallback is None or fallback.allow_p2p),
+                "disk_requested": bool(requested_disk),
+                "allow_p2p": bool(allow_p2p),
                 "source": source_label,
             },
         )
@@ -826,8 +906,9 @@ class MaterializationPipeline:
                 "store.materialize.p2p",
                 {
                     "tc.artifact.id": result.artifact_id or artifact_id or "",
-                    "tc.store.disk_requested": bool(fallback and fallback.prefer_disk),
-                    "tc.store.allow_p2p": bool(fallback is None or fallback.allow_p2p),
+                    "tc.store.disk_requested": bool(requested_disk),
+                    "tc.store.allow_p2p": bool(allow_p2p),
+                    "tc.store.preference": effective_prefer,
                     "tc.store.source": source_label,
                 },
             )
@@ -886,6 +967,10 @@ class MaterializationPipeline:
                 view_data_hash=base_payload.view_data_hash,
                 source=base_payload.source,
                 device_uuid=base_payload.device_uuid,
+                ticket_replica_uuid=base_payload.ticket_replica_uuid,
+                ticket_status=base_payload.ticket_status,
+                ticket_created_at_ts=base_payload.ticket_created_at_ts,
+                ticket_expires_at_ts=base_payload.ticket_expires_at_ts,
             )
         return result
 
@@ -923,6 +1008,9 @@ class MaterializationPipeline:
         canonical_index_hint: bytes | None = None,
         disk_path_hint: str | None = None,
         tensor_names: Sequence[str] | None = None,
+        view_data_hash: str | None = None,
+        view_index_hint: bytes | None = None,
+        replica_uuid: str | None = None,
     ) -> tuple[MaterializationPayload, int]:
         policy = self._runtime.retry_policies.get(
             method, self._runtime.retry_policies.get("get")
@@ -936,7 +1024,7 @@ class MaterializationPipeline:
             "tc.store.method": method,
             "tc.store.lookup.by_key": bool(key),
             "tc.store.lookup.by_id": bool(artifact_id),
-            "tc.store.fallback.prefer_disk": bool(fallback and fallback.prefer_disk),
+            "tc.store.fallback.prefer": (fallback.prefer if fallback else "auto"),
             "tc.store.fallback.allow_p2p": bool(fallback is None or fallback.allow_p2p),
         }
         source_label: str | None = None
@@ -989,6 +1077,9 @@ class MaterializationPipeline:
                         canonical_index_hint=canonical_index_hint,
                         disk_path_hint=disk_path_hint,
                         tensor_names=tensor_names,
+                        view_data_hash=view_data_hash,
+                        view_index_hint=view_index_hint,
+                        replica_uuid=replica_uuid,
                     )
                     summary = self._summarize_materialized(materialized, tensor_names)
                     selection_label = summary["selection"]
@@ -1135,6 +1226,9 @@ class MaterializationPipeline:
         canonical_index_hint: bytes | None = None,
         disk_path_hint: str | None = None,
         tensor_names: Sequence[str] | None = None,
+        view_data_hash: str | None = None,
+        view_index_hint: bytes | None = None,
+        replica_uuid: str | None = None,
     ) -> tuple[MaterializationPayload, int]:
         resolved_fallback = fallback or self._runtime.opts.fallback
         artifact_id, key = self._resolve_identifiers(
@@ -1158,6 +1252,9 @@ class MaterializationPipeline:
                 canonical_index_hint=canonical_index_hint,
                 disk_path_hint=disk_path_hint,
                 tensor_names=tensor_names,
+                view_data_hash=view_data_hash,
+                view_index_hint=view_index_hint,
+                replica_uuid=replica_uuid,
             )
         except Exception as exc:  # noqa: BLE001
             raise map_materialization_error(exc) from exc

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import threading
 import time
@@ -20,8 +19,10 @@ from tensorcast.api._materialize import (
     materialize_artifact_v2,
 )
 from tensorcast.api.store.async_ops import ArtifactFuture, TrackedExecutor
+from tensorcast.api.store.cache import ArtifactCacheEntry
 from tensorcast.api.store.common import (
     canonical_index_from_bytes,
+    canonical_index_to_bytes,
     validate_targets,
 )
 from tensorcast.api.store.retry import (
@@ -528,6 +529,8 @@ class MaterializationPipeline:
         artifact_id: str | None,
         key: str | None,
         fallback: FallbackOptions | None,
+        *,
+        disk_path_hint: str | None = None,
     ) -> tuple[str | None, str | None]:
         if artifact_id and key:
             raise ArtifactError(
@@ -542,7 +545,7 @@ class MaterializationPipeline:
                     disk_path = fallback.disk_path.strip()
                 else:
                     disk_path = fallback.disk_path
-            if disk_path:
+            if disk_path or disk_path_hint:
                 return None, None
             raise ArtifactError(
                 "Either artifact_id or key is required",
@@ -645,17 +648,10 @@ class MaterializationPipeline:
         canonical_count: int | None = None
         if canonical_index_bytes:
             try:
-                index_obj = json.loads(canonical_index_bytes)
-                canonical_count = len(index_obj)
+                index_obj = canonical_index_from_bytes(canonical_index_bytes)
+                canonical_count = len(index_obj.entries)
                 if bytes_total == 0:
-                    names = descriptor_names or list(index_obj.keys())
-                    for name in names:
-                        if (
-                            name in index_obj
-                            and isinstance(index_obj[name], list)
-                            and len(index_obj[name]) > 1
-                        ):
-                            bytes_total += int(index_obj[name][1])
+                    bytes_total = int(index_obj.total_size_bytes)
             except Exception:  # noqa: BLE001
                 canonical_count = None
 
@@ -750,6 +746,7 @@ class MaterializationPipeline:
         resolved_artifact_id = artifact_id
         canonical_hint: bytes | None = canonical_index_hint
         generation_hint: int | None = None
+        cached_entry: ArtifactCacheEntry | None = None
         fallback_opts = fallback
         verify_checksums = (
             bool(fallback_opts.verify_checksums) if fallback_opts else True
@@ -765,8 +762,14 @@ class MaterializationPipeline:
         allow_p2p = True if fallback_opts is None else bool(fallback_opts.allow_p2p)
         if effective_prefer == "local":
             allow_p2p = False
-        requested_disk = effective_prefer == "disk" or bool(
-            fallback_opts and fallback_opts.disk_path
+        requested_disk = (
+            effective_prefer == "disk"
+            or bool(fallback_opts and fallback_opts.disk_path)
+            or bool(disk_path)
+        )
+        # Local-only preference disables P2P but should not force a disk fallback.
+        disk_required = requested_disk or (
+            not allow_p2p and effective_prefer != "local"
         )
 
         preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO
@@ -774,6 +777,21 @@ class MaterializationPipeline:
             preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_P2P
         elif effective_prefer == "disk":
             preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
+        if (
+            disk_path
+            and preference == store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO
+        ):
+            preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
+        if disk_path and fallback_opts is None:
+            allow_p2p = False
+
+        if disk_path and canonical_hint is None:
+            cached_entry = self._runtime.get_artifact_index_by_disk_path(disk_path)
+            if cached_entry is not None:
+                canonical_hint = cached_entry.canonical_index_bytes
+                generation_hint = cached_entry.generation
+                if cached_entry.artifact_id:
+                    resolved_artifact_id = cached_entry.artifact_id
 
         if fallback_opts and (requested_disk or not allow_p2p):
             disk_path, resolved_artifact_id, disk_error = (
@@ -786,7 +804,12 @@ class MaterializationPipeline:
             )
             if disk_path:
                 requested_disk = True
-                if effective_prefer == "disk":
+                disk_required = True
+                if (
+                    effective_prefer == "disk"
+                    or preference
+                    == store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO
+                ):
                     preference = (
                         store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
                     )
@@ -809,7 +832,7 @@ class MaterializationPipeline:
                         },
                     )
                 resolved_artifact_id = resolved_artifact_id or artifact_id
-            if not allow_p2p and not disk_path:
+            if disk_required and not disk_path:
                 if disk_error is not None:
                     raise ArtifactError(
                         f"Disk fallback lookup failed: {disk_error}",
@@ -832,6 +855,17 @@ class MaterializationPipeline:
                     resolved_artifact_id = disk_meta.artifact_id
                 if getattr(disk_meta, "generation", 0):
                     generation_hint = int(disk_meta.generation)
+                if canonical_hint and resolved_artifact_id:
+                    parsed_index = canonical_index_from_bytes(canonical_hint)
+                    cache_entry = ArtifactCacheEntry(
+                        artifact_id=resolved_artifact_id,
+                        canonical_index_bytes=canonical_hint,
+                        parsed_index=parsed_index,
+                        generation=generation_hint,
+                        disk_path=disk_path,
+                        expires_at=time.monotonic(),
+                    )
+                    self._runtime.cache_artifact_index(cache_entry)
             except Exception as exc:  # noqa: BLE001
                 if not allow_p2p:
                     raise map_materialization_error(exc) from exc
@@ -925,19 +959,19 @@ class MaterializationPipeline:
                     status_code="NOT_FOUND",
                     retryable=False,
                 )
-            requested = set(tensor_names)
+            requested_names = tuple(tensor_names)
+            requested = set(requested_names)
             base_payload = result
             filtered_descriptors = tuple(
                 desc for desc in result.descriptors if desc.name in requested
             )
             try:
-                index_obj = json.loads(base_payload.canonical_index_bytes)
-                filtered_index = {
-                    name: meta for name, meta in index_obj.items() if name in requested
-                }
-                canonical_bytes = json.dumps(
-                    filtered_index, separators=(",", ":")
-                ).encode("utf-8")
+                canonical_index = canonical_index_from_bytes(
+                    base_payload.canonical_index_bytes
+                )
+                canonical_bytes = canonical_index_to_bytes(
+                    canonical_index, requested_names
+                )
             except Exception:  # noqa: BLE001
                 canonical_bytes = base_payload.canonical_index_bytes
 
@@ -1232,7 +1266,7 @@ class MaterializationPipeline:
     ) -> tuple[MaterializationPayload, int]:
         resolved_fallback = fallback or self._runtime.opts.fallback
         artifact_id, key = self._resolve_identifiers(
-            artifact_id, key, resolved_fallback
+            artifact_id, key, resolved_fallback, disk_path_hint=disk_path_hint
         )
         self._fallback.ensure_supported(resolved_fallback)
         device_id = self._resolve_device_selector(device, resolved_fallback)

--- a/tensorcast/api/store/runtime.py
+++ b/tensorcast/api/store/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import concurrent.futures
 import contextlib
 import logging
@@ -104,6 +105,13 @@ class StoreRuntimeContext:
             ttl_seconds=self._artifact_cache_ttl_seconds,
             max_entries=self._artifact_cache_max_entries,
         )
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._run_loop,
+            daemon=True,
+            name="tensorcast-store-loop",
+        )
+        self._loop_thread.start()
         self._closed = False
 
         self._init_session_record()
@@ -116,6 +124,10 @@ class StoreRuntimeContext:
     # ------------------------------------------------------------------
     def _create_client(self) -> DaemonCtl:
         return self._client_factory(self._daemon_endpoint)
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
 
     @staticmethod
     def _default_capabilities() -> StoreCapabilities:
@@ -434,6 +446,13 @@ class StoreRuntimeContext:
             ttl_seconds=self._artifact_cache_ttl_seconds,
             max_entries=self._artifact_cache_max_entries,
         )
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._run_loop,
+            daemon=True,
+            name="tensorcast-store-loop",
+        )
+        self._loop_thread.start()
         self._init_session_record()
 
     def ensure_client(self) -> DaemonCtl:
@@ -458,6 +477,12 @@ class StoreRuntimeContext:
                 self._client = None
         self.release_all_leases()
         self._executor_handle.close()
+        with contextlib.suppress(Exception):
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if hasattr(self, "_loop_thread") and self._loop_thread.is_alive():
+            self._loop_thread.join(timeout=1.0)
+        with contextlib.suppress(Exception):
+            self._loop.close()
         with self._key_cache_lock:
             self._key_cache.clear()
         self._artifact_cache.clear()
@@ -540,6 +565,10 @@ class StoreRuntimeContext:
     @property
     def opts(self) -> StoreOptions:
         return self._opts
+
+    @property
+    def event_loop(self) -> asyncio.AbstractEventLoop:
+        return self._loop
 
     @property
     def closed(self) -> bool:

--- a/tensorcast/api/store/runtime.py
+++ b/tensorcast/api/store/runtime.py
@@ -310,6 +310,11 @@ class StoreRuntimeContext:
     def get_artifact_index_cached(self, artifact_id: str) -> ArtifactCacheEntry | None:
         return self._artifact_cache.get_artifact_index_cached(artifact_id)
 
+    def get_artifact_index_by_disk_path(
+        self, disk_path: str
+    ) -> ArtifactCacheEntry | None:
+        return self._artifact_cache.get_artifact_index_by_disk_path(disk_path)
+
     def cache_artifact_index(self, entry: ArtifactCacheEntry) -> None:
         self._artifact_cache.cache_artifact_index(entry)
 

--- a/tensorcast/api/store/types.py
+++ b/tensorcast/api/store/types.py
@@ -61,12 +61,33 @@ class RetryPolicy:
 
 @dataclass(frozen=True)
 class FallbackOptions:
-    """Disk fallback hints; verify_checksums is retained for compatibility but is a no-op."""
+    """Source selection and replica hints for materialization."""
 
+    prefer: Literal["auto", "local", "p2p", "disk"] = "auto"
     disk_path: str | None = None
-    prefer_disk: bool = False
     allow_p2p: bool = True
     verify_checksums: bool = True
+    prefer_disk: bool | None = None  # Deprecated compatibility flag
+    replica_uuid: str | None = None
+
+    @classmethod
+    def for_disk(cls, path: str, *, verify: bool = True) -> "FallbackOptions":
+        return cls(
+            prefer="disk",
+            disk_path=path,
+            allow_p2p=False,
+            verify_checksums=verify,
+            prefer_disk=True,
+        )
+
+    @classmethod
+    def local_only(cls) -> "FallbackOptions":
+        return cls(
+            prefer="local",
+            allow_p2p=False,
+            verify_checksums=True,
+            prefer_disk=False,
+        )
 
 
 @dataclass(frozen=True)

--- a/tensorcast/api/store/view_composer.py
+++ b/tensorcast/api/store/view_composer.py
@@ -80,8 +80,10 @@ def _compose_narrow(
 
     if parent is not None:
         _validate(parent)
-        ops.append(parent)
     if child is None:
+        if parent is None:
+            return ops
+        ops.append(parent)
         return ops
 
     _validate(child)
@@ -101,7 +103,10 @@ def _compose_narrow(
     narrowed_length = parent.length
     if child.start + child.length > narrowed_length:
         raise ArtifactError(
-            f"Slice [{child.start}, {child.start + child.length}) exceeds narrowed length {narrowed_length} for '{tensor_name}'",
+            (
+                f"Slice [{child.start}, {child.start + child.length}) exceeds "
+                f"narrowed length {narrowed_length} for '{tensor_name}'"
+            ),
             status_code="INVALID_ARGUMENT",
             retryable=False,
         )
@@ -385,7 +390,7 @@ class ViewSpecComposer:
         view_entries: list[CanonicalIndexEntry] = []
         for name in names:
             entry = base_entries[name]
-            ops = ()
+            ops: Sequence[TensorViewOp] = ()
             if view_spec is not None:
                 ops = view_spec.tensor_ops.get(name, ())
             view_entries.append(_apply_view_ops(entry, ops))

--- a/tensorcast/api/store/view_composer.py
+++ b/tensorcast/api/store/view_composer.py
@@ -1,0 +1,447 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+# Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import weakref
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from tensorcast.api._view_ops import (
+    NarrowOp,
+    TensorViewOp,
+    TransposeOp,
+    ViewSpecBuildResult,
+    build_view_spec,
+)
+from tensorcast.api.store.types import (
+    ArtifactError,
+    CanonicalIndex,
+    CanonicalIndexEntry,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ViewMetadataCache:
+    view_id: str
+    view_index_bytes: bytes
+    view_data_hash: str
+    tensor_names: tuple[str, ...]
+    nbytes: int
+    canonical_index: CanonicalIndex
+
+
+def _serialize_index(index: CanonicalIndex) -> bytes:
+    entries: dict[str, list[object]] = {}
+    for entry in index.entries:
+        entries[entry.name] = [
+            int(entry.segment_offset),
+            int(entry.size_bytes),
+            list(entry.shape),
+            list(entry.stride),
+            str(entry.dtype),
+            int(entry.storage_offset),
+        ]
+    return json.dumps(entries, separators=(",", ":")).encode("utf-8")
+
+
+def _compose_narrow(
+    *,
+    base_shape: tuple[int, ...],
+    parent: NarrowOp | None,
+    child: NarrowOp | None,
+    tensor_name: str,
+) -> list[TensorViewOp]:
+    ops: list[TensorViewOp] = []
+    shape = tuple(int(dim) for dim in base_shape)
+
+    def _validate(op: NarrowOp) -> None:
+        if op.dim < 0 or op.dim >= len(shape):
+            raise ArtifactError(
+                f"Slice dim {op.dim} out of range for tensor '{tensor_name}'",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        if op.start < 0 or op.length <= 0:
+            raise ArtifactError(
+                f"Slice for '{tensor_name}' must have positive start/length",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        if op.start + op.length > shape[op.dim]:
+            raise ArtifactError(
+                f"Slice [{op.start}, {op.start + op.length}) exceeds dim {op.dim} for '{tensor_name}'",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+
+    if parent is not None:
+        _validate(parent)
+        ops.append(parent)
+    if child is None:
+        return ops
+
+    _validate(child)
+    if parent is None:
+        if child.start == 0 and child.length == shape[child.dim]:
+            return []
+        ops.append(child)
+        return ops
+
+    if child.dim != parent.dim:
+        raise ArtifactError(
+            f"Multiple slice dimensions for tensor '{tensor_name}' are not supported",
+            status_code="INVALID_ARGUMENT",
+            retryable=False,
+        )
+
+    narrowed_length = parent.length
+    if child.start + child.length > narrowed_length:
+        raise ArtifactError(
+            f"Slice [{child.start}, {child.start + child.length}) exceeds narrowed length {narrowed_length} for '{tensor_name}'",
+            status_code="INVALID_ARGUMENT",
+            retryable=False,
+        )
+    composed_start = parent.start + child.start
+    ops.append(NarrowOp(dim=parent.dim, start=composed_start, length=child.length))
+    return ops
+
+
+def _permutation_from_ops(ndim: int, ops: Sequence[TransposeOp]) -> list[int]:
+    perm = list(range(ndim))
+    for op in ops:
+        if op.dim0 < 0 or op.dim1 < 0 or op.dim0 >= ndim or op.dim1 >= ndim:
+            raise ArtifactError(
+                "Transpose dims out of range",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        perm[op.dim0], perm[op.dim1] = perm[op.dim1], perm[op.dim0]
+    return perm
+
+
+def _ops_from_permutation(perm: list[int]) -> list[TensorViewOp]:
+    ops: list[TensorViewOp] = []
+    current = list(range(len(perm)))
+    for target_idx, desired in enumerate(perm):
+        if current[target_idx] == desired:
+            continue
+        try:
+            source_idx = current.index(desired)
+        except ValueError:
+            continue
+        if target_idx == source_idx:
+            continue
+        ops.append(TransposeOp(dim0=target_idx, dim1=source_idx))
+        current[target_idx], current[source_idx] = (
+            current[source_idx],
+            current[target_idx],
+        )
+    return ops
+
+
+def _apply_view_ops(
+    entry: CanonicalIndexEntry, ops: Sequence[TensorViewOp]
+) -> CanonicalIndexEntry:
+    shape = list(entry.shape)
+    stride = list(entry.stride)
+    storage_offset = int(entry.storage_offset)
+
+    for op in ops:
+        if isinstance(op, NarrowOp):
+            if op.dim < 0 or op.dim >= len(shape):
+                raise ArtifactError(
+                    f"Slice dim {op.dim} out of range for tensor '{entry.name}'",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            storage_offset += op.start * stride[op.dim]
+            shape[op.dim] = op.length
+        elif isinstance(op, TransposeOp):
+            dim0, dim1 = op.dim0, op.dim1
+            if dim0 < 0 or dim1 < 0 or dim0 >= len(shape) or dim1 >= len(shape):
+                raise ArtifactError(
+                    f"Transpose dims {dim0},{dim1} out of range for tensor '{entry.name}'",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            shape[dim0], shape[dim1] = shape[dim1], shape[dim0]
+            stride[dim0], stride[dim1] = stride[dim1], stride[dim0]
+
+    base_numel = 1
+    for dim in entry.shape:
+        base_numel *= dim
+    base_numel = max(base_numel, 1)
+    elem_size = float(entry.size_bytes) / float(base_numel)
+    new_numel = 1
+    for dim in shape:
+        new_numel *= dim
+    size_bytes = int(elem_size * float(new_numel)) if new_numel > 0 else 0
+
+    return CanonicalIndexEntry(
+        name=entry.name,
+        dtype=entry.dtype,
+        shape=tuple(int(v) for v in shape),
+        stride=tuple(int(v) for v in stride),
+        storage_offset=storage_offset,
+        segment_offset=entry.segment_offset,
+        size_bytes=size_bytes,
+    )
+
+
+class ViewSpecComposer:
+    """Pure view composer that flattens parent/child specs without RPC calls."""
+
+    def __init__(self, *, max_depth: int = 8) -> None:
+        self._max_depth = max(1, int(max_depth))
+
+    @staticmethod
+    def hash_view_spec(
+        view_spec: ViewSpecBuildResult | None, *, subset: Sequence[str] | None = None
+    ) -> str:
+        normalized_ops = view_spec.to_normalized_dict() if view_spec is not None else {}
+        payload = {
+            "ops": normalized_ops,
+            "subset": sorted(subset) if subset else [],
+        }
+        digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8"))
+        return digest.hexdigest()
+
+    def compose(
+        self,
+        *,
+        canonical_index: CanonicalIndex,
+        parent_spec: ViewSpecBuildResult | None,
+        child_spec: ViewSpecBuildResult | None,
+        parent_depth: int,
+        subset_names: Sequence[str] | None = None,
+    ) -> tuple[ViewSpecBuildResult | None, ViewMetadataCache | None, int]:
+        depth = parent_depth
+        base_spec = parent_spec if parent_spec and not parent_spec.is_identity else None
+        child = child_spec if child_spec and not child_spec.is_identity else None
+        composed_spec: ViewSpecBuildResult | None = None
+        if base_spec is None and child is None:
+            composed_spec = None
+        elif base_spec is None:
+            composed_spec = child
+            depth += 1 if child is not None else 0
+        elif child is None:
+            composed_spec = base_spec
+        else:
+            composed_spec = self._compose_specs(
+                canonical_index=canonical_index,
+                parent=base_spec,
+                child=child,
+            )
+            depth += 1
+
+        if depth > self._max_depth:
+            raise ArtifactError(
+                f"View depth {depth} exceeds limit {self._max_depth}",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+
+        view_index: CanonicalIndex | None = None
+        tensor_names: tuple[str, ...] | None = None
+        if composed_spec is not None or subset_names:
+            view_index, tensor_names = self._build_view_index(
+                canonical_index=canonical_index,
+                view_spec=composed_spec,
+                subset_names=subset_names,
+            )
+
+        view_cache: ViewMetadataCache | None = None
+        if view_index is not None and tensor_names is not None:
+            view_hash = self.hash_view_spec(composed_spec, subset=tensor_names)
+            view_cache = ViewMetadataCache(
+                view_id=view_hash,
+                view_index_bytes=_serialize_index(view_index),
+                view_data_hash=view_hash,
+                tensor_names=tensor_names,
+                nbytes=sum(entry.size_bytes for entry in view_index.entries),
+                canonical_index=view_index,
+            )
+
+        return composed_spec, view_cache, depth
+
+    def _compose_specs(
+        self,
+        *,
+        canonical_index: CanonicalIndex,
+        parent: ViewSpecBuildResult,
+        child: ViewSpecBuildResult,
+    ) -> ViewSpecBuildResult:
+        tensor_ops: dict[str, list[TensorViewOp]] = {}
+        entry_shapes = {
+            entry.name: tuple(entry.shape) for entry in canonical_index.entries
+        }
+        tensor_names = set(parent.tensor_ops.keys()) | set(child.tensor_ops.keys())
+
+        for name in sorted(tensor_names):
+            shape = entry_shapes.get(name)
+            if shape is None:
+                raise ArtifactError(
+                    f"View references unknown tensor '{name}'",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            parent_ops = list(parent.tensor_ops.get(name, ()))
+            child_ops = list(child.tensor_ops.get(name, ()))
+            has_parent_narrow = any(isinstance(op, NarrowOp) for op in parent_ops)
+            has_child_narrow = any(isinstance(op, NarrowOp) for op in child_ops)
+            has_parent_transpose = any(isinstance(op, TransposeOp) for op in parent_ops)
+            has_child_transpose = any(isinstance(op, TransposeOp) for op in child_ops)
+
+            if (has_parent_narrow or has_child_narrow) and (
+                has_parent_transpose or has_child_transpose
+            ):
+                raise ArtifactError(
+                    f"Cannot mix slice and transpose for tensor '{name}'",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+
+            if has_parent_narrow or has_child_narrow:
+                parent_narrow = next(
+                    (op for op in parent_ops if isinstance(op, NarrowOp)), None
+                )
+                child_narrow = next(
+                    (op for op in child_ops if isinstance(op, NarrowOp)), None
+                )
+                composed_narrows = _compose_narrow(
+                    base_shape=shape,
+                    parent=parent_narrow,
+                    child=child_narrow,
+                    tensor_name=name,
+                )
+                if composed_narrows:
+                    tensor_ops[name] = composed_narrows
+                continue
+
+            if has_parent_transpose or has_child_transpose:
+                parent_perm = _permutation_from_ops(
+                    len(shape),
+                    [op for op in parent_ops if isinstance(op, TransposeOp)],
+                )
+                child_perm = _permutation_from_ops(
+                    len(shape),
+                    [op for op in child_ops if isinstance(op, TransposeOp)],
+                )
+                # Apply child permutation on top of parent result.
+                composed_perm = [parent_perm[idx] for idx in child_perm]
+                composed_ops = _ops_from_permutation(composed_perm)
+                if composed_ops:
+                    tensor_ops[name] = composed_ops
+                continue
+
+        if not tensor_ops:
+            return ViewSpecBuildResult.identity()
+
+        view_spec_proto = build_view_spec(
+            entry_shapes=entry_shapes,
+            slices={
+                name: (op.dim, slice(op.start, op.start + op.length))
+                for name, ops in tensor_ops.items()
+                for op in ops
+                if isinstance(op, NarrowOp)
+            },
+            transpose={
+                name: [(op.dim0, op.dim1) for op in ops if isinstance(op, TransposeOp)]
+                for name, ops in tensor_ops.items()
+                if any(isinstance(op, TransposeOp) for op in ops)
+            },
+        ).proto
+
+        ordered_ops: dict[str, tuple[TensorViewOp, ...]] = {
+            name: tuple(ops) for name, ops in tensor_ops.items()
+        }
+        return ViewSpecBuildResult(proto=view_spec_proto, tensor_ops=ordered_ops)
+
+    def _build_view_index(
+        self,
+        *,
+        canonical_index: CanonicalIndex,
+        view_spec: ViewSpecBuildResult | None,
+        subset_names: Sequence[str] | None,
+    ) -> tuple[CanonicalIndex, tuple[str, ...]]:
+        base_entries = {entry.name: entry for entry in canonical_index.entries}
+        names = (
+            tuple(subset_names)
+            if subset_names is not None
+            else tuple(entry.name for entry in canonical_index.entries)
+        )
+        unknown = [name for name in names if name not in base_entries]
+        if unknown:
+            raise ArtifactError(
+                f"View references unknown tensor(s): {', '.join(sorted(unknown))}",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+
+        view_entries: list[CanonicalIndexEntry] = []
+        for name in names:
+            entry = base_entries[name]
+            ops = ()
+            if view_spec is not None:
+                ops = view_spec.tensor_ops.get(name, ())
+            view_entries.append(_apply_view_ops(entry, ops))
+
+        total = sum(entry.size_bytes for entry in view_entries)
+        view_index = CanonicalIndex(
+            entries=tuple(view_entries),
+            total_size_bytes=total,
+            avbs_hash=canonical_index.avbs_hash,
+        )
+        return view_index, tuple(names)
+
+
+class ViewBuilder:
+    """Fluent builder for composing multiple view operations before construction."""
+
+    def __init__(
+        self,
+        *,
+        artifact_ref: weakref.ReferenceType,
+        composer: ViewSpecComposer,
+    ) -> None:
+        self._artifact_ref = artifact_ref
+        self._composer = composer
+        self._slices: dict[str, Sequence[object]] = {}
+        self._transpose: dict[str, Sequence[tuple[int, int]]] = {}
+        self._subset: list[str] | None = None
+
+    def slice(self, tensor_slices: Mapping[str, Sequence[object]]) -> "ViewBuilder":
+        self._slices.update(tensor_slices)
+        return self
+
+    def transpose(
+        self, tensor_dims: Mapping[str, Sequence[tuple[int, int]]]
+    ) -> "ViewBuilder":
+        self._transpose.update(tensor_dims)
+        return self
+
+    def select(self, names: Sequence[str]) -> "ViewBuilder":
+        self._subset = list(names)
+        return self
+
+    def build(self):
+        artifact = self._artifact_ref()
+        if artifact is None:
+            raise ArtifactError(
+                "Artifact no longer available",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        return artifact._derive_view(
+            slices=self._slices or None,
+            transpose=self._transpose or None,
+            subset=self._subset,
+            composer=self._composer,
+        )
+
+
+__all__ = ["ViewBuilder", "ViewMetadataCache", "ViewSpecComposer"]

--- a/tensorcast/daemon_ctl.py
+++ b/tensorcast/daemon_ctl.py
@@ -528,6 +528,44 @@ class DaemonCtl:
                 raise RuntimeError("GetMaterializeCapabilities failed") from e
         return response
 
+    def query_replica_status(
+        self, ticket: store_daemon_v2_pb2.ReplicaTicket
+    ) -> store_daemon_v2_pb2.QueryReplicaStatusResponse:
+        with self._client_span("Client/QueryReplicaStatus") as span:
+            request = store_daemon_v2_pb2.QueryReplicaStatusRequest(ticket=ticket)
+            try:
+                response: store_daemon_v2_pb2.QueryReplicaStatusResponse = (
+                    self._unary_call(
+                        self.stub_v2.QueryReplicaStatus,
+                        request,
+                        timeout=5.0,
+                        span=span,
+                        retries=1,
+                    )
+                )
+            except grpc.RpcError as e:  # noqa: BLE001
+                span.record_exception(e)
+                raise
+        return response
+
+    def release_replica(
+        self, ticket: store_daemon_v2_pb2.ReplicaTicket
+    ) -> store_daemon_v2_pb2.ReleaseReplicaResponse:
+        with self._client_span("Client/ReleaseReplica") as span:
+            request = store_daemon_v2_pb2.ReleaseReplicaRequest(ticket=ticket)
+            try:
+                response: store_daemon_v2_pb2.ReleaseReplicaResponse = self._unary_call(
+                    self.stub_v2.ReleaseReplica,
+                    request,
+                    timeout=5.0,
+                    span=span,
+                    retries=1,
+                )
+            except grpc.RpcError as e:  # noqa: BLE001
+                span.record_exception(e)
+                raise
+        return response
+
     @overload
     def materialize_by_artifact_id_v2(
         self,
@@ -545,6 +583,7 @@ class DaemonCtl:
         preference: store_daemon_pb2.SourcePreference | None = None,
         tensor_names: Sequence[str] | None = None,
         verify_checksums: bool = True,
+        view_subset_hash: bytes | None = None,
     ) -> store_daemon_v2_pb2.MaterializeReplicaResponse: ...
 
     @overload
@@ -564,6 +603,7 @@ class DaemonCtl:
         preference: store_daemon_pb2.SourcePreference | None = None,
         tensor_names: Sequence[str] | None = None,
         verify_checksums: bool = True,
+        view_subset_hash: bytes | None = None,
     ) -> tuple[bytes, store_daemon_pb2.MaterializeReplicaStatus]: ...
 
     @overload
@@ -583,6 +623,7 @@ class DaemonCtl:
         preference: store_daemon_pb2.SourcePreference | None = None,
         tensor_names: Sequence[str] | None = None,
         verify_checksums: bool = True,
+        view_subset_hash: bytes | None = None,
     ) -> bytes: ...
 
     def materialize_by_artifact_id_v2(
@@ -600,6 +641,7 @@ class DaemonCtl:
         preference: store_daemon_pb2.SourcePreference | None = None,
         tensor_names: Sequence[str] | None = None,
         verify_checksums: bool = True,
+        view_subset_hash: bytes | None = None,
     ) -> (
         store_daemon_v2_pb2.MaterializeReplicaResponse
         | bytes
@@ -631,6 +673,8 @@ class DaemonCtl:
                 request.disk_fallback.verify_checksums = bool(verify_checksums)
             if tensor_names:
                 request.tensor_names.extend(tensor_names)
+            if view_subset_hash:
+                request.view_subset_hash = view_subset_hash
             if view is not None:
                 request.view.CopyFrom(view)
             elif view_id:
@@ -705,6 +749,7 @@ class DaemonCtl:
         return_response: Literal[True],
         preference: store_daemon_pb2.SourcePreference | None = None,
         tensor_names: Sequence[str] | None = None,
+        view_subset_hash: bytes | None = None,
     ) -> store_daemon_v2_pb2.MaterializeByKeyResponse: ...
 
     @overload
@@ -719,6 +764,7 @@ class DaemonCtl:
         return_response: Literal[False] = False,
         preference: store_daemon_pb2.SourcePreference | None = None,
         tensor_names: Sequence[str] | None = None,
+        view_subset_hash: bytes | None = None,
     ) -> tuple[bytes, store_daemon_pb2.MaterializeReplicaStatus, str, str]: ...
 
     @overload
@@ -733,6 +779,7 @@ class DaemonCtl:
         return_response: Literal[False] = False,
         preference: store_daemon_pb2.SourcePreference | None = None,
         tensor_names: Sequence[str] | None = None,
+        view_subset_hash: bytes | None = None,
     ) -> tuple[bytes, str, str]: ...
 
     def materialize_by_key_v2(
@@ -745,6 +792,7 @@ class DaemonCtl:
         return_response: bool = False,
         preference: store_daemon_pb2.SourcePreference | None = None,
         tensor_names: Sequence[str] | None = None,
+        view_subset_hash: bytes | None = None,
     ) -> (
         store_daemon_v2_pb2.MaterializeByKeyResponse
         | tuple[bytes, store_daemon_pb2.MaterializeReplicaStatus, str, str]
@@ -770,6 +818,8 @@ class DaemonCtl:
             )
             if tensor_names:
                 request.tensor_names.extend(tensor_names)
+            if view_subset_hash:
+                request.view_subset_hash = view_subset_hash
             try:
                 response: store_daemon_v2_pb2.MaterializeByKeyResponse = (
                     self._unary_call(
@@ -843,6 +893,44 @@ class DaemonCtl:
         if return_response:
             return response
         return (handle_bytes, used_disk_path, artifact_id)
+
+    def resolve_artifact_from_disk_v2(
+        self, *, disk_path: str, verify_checksums: bool = True
+    ) -> store_daemon_v2_pb2.ResolveArtifactFromDiskResponse:
+        if not disk_path:
+            raise ValueError("disk_path is required")
+        with self._client_span("Client/ResolveArtifactFromDiskV2") as span:
+            request = store_daemon_v2_pb2.ResolveArtifactFromDiskRequest(
+                disk_path=disk_path, verify_checksums=bool(verify_checksums)
+            )
+            try:
+                return self._unary_call(
+                    self.stub_v2.ResolveArtifactFromDisk,
+                    request,
+                    timeout=15.0,
+                    span=span,
+                    retries=1,
+                )
+            except grpc.RpcError as e:  # noqa: BLE001
+                span.record_exception(e)
+                code = e.code()
+                if code == grpc.StatusCode.UNAVAILABLE:
+                    raise RuntimeError(
+                        f"Local StoreDaemon ({self.server_address}) is not available."
+                    ) from e
+                if code == grpc.StatusCode.INVALID_ARGUMENT:
+                    raise ValueError(e.details() or str(e)) from e
+                if code == grpc.StatusCode.NOT_FOUND:
+                    raise FileNotFoundError(
+                        e.details() or "artifact not found on disk"
+                    ) from e
+                if code == grpc.StatusCode.PERMISSION_DENIED:
+                    raise PermissionError(
+                        e.details() or "disk_path not permitted"
+                    ) from e
+                raise RuntimeError(
+                    f"ResolveArtifactFromDiskV2 RPC failed: {e.details() or str(e)}"
+                ) from e
 
     def materialize_by_key(
         self,

--- a/tests/python/api/test_artifact_cache.py
+++ b/tests/python/api/test_artifact_cache.py
@@ -10,7 +10,7 @@ from tensorcast.api.store.cache import ArtifactCache, ArtifactCacheEntry
 from tensorcast.api.store.types import CanonicalIndex, CanonicalIndexEntry
 
 
-def _make_entry(artifact_id: str) -> ArtifactCacheEntry:
+def _make_entry(artifact_id: str, generation: int | None = None) -> ArtifactCacheEntry:
     entry = CanonicalIndexEntry(
         name="x",
         dtype=torch.float32,
@@ -25,7 +25,7 @@ def _make_entry(artifact_id: str) -> ArtifactCacheEntry:
         artifact_id=artifact_id,
         canonical_index_bytes=b'{"x":[0,4,[1],[1],"float32",0]}',
         parsed_index=index,
-        generation=None,
+        generation=generation,
         disk_path=None,
         expires_at=time.monotonic(),
     )
@@ -40,6 +40,14 @@ def test_cache_hit_and_ttl_expiry():
     assert cached.hit_count == 1
     time.sleep(0.02)
     assert cache.get_artifact_index_cached("a1") is None
+
+
+def test_cache_round_trip_preserves_generation():
+    cache = ArtifactCache(daemon_endpoint="daemon", ttl_seconds=10, max_entries=2)
+    cache.cache_artifact_index(_make_entry("g1", generation=9))
+    cached = cache.get_artifact_index_cached("g1")
+    assert cached is not None
+    assert cached.generation == 9
 
 
 def test_cache_lru_eviction():

--- a/tests/python/api/test_artifact_handle.py
+++ b/tests/python/api/test_artifact_handle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 import weakref
 from typing import cast
@@ -113,6 +114,9 @@ class _RuntimeStub:
 
     def get_artifact_index_cached(self, artifact_id: str):
         return self._artifact_cache.get_artifact_index_cached(artifact_id)
+
+    def get_artifact_index_by_disk_path(self, disk_path: str):
+        return self._artifact_cache.get_artifact_index_by_disk_path(disk_path)
 
     def invalidate_artifact(self, artifact_id: str | None, *, key=None, reason=None) -> None:
         self._artifact_cache.invalidate_artifact(artifact_id or "", reason=reason)
@@ -320,3 +324,82 @@ def test_from_disk_resolves_once_and_caches_generation():
     assert cached.canonical_index_bytes == canonical_bytes
     assert cached.generation == 11
     assert cached.disk_path == "/tmp/artifact"
+
+
+def test_from_disk_uses_cached_entry_for_disk_path():
+    canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
+    client = _ClientStub(canonical_bytes, disk_generation=5, disk_artifact_id="disk-aid")
+    runtime = _RuntimeStub(client)
+    cache_entry = ArtifactCacheEntry(
+        artifact_id="disk-aid",
+        canonical_index_bytes=canonical_bytes,
+        parsed_index=canonical_index_from_bytes(canonical_bytes),
+        generation=5,
+        disk_path="/tmp/artifact",
+        expires_at=time.monotonic() + 5.0,
+    )
+    runtime.cache_artifact_index(cache_entry)
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(
+        store_ref=_store_ref(store),
+        disk_path="/tmp/artifact",
+        fallback=FallbackOptions.for_disk("/tmp/artifact"),
+    )
+
+    desc = artifact.describe()
+
+    assert desc.artifact_id == "disk-aid"
+    assert desc.generation == 5
+    assert client.resolve_calls == []
+    assert client.get_index_calls == 0
+
+
+def test_disk_cache_mismatch_invalidates_and_refetches():
+    canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
+    client = _ClientStub(canonical_bytes)
+    runtime = _RuntimeStub(client)
+    stale_entry = ArtifactCacheEntry(
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+        parsed_index=canonical_index_from_bytes(canonical_bytes),
+        generation=1,
+        disk_path="/other/path",
+        expires_at=time.monotonic() + 5.0,
+    )
+    runtime.cache_artifact_index(stale_entry)
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(
+        store_ref=_store_ref(store), artifact_id="aid", disk_path="/real/path"
+    )
+
+    _ = artifact.tensor_names
+
+    assert client.get_index_calls == 1
+    refreshed = runtime.get_artifact_index_cached("aid")
+    assert refreshed is not None
+    assert refreshed.disk_path == "/real/path"
+
+
+def test_ensure_metadata_sets_under_lock(monkeypatch):
+    canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
+    client = _ClientStub(canonical_bytes)
+    runtime = _RuntimeStub(client)
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(store_ref=_store_ref(store), artifact_id="aid")
+
+    lock_checked = threading.Event()
+    original_set_metadata = Artifact._set_metadata
+
+    def _wrapped(self, *args, **kwargs):
+        if not self._lock._is_owned():
+            raise AssertionError("metadata updated without holding artifact lock")
+        lock_checked.set()
+        return original_set_metadata(self, *args, **kwargs)
+
+    monkeypatch.setattr(Artifact, "_set_metadata", _wrapped)
+
+    assert artifact.tensor_names == ("foo",)
+    assert lock_checked.is_set()

--- a/tests/python/api/test_artifact_handle.py
+++ b/tests/python/api/test_artifact_handle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 import weakref
 from typing import cast
 
@@ -12,7 +13,8 @@ import torch
 from tensorcast.api._materialize import MaterializationPayload, TensorPayloadDescriptor
 from tensorcast.api.store import Store
 from tensorcast.api.store.artifact import Artifact
-from tensorcast.api.store.cache import ArtifactCache
+from tensorcast.api.store.cache import ArtifactCache, ArtifactCacheEntry
+from tensorcast.api.store.common import canonical_index_from_bytes
 from tensorcast.api.store.types import ArtifactError, FallbackOptions, StoreOptions
 from tensorcast.api.store.retry import build_retry_policies
 
@@ -52,14 +54,39 @@ def _build_payload(tensors: dict[str, torch.Tensor]) -> tuple[bytes, Materializa
 
 
 class _ClientStub:
-    def __init__(self, canonical_index_bytes: bytes) -> None:
+    def __init__(
+        self,
+        canonical_index_bytes: bytes,
+        *,
+        disk_generation: int | None = None,
+        disk_artifact_id: str | None = None,
+    ) -> None:
         self.canonical_index_bytes = canonical_index_bytes
+        self.disk_generation = disk_generation
+        self.disk_artifact_id = disk_artifact_id
         self.unloaded: list[tuple[str, str]] = []
         self.get_index_calls = 0
+        self.resolve_calls: list[tuple[str, bool]] = []
 
     def get_artifact_index_by_id(self, artifact_id: str) -> bytes:
         self.get_index_calls += 1
         return self.canonical_index_bytes
+
+    def resolve_artifact_from_disk_v2(
+        self, *, disk_path: str, verify_checksums: bool = True
+    ):
+        self.resolve_calls.append((disk_path, bool(verify_checksums)))
+        generation = self.disk_generation if self.disk_generation is not None else 0
+
+        class _Resp:
+            pass
+
+        resp = _Resp()
+        resp.artifact_id = self.disk_artifact_id or f"disk:{disk_path}"
+        resp.disk_path = disk_path
+        resp.canonical_index_bytes = self.canonical_index_bytes
+        resp.generation = generation
+        return resp
 
     def unload_replica(self, replica_uuid: str, *, disk_path: str = "") -> bool:
         self.unloaded.append((replica_uuid, disk_path))
@@ -227,6 +254,28 @@ def test_with_fallback_handles_multiple_identifiers():
     assert clone.tensor_names == ("foo",)
 
 
+def test_describe_uses_cached_generation_without_fetch():
+    canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
+    runtime = _RuntimeStub(_ClientStub(canonical_bytes))
+    cache_entry = ArtifactCacheEntry(
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+        parsed_index=canonical_index_from_bytes(canonical_bytes),
+        generation=42,
+        disk_path=None,
+        expires_at=time.monotonic() + 1.0,
+    )
+    runtime.cache_artifact_index(cache_entry)
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(store_ref=_store_ref(store), artifact_id="aid")
+
+    desc = artifact.describe()
+
+    assert desc.generation == 42
+    assert runtime._client.get_index_calls == 0
+
+
 def test_from_dict_accepts_key_and_artifact_id():
     canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
     runtime = _RuntimeStub(_ClientStub(canonical_bytes))
@@ -242,3 +291,32 @@ def test_from_dict_accepts_key_and_artifact_id():
     assert restored.artifact_id == "aid"
     assert restored.key == "mapped"
     assert restored.tensor_names == ("foo",)
+
+
+def test_from_disk_resolves_once_and_caches_generation():
+    canonical_bytes, payload = _build_payload({"foo": torch.ones(1)})
+    client = _ClientStub(
+        canonical_bytes, disk_generation=11, disk_artifact_id="disk-aid"
+    )
+    runtime = _RuntimeStub(client)
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(
+        store_ref=_store_ref(store),
+        disk_path="/tmp/artifact",
+        fallback=FallbackOptions.for_disk("/tmp/artifact"),
+    )
+
+    desc = artifact.describe()
+    repeat = artifact.describe()
+
+    assert desc.artifact_id == "disk-aid"
+    assert desc.generation == 11
+    assert repeat.generation == 11
+    assert client.resolve_calls == [("/tmp/artifact", True)]
+    assert client.get_index_calls == 0
+    cached = runtime.get_artifact_index_cached("disk-aid")
+    assert cached is not None
+    assert cached.canonical_index_bytes == canonical_bytes
+    assert cached.generation == 11
+    assert cached.disk_path == "/tmp/artifact"

--- a/tests/python/api/test_fallback_options.py
+++ b/tests/python/api/test_fallback_options.py
@@ -1,0 +1,19 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from tensorcast.api.store.types import FallbackOptions
+
+
+def test_fallback_options_compat_prefer_disk():
+    opts = FallbackOptions(prefer="auto", prefer_disk=True, disk_path="/tmp/x")
+    assert opts.prefer == "auto"
+    assert opts.prefer_disk is True
+    disk_opts = FallbackOptions.for_disk("/tmp/y")
+    assert disk_opts.prefer == "disk"
+    assert disk_opts.allow_p2p is False
+    assert disk_opts.disk_path == "/tmp/y"
+
+
+def test_fallback_options_local_only():
+    opts = FallbackOptions.local_only()
+    assert opts.prefer == "local"
+    assert opts.allow_p2p is False

--- a/tests/python/api/test_materialization_pipeline_v2.py
+++ b/tests/python/api/test_materialization_pipeline_v2.py
@@ -16,6 +16,7 @@ from tensorcast.api.store.materialization import MaterializationPipeline
 from tensorcast.api.store.retry import build_retry_policies
 from tensorcast.api.store.types import ArtifactError, FallbackOptions, StoreOptions
 from tensorcast.api.store.views import ViewOrchestrator
+from tensorcast.proto.daemon.v2 import store_daemon_pb2 as store_daemon_v2_pb2
 
 
 @pytest.fixture(autouse=True)
@@ -35,6 +36,14 @@ def _patch_validate_targets(monkeypatch):
         return pairs
 
     monkeypatch.setattr(mat_mod, "validate_targets", _pair)
+
+
+def test_materialization_proto_alignment():
+    resp = store_daemon_v2_pb2.MaterializeReplicaResponse()
+    assert hasattr(resp, "canonical_index_bytes")
+    assert hasattr(resp, "view_index_bytes")
+    assert hasattr(resp, "generation")
+    assert not hasattr(resp, "canonical_index_json")
 
 
 class _DummySpan:

--- a/tests/python/api/test_materialization_pipeline_v2.py
+++ b/tests/python/api/test_materialization_pipeline_v2.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import concurrent.futures
 import json
 import threading
+import time
 from contextlib import contextmanager
 from typing import Callable
 
@@ -12,10 +13,13 @@ import pytest
 import torch
 
 from tensorcast.api._materialize import MaterializationPayload, TensorPayloadDescriptor
+from tensorcast.api.store.cache import ArtifactCache, ArtifactCacheEntry
+from tensorcast.api.store.common import canonical_index_from_bytes
 from tensorcast.api.store.materialization import MaterializationPipeline
 from tensorcast.api.store.retry import build_retry_policies
 from tensorcast.api.store.types import ArtifactError, FallbackOptions, StoreOptions
 from tensorcast.api.store.views import ViewOrchestrator
+from tensorcast.proto.daemon.v1 import store_daemon_pb2
 from tensorcast.proto.daemon.v2 import store_daemon_pb2 as store_daemon_v2_pb2
 
 
@@ -68,10 +72,26 @@ class _DummySpan:
 class _FakeClient:
     def __init__(self) -> None:
         self.unloaded: list[str] = []
+        self.resolve_calls: list[tuple[str, bool]] = []
 
     def unload_replica(self, replica_uuid: str, *, disk_path: str = "") -> bool:
         self.unloaded.append(f"{replica_uuid}:{disk_path}")
         return True
+
+    def resolve_artifact_from_disk_v2(
+        self, *, disk_path: str, verify_checksums: bool = True
+    ):
+        self.resolve_calls.append((disk_path, bool(verify_checksums)))
+
+        class _Resp:
+            pass
+
+        resp = _Resp()
+        resp.artifact_id = "aid"
+        resp.disk_path = disk_path
+        resp.canonical_index_bytes = json.dumps({}).encode("utf-8")
+        resp.generation = 0
+        return resp
 
 
 class _RuntimeStub:
@@ -83,6 +103,9 @@ class _RuntimeStub:
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
         self.client = _FakeClient()
         self.futures: list[object] = []
+        self._artifact_cache = ArtifactCache(
+            daemon_endpoint="daemon", ttl_seconds=10, max_entries=8
+        )
 
     def track_future(self, future: concurrent.futures.Future[object]) -> None:
         self.futures.append(future)
@@ -92,6 +115,12 @@ class _RuntimeStub:
 
     def ensure_client(self) -> _FakeClient:
         return self.client
+
+    def cache_artifact_index(self, entry: ArtifactCacheEntry) -> None:
+        self._artifact_cache.cache_artifact_index(entry)
+
+    def get_artifact_index_by_disk_path(self, disk_path: str):
+        return self._artifact_cache.get_artifact_index_by_disk_path(disk_path)
 
     def cache_key_mapping(self, *_, **__) -> None:  # pragma: no cover - noop
         return None
@@ -267,6 +296,79 @@ def test_disk_fallback_verify_flag_passed():
     runtime.close()
 
     assert captured["verify_checksums"] is False
+
+
+def test_disk_path_hint_prefers_disk_without_fallback():
+    runtime = _RuntimeStub()
+    views = ViewOrchestrator(runtime)
+    pipeline = MaterializationPipeline(runtime, views)
+    captured: dict[str, object] = {}
+
+    def fake_materialize(**kwargs):
+        captured["preference"] = kwargs.get("preference")
+        captured["disk_path_hint"] = kwargs.get("disk_path_hint")
+        captured["artifact_id"] = kwargs.get("artifact_id")
+        return _make_payload({"a": torch.ones(1)}, replica_uuid="disk")
+
+    pipeline.set_materialize_fn(fake_materialize)
+    materialized, _ = pipeline.materialize_subset(
+        artifact_id=None,
+        key=None,
+        device=0,
+        fallback=None,
+        tensor_names=None,
+        disk_path_hint="/tmp/artifact",
+    )
+    runtime.close()
+
+    assert captured["disk_path_hint"] == "/tmp/artifact"
+    assert (
+        captured["preference"]
+        == store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
+    )
+    assert runtime.client.resolve_calls == [("/tmp/artifact", True)]
+    assert materialized.replica_uuid == "disk"
+
+
+def test_disk_path_cache_reuses_index_without_resolve():
+    runtime = _RuntimeStub()
+    views = ViewOrchestrator(runtime)
+    pipeline = MaterializationPipeline(runtime, views)
+    payload = _make_payload({"a": torch.ones(1)}, generation=7)
+    canonical_bytes = payload.canonical_index_bytes
+    cache_entry = ArtifactCacheEntry(
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+        parsed_index=canonical_index_from_bytes(canonical_bytes),
+        generation=7,
+        disk_path="/tmp/artifact",
+        expires_at=time.monotonic() + 5.0,
+    )
+    runtime.cache_artifact_index(cache_entry)
+    captured: dict[str, object] = {}
+
+    def fake_materialize(**kwargs):
+        captured["artifact_id"] = kwargs.get("artifact_id")
+        captured["canonical_index_hint"] = kwargs.get("canonical_index_hint")
+        captured["generation_hint"] = kwargs.get("generation_hint")
+        return payload
+
+    pipeline.set_materialize_fn(fake_materialize)
+    materialized, _ = pipeline.materialize_subset(
+        artifact_id=None,
+        key=None,
+        device=0,
+        fallback=None,
+        tensor_names=None,
+        disk_path_hint="/tmp/artifact",
+    )
+    runtime.close()
+
+    assert captured["artifact_id"] == "aid"
+    assert captured["canonical_index_hint"] == canonical_bytes
+    assert captured["generation_hint"] == 7
+    assert runtime.client.resolve_calls == []
+    assert materialized.generation == 7
 
 
 def test_materialize_subset_preserves_generation():

--- a/tests/python/api/test_view_composer.py
+++ b/tests/python/api/test_view_composer.py
@@ -2,8 +2,13 @@
 
 import torch
 
+from tensorcast.api._view_ops import NarrowOp
 from tensorcast.api.store.types import CanonicalIndex, CanonicalIndexEntry
-from tensorcast.api.store.view_composer import ViewSpecComposer
+from tensorcast.api.store.view_composer import (
+    ViewSpecComposer,
+    _apply_view_ops,
+    _compose_narrow,
+)
 
 
 def _index() -> CanonicalIndex:
@@ -84,3 +89,34 @@ def test_view_composer_transpose_hash_stable():
     h1 = composer.hash_view_spec(spec, subset=("a", "b"))
     h2 = composer.hash_view_spec(spec, subset=("a", "b"))
     assert h1 == h2
+
+
+def test_compose_narrow_collapses_parent_and_child():
+    parent = NarrowOp(dim=1, start=1, length=2)
+    child = NarrowOp(dim=1, start=1, length=1)
+    ops = _compose_narrow(
+        base_shape=(4, 4),
+        parent=parent,
+        child=child,
+        tensor_name="a",
+    )
+    assert len(ops) == 1
+    fused = ops[0]
+    assert isinstance(fused, NarrowOp)
+    assert fused.start == 2
+    assert fused.length == 1
+
+
+def test_compose_narrow_storage_offset_applies_once():
+    base_entry = _index().entries[0]
+    parent = NarrowOp(dim=0, start=2, length=2)
+    child = NarrowOp(dim=0, start=1, length=1)
+    ops = _compose_narrow(
+        base_shape=base_entry.shape,
+        parent=parent,
+        child=child,
+        tensor_name="a",
+    )
+    view_entry = _apply_view_ops(base_entry, ops)
+    expected_offset = (parent.start + child.start) * base_entry.stride[0]
+    assert view_entry.storage_offset == expected_offset

--- a/tests/python/api/test_view_composer.py
+++ b/tests/python/api/test_view_composer.py
@@ -1,0 +1,86 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+import torch
+
+from tensorcast.api.store.types import CanonicalIndex, CanonicalIndexEntry
+from tensorcast.api.store.view_composer import ViewSpecComposer
+
+
+def _index() -> CanonicalIndex:
+    return CanonicalIndex(
+        entries=(
+            CanonicalIndexEntry(
+                name="a",
+                dtype=torch.float32,
+                shape=(4, 4),
+                stride=(4, 1),
+                storage_offset=0,
+                segment_offset=0,
+                size_bytes=64,
+            ),
+            CanonicalIndexEntry(
+                name="b",
+                dtype=torch.float32,
+                shape=(2, 2),
+                stride=(2, 1),
+                storage_offset=0,
+                segment_offset=64,
+                size_bytes=16,
+            ),
+        ),
+        total_size_bytes=80,
+        avbs_hash="",
+    )
+
+
+def test_view_composer_composes_narrow():
+    composer = ViewSpecComposer()
+    base_index = _index()
+
+    parent = composer.compose(
+        canonical_index=base_index,
+        parent_spec=None,
+        child_spec=composer.compose(
+            canonical_index=base_index,
+            parent_spec=None,
+            child_spec=None,
+            parent_depth=0,
+            subset_names=None,
+        )[0],
+        parent_depth=0,
+        subset_names=None,
+    )[0]
+
+    child_spec, cache, depth = composer.compose(
+        canonical_index=base_index,
+        parent_spec=parent,
+        child_spec=composer.compose(
+            canonical_index=base_index,
+            parent_spec=None,
+            child_spec=None,
+            parent_depth=0,
+            subset_names=None,
+        )[0],
+        parent_depth=0,
+        subset_names=["a"],
+    )
+
+    assert depth <= 8
+    assert cache is not None
+    assert cache.tensor_names == ("a",)
+    assert child_spec is None or child_spec.is_identity
+
+
+def test_view_composer_transpose_hash_stable():
+    composer = ViewSpecComposer()
+    base_index = _index()
+    spec, cache, _ = composer.compose(
+        canonical_index=base_index,
+        parent_spec=None,
+        child_spec=None,
+        parent_depth=0,
+        subset_names=["a", "b"],
+    )
+    h1 = composer.hash_view_spec(spec, subset=("a", "b"))
+    h2 = composer.hash_view_spec(spec, subset=("a", "b"))
+    assert h1 == h2

--- a/tests/python/test_store_session_api.py
+++ b/tests/python/test_store_session_api.py
@@ -55,6 +55,7 @@ class FakeDaemonCtl:
         self.keepalive_calls: list[tuple[str, int, int]] = []
         self.server_address = "fake://daemon"
         self.resolve_calls: list[str] = []
+        self.resolve_disk_calls: list[tuple[str, bool]] = []
 
     def get_server_config(self) -> ServerConfig:
         return ServerConfig(tx_slice_bytes=4096, mem_pool_size=1 << 20, artifact_chunk_bytes=1 << 18)
@@ -62,6 +63,26 @@ class FakeDaemonCtl:
     def resolve_key_mapping(self, key: str) -> tuple[str | None, str | None]:
         self.resolve_calls.append(key)
         return self.resolves.get(key, (None, None))
+
+    def resolve_artifact_from_disk_v2(
+        self, *, disk_path: str, verify_checksums: bool = True
+    ):
+        self.resolve_disk_calls.append((disk_path, bool(verify_checksums)))
+        artifact_id = None
+        for resolved_id, mapped_path in self.resolves.values():
+            if mapped_path == disk_path and resolved_id:
+                artifact_id = resolved_id
+                break
+
+        class _Resp:
+            pass
+
+        resp = _Resp()
+        resp.artifact_id = artifact_id or ""
+        resp.disk_path = disk_path
+        resp.canonical_index_bytes = json.dumps({}, separators=(",", ":")).encode("utf-8")
+        resp.generation = 0
+        return resp
 
     def keep_alive_registered_artifact(self, registration_id: str, ttl_ms: int, epoch: int) -> bool:  # noqa: D401
         self.keepalive_calls.append((registration_id, ttl_ms, epoch))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add v2 RPCs (disk resolve + ticket status/release), switch index fields to bytes with generation, and deliver lazy handle views/batching/async/prefetch in SDK with new metrics and tests.
> 
> - **Daemon (C++)**:
>   - Add `ResolveArtifactFromDisk` RPC and handler; validate/whitelist paths and return `{artifact_id, canonical_index_bytes, generation}`.
>   - Extend v2 materialization: return `canonical_index_bytes`/`view_index_bytes` (replacing `*_json`) and compute `generation`; propagate `view_subset_hash` and payloads; fill `view_index_bytes` for by-key.
>   - Wire new v2 RPCs: `QueryReplicaStatus`/`ReleaseReplica`.
> - **Proto** (`tensorcast.daemon.v2`):
>   - Add services/messages for disk resolve and replica ticket query/release.
>   - Update responses to `*_bytes` fields and add `uint64 generation`; extend requests with `view_subset_hash`.
> - **Python SDK**:
>   - Implement Phase 3 lazy handle: `.view()/.subset()/.slice()`, `ViewSpecComposer`, `BatchContext`, `MaterializationBatcher`, async `tensor*`, and `prefetch()` with tickets.
>   - Materialization pipeline: support source preferences, disk resolution via daemon, view hints/subset hashes, `replica_uuid`, and stricter fallback enforcement; preserve `generation`.
>   - Runtime: add asyncio event loop; clean shutdown; feature flags for batcher/prefetch; expose `artifact_async` and `from_disk`.
>   - Metrics: add batch/prefetch counters and histogram.
>   - Daemon client: add v2 helpers for disk resolve/ticket query-release; pass `view_subset_hash`.
> - **Docs**: Update architecture/designs and SDK README to reflect v2 fields, disk resolve, views/batching/async/prefetch, and feature flags.
> - **Tests**: Add/extend tests for cache generation, proto alignment, view composer, pipeline behaviors, and disk resolution caching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47fb544520a4a5c3b3424179d791be7d7d0764f9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->