### PR TITLE
feat(api): enhance artifact-first SDK with public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ ctx = init()  # or init(address="auto")
 
 # Force local launch (private session). If daemon_config_path is omitted,
 # init() will try $TENSORCAST_DAEMON_CONFIG, ~/.tensorcast/store_daemon_config.yaml,
-# or examples/config/store_daemon_config.yaml.
+# examples/config/store_daemon_config.yaml, and finally an embedded loopback config
+# with ephemeral ports and a writable cache under ~/.tensorcast (or a temp dir).
 # Private launches do not publish ~/.tensorcast/current_session or meta.json and bind to 127.0.0.1.
 ctx = init(address="local", daemon_config_path="examples/config/store_daemon_config.yaml")
 
@@ -158,10 +159,11 @@ tc.init(address="auto")
 state_dict = {"layer.weight": torch.randn(8, 8, device="cuda")}
 
 registered = tc.register(state_dict, key="demo:model:001")
-latest = tc.get(key="demo:model:001", device="cuda:0")
+handle = tc.artifact(key="demo:model:001")
+latest = handle.tensor_dict(device="cuda:0")
 
 buffers = {"layer.weight": torch.empty_like(state_dict["layer.weight"])}
-tc.get_into(buffers, artifact_id=registered.artifact_id, device="cuda:0")
+handle.tensor_dict_into(buffers, device="cuda:0")
 ```
 
 For advanced scenarios (async verbs, fine-grained inspection, or direct access to diagnostics) use

--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ latest = handle.tensor_dict(device="cuda:0")
 
 buffers = {"layer.weight": torch.empty_like(state_dict["layer.weight"])}
 handle.tensor_dict_into(buffers, device="cuda:0")
+
+# Stream a single tensor directly into an existing buffer without populating a
+# full mapping. TensorCast copies only the requested tensor.
+target = torch.empty_like(state_dict["layer.weight"])
+handle.tensor_into("layer.weight", target, device="cuda:0")
+
+# Issue background materialization without mutating the original handle.
+prefetched, ticket = handle.prefetch(device="cuda:0")
+ticket.wait(timeout=5.0)
+prefetched.tensor_dict(device="cuda:0")
 ```
 
 For advanced scenarios (async verbs, fine-grained inspection, or direct access to diagnostics) use

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -70,13 +70,12 @@ graph TD
 ### 3. User Process Worker
 **Role**: PyTorch client process accessing artifacts
 
-- **Interface**: Uses the functional facade (`tensorcast.get`, `tensorcast.get_into`) backed by the shared Store to request artifacts via daemon `MaterializeByKey` (RFC‑0017).
+- **Interface**: Uses the handle-first facade (`tensorcast.artifact(...).tensor_dict` / `.tensor_into`) backed by the shared Store to request artifacts via daemon `MaterializeByKey` (RFC‑0017).
 - **Memory Access**: Maps CUDA IPC handles for zero‑copy GPU access; falls back to RAM/DISK as needed
 - **Lifecycle**: Confirms, references, and unloads replicas via daemon RPCs
 - **Lazy Handles**: `tensorcast.artifact(...)` returns a store-bound handle that
-  exposes metadata (`tensor_names`, `describe`) and selective tensor fetch
-  without changing the eager `get*` APIs. Handles surface
-  `FAILED_PRECONDITION` if used after `Store.close()`.
+  exposes metadata (`tensor_names`, `describe`) and selective tensor fetch; it
+  surfaces `FAILED_PRECONDITION` if used after `Store.close()`.
 - **Disk-backed Handles**: `tensorcast.from_disk(path)` routes through the
   daemon (`ResolveArtifactFromDisk`) so disk paths stay daemon-owned. The RPC
   enforces whitelist entries, validates descriptor multihashes when requested

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -92,9 +92,10 @@ graph TD
 - **Batching & Async**: `BatchContext` batches sync fetches; async
   `.tensor_async()`/`.tensor_dict_async()` coalesce via `MaterializationBatcher`
   on the store event loop.
-- **Prefetch Tickets**: `prefetch(wait_for_completion=False)` returns replica
-  tickets propagated through `FallbackOptions.replica_uuid` to reuse staged
-  replicas without reloading.
+- **Prefetch Tickets**: `prefetch(wait_for_completion=False)` returns a cloned
+  handle plus a replica ticket. The clone carries the ticket’s
+  `replica_uuid` hint while the original handle remains untouched; callers use
+  the ticket to `wait()` or `cancel()` the staged replica before materializing.
 
 ## Key Design Principles
 

--- a/docs/designs/0017-client-generated-artifact-id.md
+++ b/docs/designs/0017-client-generated-artifact-id.md
@@ -68,7 +68,7 @@ tc.register(tensors, *,
 
 # Convenience wrappers (optional):
 # tc.register_cgid(tensors, cgid: str, *, key=None, ttl_ms=None)
-# tc.register_kv_block({"k": k, "v": v}, block_hash, *, ttl_ms=None)  # internally uses artifact_id=f"cgid:{block_hash}"
+# Deprecated helper: use `tc.register(..., artifact_id=f"cgid:{block_hash}")` to reuse KV layouts.
 ```
 
 Rules

--- a/docs/designs/0021-region‑backed-registration.md
+++ b/docs/designs/0021-region‑backed-registration.md
@@ -138,7 +138,7 @@ The design maintains backward compatibility by marking new fields as optional an
 - Capability negotiation:
   - During session establishment, clients detect whether the daemon advertises `region_registration_capability`.
   - When absent, SDK silently keeps the legacy handle path and hides region APIs behind a runtime check (raising `UnsupportedFeatureError` if invoked).
-- Convenience helper: expose `Store.register_kv_block(kv_pair, block_hash, ttl_ms=...)` that enforces `artifact_id=f"cgid:kv:{block_hash}"`, registers backing regions first when needed, and emits metrics for reuse.
+- Convenience helper (removed in 0039): instead of `Store.register_kv_block(...)`, rely on standard `register(...)` with region reuse and consistent `artifact_id`/`key` conventions for KV layouts.
 
 ## Global Store (`tensorcast/global_store/`)
 

--- a/docs/designs/0039-artifact-first-sdk.md
+++ b/docs/designs/0039-artifact-first-sdk.md
@@ -1,0 +1,138 @@
+---
+slug: 0039-artifact-first-sdk
+title: Artifact-First TensorCast SDK API
+links: {}
+areas: ["sdk"]
+related_code:
+  - tensorcast/startup.py
+  - tensorcast/api/store/__init__.py
+  - tensorcast/api/store/artifact.py
+  - tensorcast/api/store/materialization.py
+  - tensorcast/api/store/registration.py
+---
+
+# Summary
+
+Define a single, artifact-first Python SDK surface that is easy to learn, consistent, and free of redundant entry points. The SDK assumes one daemon per process and exposes functional helpers plus a single handle type (`Artifact`). Retrieval flows are handle-driven; legacy eager verbs (`get`, `get_into`, `get_view`, etc.) will be removed after the migration in favor of `artifact(...).tensor_*`. Ingestion remains explicit via `register`/`put` and view registration. Region-backed flows stay available but clearly separated as lifecycle utilities.
+
+# Goals / Non-Goals
+
+Goals
+- One-concept-per-interface: each user goal maps to exactly one public function or method.
+- Artifact-first retrieval: all fetch, view, batch, async, and prefetch flows hang off `Artifact`.
+- Minimal, user-friendly parameters: hide internal knobs; keep enums small and intention-based.
+- Default “just works”: per-process daemon launch via `tc.init()`, lazy resolution, P2P-by-default retrieval with safe fallbacks.
+- Clean slate: remove redundant/legacy verbs once the new surface ships (no compatibility constraints).
+
+Non-Goals
+- Changing daemon/Global Store RPC schemas or wire formats (reuse existing v2 flows).
+- Altering C++ core, UMA, or transport internals.
+- Adding new persistence schemas (no `schema.sql` changes).
+
+# Architecture & Interfaces
+
+## Top-Level API (functional)
+
+- `tc.init(address="local", daemon_config_path=None, wait=True, timeout=20.0, show_daemon_logs=True, install_signal_handlers=False, fate_share_sigterm=False)`  
+  Launch or connect to a single per-process daemon (prefers launch); sets global daemon address used by the process Store.  
+  **Default config:** if no config path is provided and none is discoverable, the SDK falls back to an embedded minimal daemon config (loopback bind, ephemeral or standard port, default cache path) so `tc.init()` “just works” after install.
+- `tc.shutdown()`, `tc.is_initialized()`.
+- `tc.artifact(key=None, artifact_id=None, disk_path=None, fallback=None) -> Artifact`  
+  Lazy handle factory; no data transfer; resolves key/disk lazily on first touch. `artifact_async(...)` mirrors it.
+- `tc.from_disk(path, *, fallback=None) -> Artifact`  
+  Convenience wrapper for `disk_path=...`.
+- Ingestion:
+  - `tc.register(tensors, *, key=None, artifact_id=None, options=None, ttl_ms=None)` / `register_async(...)`.
+  - `tc.put(tensors, *, key=None, artifact_id=None, options=None, device=None)` / `put_async(...)`.
+  - `tc.register_view(tensors, *, key=None, artifact_id=None, slices=None, transpose=None, view_id=None, placement=None, ttl_ms=None, allow_partial=False, options=None)`.
+- Region & lifecycle (advanced):
+  - `tc.register_vram_region(device_id, base_ptr, size_bytes, ttl_ms, name=None) -> VramRegionHandle`.
+  - `tc.unregister_vram_region(region_id, *, force=None) -> bool`.
+  - `tc.deregister_artifact(artifact_id, *, wait=True, drain_timeout_s=None, extend_ttl_ms=None, device_id=None) -> DeregisterArtifactOutcome`.
+
+Removed after migration: module-level `get`, `get_into`, `get_view`, `get_view_into` (sync/async); `store()` remains for advanced callers but is not required for common flows.
+
+## Artifact Handle (single retrieval surface)
+
+- Identity & metadata: `.artifact_id`, `.key`, `.tensor_names`, `.tensor_meta(name)`, `.describe()`, `.exists()`, `.is_valid`, `.release()`.
+- Materialization (sync): `.tensor_dict(device, names=None)`, `.tensor(name, device)`, `.tensor_dict_into(target, device=None)`.
+- Symmetry convenience (proposed): `.tensor_into(name, target_tensor, device=None)` as a thin helper over `tensor_dict_into({name: target_tensor}, ...)`.
+- Materialization (async): `.tensor_async(name, device)`, `.tensor_dict_async(device, names=None)`.
+- Views/composition: `.view(slices=None, transpose=None, names=None)`, `.subset(names)`, `.slice({...})`, `.view_builder()`.
+- Performance helpers: `.batch(device=...) -> BatchContext`, `.prefetch(device=...) -> PrefetchTicket`.
+- Policy override: `.with_fallback(FallbackOptions(...))`.
+- Serialization (process-local): `.to_dict()`, `.from_dict(data, store)`.
+
+All retrieval flows pass through `MaterializationPipeline` with canonical index caching (`ArtifactCache`) and optional view metadata caching.
+
+## Region-Backed Layout Reuse (no KV-only helper)
+
+- Region registration (`register_vram_region` / `unregister_vram_region`) remains the single mechanism for reusing GPU slabs across multiple artifacts, regardless of payload type (KV blocks, rolling weights, activations).
+- Standard `register`/`put` automatically detect registered regions and emit region-backed leases; there is no KV-specific helper. Users publish multiple artifacts (e.g., weight v1/v2 on the same base_ptr) by calling `register` with different `artifact_id`/`key`; the runtime maps storages to regions and avoids duplicate handle exports.
+- For repeated updates of the same layout, callers should choose stable `artifact_id`/`key` conventions (e.g., `model:latest`, `model:v2`, `cgid:...`) and rely on region reuse rather than special-purpose APIs.
+
+## Options and Enums (user-friendly)
+
+- `FallbackOptions`: `prefer` = `"auto" | "local" | "p2p" | "disk"` (default `"auto"`); `disk_path`; `allow_p2p` (default `True`); `verify_checksums` (default `True`); `replica_uuid` (prefetch reuse). Helpers: `for_disk(path, verify=True)`, `local_only()`. Accept string shortcuts at the surface (e.g., `fallback="disk:/tmp/foo"` → `for_disk`).
+- `PlanType`: user-facing strings `plan="lease" | "copy"` (default `lease`), coerced internally to `PlanType.VRAM_LEASED` / `PlanType.VRAM_COALESCED`; enum remains for power users.
+- `RegisterArtifactOptions`: public-facing fields `plan`, `lease_in_place`, `max_inflight_bytes`, `release_on_tensor_commit`; accept string `plan` and map to enum internally; keep advanced knobs optional.
+- `GetArtifactOptions`: `prefer` (mirrors `FallbackOptions`), `wait_for_completion` (default `True`), `enable_verification` (default `True`), `transport_hold_ms` (advanced).
+- Devices: accept `str | torch.device`; default to current CUDA device if available, otherwise require explicit CPU with disk fallback.
+
+## Behavioral Notes
+
+- Lazy resolution: `artifact()` creates a handle; first access may resolve key→artifact_id via daemon (and GS behind it) and hydrate canonical index into `ArtifactCache`. No tensor bytes move until `tensor*`/`tensor_dict*`.
+- Lazy views: chaining `.view().slice().transpose()` builds view specs only; no RPCs or data transfer occur until `.tensor*`/`.tensor_dict*`/`.exists()`.
+- Single-process Store: all functional helpers delegate to the process Store (singleton); initialization flows through `StoreRuntimeContext` with `get_daemon_client`.
+- View composition: uses `ViewSpecComposer` and `ViewMetadataCache`; derived handles keep parent hints and share caches.
+- Prefetch: returns a ticket carrying `replica_uuid`; subsequent materialization reuses it via `FallbackOptions.replica_uuid`.
+- Region-backed registration: unchanged semantics per 0021; clearly scoped as an advanced lifecycle path.
+- Error surfaces: constructing an `Artifact` handle never raises `NOT_FOUND`; `ArtifactError` is raised on materialization (`tensor*`, `tensor_dict*`, `tensor_dict_into`, `tensor_into`) or explicit checks (`exists()`) when identity/metadata resolution fails.
+
+## Naming Compliance (Python)
+
+- Public functions/methods use `snake_case`; classes use `PascalCase`; constants use `ALL_CAPS`, matching repo Python standards.
+- No relative imports in user-facing examples; absolute imports (`import tensorcast as tc`) remain canonical.
+
+## Flow Diagram
+
+```mermaid
+flowchart LR
+    U["User code<br>tc.artifact(...)"] --> H["Artifact handle<br>lazy id + metadata"]
+    H --> M["Materialization pipeline<br>(view, batch, prefetch)"]
+    M --> R["Runtime ctx + caches<br>(key cache, ArtifactCache)"]
+    R --> D["Daemon<br>(may consult Global Store)"]
+    D -->|replica| M
+    M -->|tensor bytes| U
+```
+
+# Schema Changes
+
+None. No persistent schema or proto schema changes are required; reuse existing materialization and registration RPCs.
+
+# Trade-offs & Risks
+
+- Removing `get`/`get_into` means users must adopt `Artifact` flows; mitigated by clearer, smaller surface and improved composability.
+- Lazy resolution can surprise users expecting pure local construction; mitigate by documenting `.exists()` / `.describe()` as explicit lightweight checks.
+- Coercing string enums improves ergonomics but risks typos; mitigate with validation and clear `ArtifactError` messages.
+
+# Compatibility & Acceptance Criteria
+
+- No backward-compatibility promise (project not yet GA); redundant verbs removed from public surface once this design is implemented.
+- Acceptance:
+  - Functional API limited to the set above; retrieval only via `Artifact` methods.
+  - `tc.init()` defaults to launch-per-process; docs updated accordingly.
+  - Options enforce small, intention-based enums with validation and clear errors.
+  - All public docs/README/AGENTS updated to reflect the new surface; legacy examples removed.
+  - Tests cover handle flows (sync/async), views, batch, prefetch, region lifecycle, and init/shutdown paths.
+
+# References
+
+- 0014-store-session-api-modernization.md
+- 0016-artifact-view-v1.md
+- 0021-region‑backed-registration.md
+- 0036-02-artifact-handle-core.md
+- 0036-03-lazy-artifact-handle.md
+- 0036-04-disk-artifact-variant.md
+- 0037-store-py-refactor.md
+- `tensorcast/api/store/__init__.py`, `tensorcast/api/store/artifact.py`, `tensorcast/startup.py`

--- a/docs/designs/0039-artifact-first-sdk.md
+++ b/docs/designs/0039-artifact-first-sdk.md
@@ -56,10 +56,10 @@ Removed after migration: module-level `get`, `get_into`, `get_view`, `get_view_i
 
 - Identity & metadata: `.artifact_id`, `.key`, `.tensor_names`, `.tensor_meta(name)`, `.describe()`, `.exists()`, `.is_valid`, `.release()`.
 - Materialization (sync): `.tensor_dict(device, names=None)`, `.tensor(name, device)`, `.tensor_dict_into(target, device=None)`.
-- Symmetry convenience (proposed): `.tensor_into(name, target_tensor, device=None)` as a thin helper over `tensor_dict_into({name: target_tensor}, ...)`.
+- Symmetry convenience: `.tensor_into(name, target_tensor, device=None)` streams a single tensor directly into the provided buffer without requiring placeholders for every tensor in the artifact.
 - Materialization (async): `.tensor_async(name, device)`, `.tensor_dict_async(device, names=None)`.
 - Views/composition: `.view(slices=None, transpose=None, names=None)`, `.subset(names)`, `.slice({...})`, `.view_builder()`.
-- Performance helpers: `.batch(device=...) -> BatchContext`, `.prefetch(device=...) -> PrefetchTicket`.
+- Performance helpers: `.batch(device=...) -> BatchContext`, `.prefetch(device=...) -> tuple[Artifact, PrefetchTicket]` so callers can opt into ticket-based fallbacks via a cloned handle.
 - Policy override: `.with_fallback(FallbackOptions(...))`.
 - Serialization (process-local): `.to_dict()`, `.from_dict(data, store)`.
 
@@ -85,7 +85,7 @@ All retrieval flows pass through `MaterializationPipeline` with canonical index 
 - Lazy views: chaining `.view().slice().transpose()` builds view specs only; no RPCs or data transfer occur until `.tensor*`/`.tensor_dict*`/`.exists()`.
 - Single-process Store: all functional helpers delegate to the process Store (singleton); initialization flows through `StoreRuntimeContext` with `get_daemon_client`.
 - View composition: uses `ViewSpecComposer` and `ViewMetadataCache`; derived handles keep parent hints and share caches.
-- Prefetch: returns a ticket carrying `replica_uuid`; subsequent materialization reuses it via `FallbackOptions.replica_uuid`.
+- Prefetch: returns `(handle_clone, PrefetchTicket)`; the clone carries `replica_uuid` via `FallbackOptions` while the original handle stays untouched. Tickets expose `wait()`/`cancel()` for staged replicas.
 - Region-backed registration: unchanged semantics per 0021; clearly scoped as an advanced lifecycle path.
 - Error surfaces: constructing an `Artifact` handle never raises `NOT_FOUND`; `ArtifactError` is raised on materialization (`tensor*`, `tensor_dict*`, `tensor_dict_into`, `tensor_into`) or explicit checks (`exists()`) when identity/metadata resolution fails.
 

--- a/docs/internals/model-loading.md
+++ b/docs/internals/model-loading.md
@@ -11,7 +11,7 @@ This diagram shows the complete artifact loading workflow in TensorCast, includi
 ## System Components
 
 - **InferenceInstance**: Python + CXX EXT
-- Entrypoint: `tensorcast.get` / `tensorcast.get_into` (facade over the process Store)
+- Entrypoint: `tensorcast.artifact(...).tensor_dict` / `.tensor_dict_into` (facade over the process Store)
   - CLI class: `client.py::DaemonCtl`
   - CXX: `checkpoint_py.cc`
 
@@ -140,13 +140,11 @@ coalesced VRAM (CUDA IPC) for zero-copy use.
   return a `RegisteredArtifact` describing the canonical index, replica metadata, and lease handle
   when applicable. Both functions call into the shared Store and offer async variants via
   `tensorcast.store().register_async(...)`.
-- `tensorcast.get(...)` returns a materialised `dict[str, torch.Tensor]` by artifact id or key with
-  retry-aware fallback handling. `tensorcast.store().get_async(...)` exposes an `ArtifactFuture`
-  that supports `result()`, cancellation, and completion callbacks.
-- `tensorcast.get_into(...)` populates caller-provided tensors in-place. The Store validates shapes,
-  strides, and device placement before mutating buffers, zero-fills PAD segments to keep tensors
-  consistent on failure or cancellation, and unloads any daemon-backed VRAM replica as soon as the
-  copy (or validation error) completes. Asynchronous flows are available via `tensorcast.store()`.
+- Retrieval is handle-first: `tensorcast.artifact(...).tensor_dict(...)` streams tensors to the requested
+  device (sync) and `tensor_dict_async(...)` mirrors it asynchronously. In-place copies use
+  `artifact.tensor_dict_into(...)` or the convenience `artifact.tensor_into(name, target, ...)`.
+  The Store validates shapes/strides/device before mutating buffers, zero-fills PAD segments to keep
+  tensors consistent on failure, and unloads daemon-backed replicas immediately after copy/validation.
 - `StoreOptions` and per-call `FallbackOptions` express disk/P2P strategies without sprinkling
   policy flags across call sites.
 - Low-level lease feeding and commit orchestration are handled internally by the Store,
@@ -158,9 +156,9 @@ coalesced VRAM (CUDA IPC) for zero-copy use.
   - `PlanType.VRAM_COALESCED` (aliases: `"coalesced"`)
   - `PlanType.VRAM_LEASED` (aliases: `"lease"`)
 - `RegisterArtifactOptions` is now a frozen dataclass with slots for immutability.
-- Loading helpers with fixed return types now forward to the Store session:
-  - Synchronous: `tensorcast.get(...) -> dict[str, torch.Tensor]`
-  - Asynchronous: `tensorcast.store().get_async(...) -> ArtifactFuture[dict[str, torch.Tensor]]`
+- Loading helpers with fixed return types now hang off `Artifact`:
+  - Synchronous: `tensorcast.artifact(...).tensor_dict(...) -> dict[str, torch.Tensor]`
+  - Asynchronous: `tensorcast.artifact(...).tensor_dict_async(...) -> ArtifactFuture[dict[str, torch.Tensor]]`
 - `ArtifactFuture.done() / result(timeout) / cancel()` mirror the standard `concurrent.futures`
   contract. Cancellation propagates to daemon RPCs (`AbortRegisteredArtifact`, `RevokeRegisteredArtifact`)
   and records telemetry for observability.

--- a/docs/internals/tensor-first-artifact-architecture.md
+++ b/docs/internals/tensor-first-artifact-architecture.md
@@ -7,6 +7,10 @@ sidebar_position: 6
 # Summary
 TensorCast’s core bet is that any model state can be treated as a rigorously described `dict[str, torch.Tensor]`. This note connects the high-level rationale from the design set (0007, 0016, 0014, checkpoint data format) with the concrete code that keeps the abstraction true. It also surfaces the main trade-offs: while a uniform tensor view enables zero-copy routing and verifiable views, it obligates us to encode tensor semantics when scheduling resources, hashing bytes, or caching replicas.
 
+Note: the public SDK surface is now handle-first (`tensorcast.artifact(...).tensor*`); legacy
+module-level `get/get_into` helpers have been removed in favor of the `Artifact` handle while
+reusing the same materialization pipeline described below.
+
 ## Related design threads
 - [0007-content-addressed-artifact-id](../designs/0007-content-addressed-artifact-id.md): canonical identity (`mi2:index:data`), hashing policy, Global Store schema.
 - [0016-artifact-view-v1](../designs/0016-artifact-view-v1.md): variant-aware retrieval/registration via `ViewSpec`, shared planners, leaf digests.

--- a/docs/plans/0039-artifact-first-sdk.md
+++ b/docs/plans/0039-artifact-first-sdk.md
@@ -1,0 +1,104 @@
+---
+title: Plan – Artifact-First TensorCast SDK API
+links:
+  design: ../designs/0039-artifact-first-sdk.md
+areas: ["sdk"]
+related_code:
+  - tensorcast/startup.py
+  - tensorcast/api/store/__init__.py
+  - tensorcast/api/store/artifact.py
+  - tensorcast/api/store/materialization.py
+  - tensorcast/api/store/registration.py
+  - tensorcast/api/_config.py
+  - tensorcast/api/store/types.py
+  - tensorcast/__init__.py
+---
+
+# Summary
+
+Implement the artifact-first SDK surface defined in Design 0039: embed a default daemon config for `tc.init()`, simplify public options/enums, add symmetric tensor materialization helpers, remove KV-specific helpers, and prune legacy eager verbs in favor of handle-centric APIs. Update docs and examples to match, and add tests to lock behavior.
+
+# Current State
+
+- `tensorcast/startup.py`: `init` raises when no daemon config path is provided or discoverable; no embedded defaults.
+- `tensorcast/api/store/__init__.py`: legacy eager helpers (`get`, `get_into`, `get_view`, `get_view_into`, async variants) coexist with handle APIs; includes `register_kv_block`.
+- `tensorcast/api/store/artifact.py`: lazy `Artifact` with `tensor_dict`, `tensor`, `tensor_dict_into`; no `tensor_into` helper; view derivation is lazy but not explicitly documented in code comments.
+- `tensorcast/api/_config.py`, `tensorcast/api/store/types.py`: public `PlanType` and options use internal naming (`vram_coalesced`/`vram_leased`, `prefer` flags).
+- Docs/examples still mention legacy eager flows and KV-specific helper.
+
+# Goals
+
+- `tc.init()` always works out-of-box via embedded minimal daemon config when no config is supplied or discoverable.
+- Public API surface is handle-first; legacy eager verbs and KV-only helpers removed from public exports.
+- Symmetric materialization convenience via `Artifact.tensor_into`.
+- User-friendly option strings (`plan="lease" | "copy"`, fallback string shortcuts) with validation mapped to existing enums.
+- Clear, lazy semantics and error surfaces documented and covered by tests.
+- Repository docs/README/AGENTS reflect the new surface; legacy examples removed.
+
+# Phases & Tasks
+
+## Phase 1: Bootstrap defaults for tc.init
+- [x] Embed minimal daemon config in SDK (loopback bind, ephemeral/standard port, default cache path) inside `tensorcast/startup.py` (inline YAML/JSON proto). Ensure cache path is writable (e.g., `tempfile.mkdtemp` fallback) and ports avoid conflicts.
+- [x] Update `startup.py:init` to fall back to embedded config when no path is provided and none is discoverable; preserve current resolve/connect code paths.
+- [x] Add logging/telemetry markers for “embedded default” path (single INFO, no spam).
+- [x] Document behavior in docstrings (`startup.py`) and user-facing docs (`README.md`, module README if present).
+
+## Phase 2: Public option ergonomics
+- [x] Accept user-friendly `plan="lease"|"copy"` at public surfaces (`tensorcast/api/store/__init__.py`, `tensorcast/api/store/registration.py`, `tensorcast/api/_config.py`, `tensorcast/api/store/types.py`); coerce to `PlanType` internally; retain enum access for power users.
+- [x] Add fallback string shortcut parsing (e.g., `fallback="disk:/tmp/foo"` → `FallbackOptions.for_disk`) in `tensorcast/api/store/types.py` or helper; keep explicit `FallbackOptions`.
+- [x] Update `RegisterArtifactOptions`/`GetArtifactOptions` docstrings/type hints to reflect user-friendly inputs; ensure `ArtifactError` messages are actionable on bad inputs.
+- [x] Identify and adjust affected tests in `tests/python` that assert enum strings.
+
+## Phase 2.5: Surface audit & deprecation mapping
+- [x] Audit imports/exports in `tensorcast/api/__init__.py`, `tensorcast/api/store/__init__.py`, `tensorcast/__init__.py` to align with handle-first surface and removed helpers.
+- [x] Search for legacy helpers in code/tests/examples (`rg "register_kv_block"`, `rg "get_view"`, etc.) and build a migration checklist.
+
+## Phase 3: API surface cleanup
+- [x] Remove `register_kv_block` from public exports and docs (`tensorcast/api/store/__init__.py`, `tensorcast/__init__.py`, examples/tests); rely on standard `register` with region reuse.
+- [x] Remove module-level eager getters (`get`, `get_into`, `get_view`, `get_view_into`, async variants) from public exports (`__all__`, imports). Provide migration note in docs.
+- [x] Ensure `tensorcast/__init__.py` mirrors the new export set; fix any star-import expectations in tests/examples.
+- [x] Keep `store()` available but de-emphasized in docs/README.
+
+## Phase 4: Artifact conveniences & clarity
+- [x] Add `Artifact.tensor_into(name, target_tensor, device=None)` in `tensorcast/api/store/artifact.py` as a thin helper over `tensor_dict_into`; export via `tensorcast/api/store/__init__.py` and `tensorcast/__init__.py`.
+- [x] Clarify lazy view chaining in code comments/docstrings within `artifact.py` (no RPC/data until `tensor*`/`tensor_dict*`/`exists()`).
+- [x] Clarify error surfaces: `tc.artifact()` construction is non-throwing for `NOT_FOUND`; materialization and `exists()` surface `ArtifactError`. Add short docstring/comment.
+
+## Phase 5: Docs & Examples
+- [x] Update design doc 0039 references if needed; add concise user-facing guide snippets in README or module README under `tensorcast/api/store/`.
+- [x] Remove legacy eager examples; add handle-first examples (sync/async, view, batch, prefetch, tensor_into).
+- [x] Update AGENTS/README where they mention public APIs or init behavior (root README, tests/python/README if applicable).
+
+## Phase 6: Tests & Validation
+- [x] Add/adjust tests (likely under `tests/python/api` or nearest suites) for: embedded default init path; `plan` string coercion and error handling; fallback string shortcut; `tensor_into`; lazy view chaining (no RPC mocked); error surfaces (`ArtifactError` on materialization, not on handle construction).
+- [ ] Run lint/format/type checks: `uv run ruff check .`, `uv run ruff format .`, `uv run pyright ./tensorcast`.
+- [ ] Run relevant Python tests: `uv run pytest tests/python/...` (targeted modules).
+  - Test execution pending locally (`uv` not available in current environment); rerun in CI or with `uv` installed.
+
+# Phase 7: Test suite cleanup for interface removal
+- [x] Audit and update tests under `tests/python` that reference removed eager helpers (`get`, `get_into`, `get_view`, `get_view_into`, `register_kv_block`) to handle-first APIs (`artifact().tensor_dict`, `.tensor_dict_into`, `.tensor`, views via `.view()`, region reuse via standard `register`).
+  - Likely files: `tests/python/test_store_session_api.py`, `tests/python/test_store_view_api.py`, `tests/python/api/test_public_exports.py`, `tests/python/api/test_artifact_handle.py`, `tests/python/api/test_materialization_pipeline_v2.py`, `tests/python/test_store_pipelines_unit.py`, `tests/python/test_store_region_registration.py`, `tests/python/test_register_cgid.py`.
+- [x] Update fixtures/mocks relying on older option strings (`vram_coalesced`/`vram_leased`, legacy fallback strings) to new user-friendly inputs in `tests/python/test_config_enum_normalization.py`, `tests/python/api/test_fallback_options.py`, `tests/python/test_store_pipelines_unit.py`, and any registration/materialization tests.
+- [x] Remove or rewrite deprecated helper shims introduced during migration; ensure coverage reflects only the new surface.
+- [ ] Re-run targeted test suite after updates: `uv run pytest tests/python/...`.
+
+# Acceptance Criteria
+
+- `tc.init()` succeeds with no user-provided config by using embedded defaults; existing explicit-config paths unchanged.
+- Public API exports exclude `register_kv_block` and legacy eager getters; handle-first surface is canonical.
+- `Artifact` exposes `tensor_into`; lazy view chaining and lazy error model documented and validated.
+- User-facing `plan` and fallback shortcuts accepted and validated; internal enums remain intact.
+- Docs/README/AGENTS updated; examples show handle-first flows.
+- Tests and linters pass for updated areas.
+
+# Rollout / Backout
+
+- Rollout: land feature branches per phase; merge when tests/docs updated. No external compatibility constraints (pre-GA).
+- Backout: revert individual phase changes if regressions appear (e.g., revert embedded default config if it impacts existing deployments), keeping design intent for subsequent iterations.
+
+# Risks / Mitigations
+
+- Removing eager helpers and KV helper may break imports/tests: audit and update all references; add migration note; consider a short-lived shim raising clear errors if needed.
+- Embedded default daemon config must choose writable paths and non-conflicting ports: use `tempfile` paths and ephemeral ports; log chosen path/port.
+- String coercions for `plan`/fallback risk silent typos: validate strictly and surface `ArtifactError` with actionable messages.
+- `tensor_into` duplication risk: keep it as a thin wrapper over `tensor_dict_into` and cover with tests to avoid divergent behavior.

--- a/docs/plans/0039-artifact-first-sdk.md
+++ b/docs/plans/0039-artifact-first-sdk.md
@@ -74,6 +74,7 @@ Implement the artifact-first SDK surface defined in Design 0039: embed a default
 - [ ] Run lint/format/type checks: `uv run ruff check .`, `uv run ruff format .`, `uv run pyright ./tensorcast`.
 - [ ] Run relevant Python tests: `uv run pytest tests/python/...` (targeted modules).
   - Test execution pending locally (`uv` not available in current environment); rerun in CI or with `uv` installed.
+- [x] Added regression coverage for `tc.artifact` exports, `Artifact.prefetch()` clone semantics, `tensor_into` subset copy, and plan defaults via `tests/python/api/test_public_surface.py`, `tests/python/api/test_artifact_handle.py`, and `tests/python/api/test_config_models.py`.
 
 # Phase 7: Test suite cleanup for interface removal
 - [x] Audit and update tests under `tests/python` that reference removed eager helpers (`get`, `get_into`, `get_view`, `get_view_into`, `register_kv_block`) to handle-first APIs (`artifact().tensor_dict`, `.tensor_dict_into`, `.tensor`, views via `.view()`, region reuse via standard `register`).

--- a/tensorcast/__init__.py
+++ b/tensorcast/__init__.py
@@ -108,6 +108,7 @@ validate_cuda_backend_consistency()
 
 from tensorcast._version import __version__  # noqa: E402
 from tensorcast.api import (  # noqa: E402
+    Artifact,
     ArtifactDescriptor,
     ArtifactError,
     ArtifactFuture,
@@ -125,17 +126,17 @@ from tensorcast.api import (  # noqa: E402
     save_dict,
 )
 from tensorcast.api.store import (  # noqa: E402
+    PrefetchTicket,
+    deregister_artifact,
     from_disk,
-    get,
-    get_async,
-    get_into,
-    get_into_async,
     put,
     put_async,
     register,
     register_async,
     register_view,
+    register_vram_region,
     store,
+    unregister_vram_region,
 )
 from tensorcast.startup import init, is_initialized, shutdown  # noqa: E402
 
@@ -159,6 +160,7 @@ __all__ = [
     "calculate_tensor_device_offsets",
     "build_indices_from_safetensors",
     "from_disk",
+    "Artifact",
     "ArtifactDescriptor",
     "store",
     "register",
@@ -166,9 +168,9 @@ __all__ = [
     "register_view",
     "put",
     "put_async",
-    "get",
-    "get_async",
-    "get_into",
-    "get_into_async",
+    "register_vram_region",
+    "unregister_vram_region",
+    "deregister_artifact",
+    "PrefetchTicket",
     "BuildConfigMismatchError",
 ]

--- a/tensorcast/__init__.py
+++ b/tensorcast/__init__.py
@@ -106,6 +106,7 @@ validate_cuda_backend_consistency()
 # Public package interface remains unchanged below.
 # -----------------------------------------------------------------------------
 
+import tensorcast.api.store as _store_api  # noqa: E402
 from tensorcast._version import __version__  # noqa: E402
 from tensorcast.api import (  # noqa: E402
     Artifact,
@@ -140,6 +141,39 @@ from tensorcast.api.store import (  # noqa: E402
 )
 from tensorcast.startup import init, is_initialized, shutdown  # noqa: E402
 
+
+def artifact(
+    *,
+    artifact_id: str | None = None,
+    key: str | None = None,
+    disk_path: str | None = None,
+    fallback: FallbackOptions | str | None = None,
+) -> Artifact:
+    """Return a process Store-backed Artifact handle."""
+    return _store_api.artifact(
+        artifact_id=artifact_id,
+        key=key,
+        disk_path=disk_path,
+        fallback=fallback,
+    )
+
+
+async def artifact_async(
+    *,
+    artifact_id: str | None = None,
+    key: str | None = None,
+    disk_path: str | None = None,
+    fallback: FallbackOptions | str | None = None,
+) -> Artifact:
+    """Async shortcut for creating Artifact handles."""
+    return await _store_api.artifact_async(
+        artifact_id=artifact_id,
+        key=key,
+        disk_path=disk_path,
+        fallback=fallback,
+    )
+
+
 __all__ = [
     "__version__",
     "init",
@@ -168,6 +202,8 @@ __all__ = [
     "register_view",
     "put",
     "put_async",
+    "artifact",
+    "artifact_async",
     "register_vram_region",
     "unregister_vram_region",
     "deregister_artifact",

--- a/tensorcast/api/README.md
+++ b/tensorcast/api/README.md
@@ -9,7 +9,7 @@ Design 0037 refactored `tensorcast.api.store` into a structured subpackage:
 
 - `store/types.py` and `store/handles.py` keep immutable dataclasses and handle wrappers importable from `tensorcast.api.store`.
 - `store/runtime.py` owns the process-wide daemon client, session record writes, key/capability caches, and fork-aware executor lifecycle.
-- `store/registration.py` and `store/materialization.py` orchestrate register/put/view and get/get_into/get_view flows with shared retry/error mapping.
+- `store/registration.py` and `store/materialization.py` orchestrate register/put/view and artifact materialization flows with shared retry/error mapping.
 - `store/views.py` keeps view-spec parsing, placement defaults, and canonical index lookups isolated from the pipelines.
 - `store/async_ops.py` centralizes async helpers (`ArtifactFuture`, `TrackedExecutor`) so cancellation/confirm semantics are consistent across verbs.
 - `store/__init__.py` is the public façade; it now eagerly wires runtime/registration/materialization without monkeypatch/override hooks or lazy rebuilds.
@@ -20,8 +20,7 @@ Module-level helpers (`tensorcast.api.store.register`, `get`, etc.) reuse a proc
 
 - `tensorcast.artifact(...)` / `Store.artifact(...)` provide lazy handles that
   expose metadata (`tensor_names`, `tensor_meta`, `describe`) and selective
-  materialization (`tensor_dict(names=...)`, `tensor(name, ...)`) without
-  changing the eager `get*` APIs.
+  materialization (`tensor_dict(names=...)`, `tensor(name, ...)`, `tensor_into(...)`) as the canonical retrieval surface.
 - Handles accept whichever identifiers are available (`artifact_id`, key, or
   disk path). At least one identifier is required, but resolved handles keep all
   known hints so `with_fallback(...)` and `to_dict()/from_dict()` remain valid
@@ -38,13 +37,13 @@ Module-level helpers (`tensorcast.api.store.register`, `get`, etc.) reuse a proc
 ## Materialization v2 (descriptor streaming)
 
 - `MaterializationPipeline` streams `TensorPayloadDescriptor` + tensor pairs from the daemon v2 surface (`tensorcast.proto.daemon.v2`) by default; the v1 path and `TC_ENABLE_MATERIALIZE_V2` flag have been removed.
-- Selective fetch (`tensor_names`) trims descriptors and canonical index bytes; iterator cancellation still routes through `_release_materialized` so CUDA IPC handles are unmapped even on early exit. `get_into*` copies consume descriptors directly without building intermediate dicts.
+- Selective fetch (`tensor_names`) trims descriptors and canonical index bytes; iterator cancellation still routes through `_release_materialized` so CUDA IPC handles are unmapped even on early exit. `tensor_dict_into` / `tensor_into` copies consume descriptors directly without building intermediate dicts.
 - Telemetry attaches per-descriptor attributes (`tc.tensor.count`/`tc.tensor.bytes`) and a subset/full selector to the materialization span, and the client metrics surface attaches the same selector to latency/error/retry series.
 - Disk fallbacks are forwarded to the daemon through `DiskFallbackHint` + `SourcePreference=PREFER_DISK` (including the `verify_checksums` hint) so all disk reads stay in the daemon data path.
 
 ## Device requirements
 
-`Store.get*`/`Store.get_into*` default to materializing replicas onto CUDA
+`Artifact.tensor*`/`tensor_dict*` default to materializing replicas onto CUDA
 devices. On hosts without `torch.cuda.is_available()`, callers must either
 provide disk fallback options (so bytes can be streamed from disk) or explicitly
 select a CPU target alongside those fallback settings. Otherwise the API raises
@@ -53,10 +52,11 @@ callers from running deeper into retry loops that can never succeed.
 
 ## View Retrieval
 
-`Store.get_view()` defaults to executing transforms on the daemon so that
+`Artifact.view(...).tensor*` defaults to executing transforms on the daemon so
 transpose views return buffers in the expected orientation. Client-side
 execution is intentionally disabled until a local transform engine exists; the
-API still accepts `placement="CLIENT"` explicitly for forward compatibility.
+pipeline still accepts `placement="CLIENT"` explicitly for forward
+compatibility.
 
 ## View Registration
 

--- a/tensorcast/api/__init__.py
+++ b/tensorcast/api/__init__.py
@@ -14,6 +14,7 @@ from tensorcast.api._indices import (
 from tensorcast.api._io_disk import save_dict
 from tensorcast.api._register import RegisteredLease, RegistrationResult
 from tensorcast.api.store import (
+    Artifact,
     ArtifactError,
     ArtifactFuture,
     FallbackOptions,
@@ -40,4 +41,5 @@ __all__ = [
     "build_indices_from_safetensors",
     "CommitResult",
     "ArtifactDescriptor",
+    "Artifact",
 ]

--- a/tensorcast/api/_config.py
+++ b/tensorcast/api/_config.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import os
 import threading
-from dataclasses import dataclass
 from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from tensorcast.api._errors import InvalidPlan
 
@@ -61,19 +62,22 @@ class PlanType(Enum):
     VRAM_LEASED = "vram_leased"
 
     @staticmethod
-    def parse(value: "PlanType | str") -> "PlanType":
+    def parse(value: object) -> "PlanType":
         if isinstance(value, PlanType):
             return value
         s = str(value).strip().lower()
-        if s in ("vram_coalesced", "coalesced"):
+        if s in ("vram_coalesced", "coalesced", "copy"):
             return PlanType.VRAM_COALESCED
         if s in ("vram_leased", "lease"):
             return PlanType.VRAM_LEASED
-        raise InvalidPlan(f"Unknown plan: {value}")
+        raise InvalidPlan(
+            f"Unknown plan '{value}'; expected 'lease' or 'copy' (or PlanType enum)."
+        )
 
 
-@dataclass(slots=True, frozen=True)
-class RegisterArtifactOptions:
+class RegisterArtifactOptions(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     plan: PlanType = PlanType.VRAM_COALESCED
     p2p_prefer: str = "vram"
     max_inflight_bytes: int = 512 * 1024 * 1024
@@ -87,20 +91,36 @@ class RegisterArtifactOptions:
     key: str | None = None
     disk_path: str | None = None
 
-    def __post_init__(self) -> None:
-        # Ensure plan is a PlanType; callers must pass PlanType per API contract.
-        if not isinstance(self.plan, PlanType):
-            raise TypeError("RegisterArtifactOptions.plan must be a PlanType")
+    @field_validator("plan", mode="before")
+    @classmethod
+    def _normalize_plan(cls, value: object) -> PlanType:
+        try:
+            return PlanType.parse(value)
+        except InvalidPlan:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise InvalidPlan(str(exc)) from exc
 
 
-@dataclass(slots=True, frozen=True)
-class GetArtifactOptions:
-    prefer: str = "p2p"  # "p2p" or "disk"
+class GetArtifactOptions(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    prefer: str = "auto"  # "auto" | "local" | "p2p" | "disk"
     pinned_allocation_timeout_ms: int = DEFAULT_PINNED_TIMEOUT_MS
     wait_for_completion: bool = True
     enable_verification: bool = True
     # Hint for P2P transport lock TTL extension; forwarded by daemons
     transport_hold_ms: int | None = None
+
+    @field_validator("prefer", mode="before")
+    @classmethod
+    def _normalize_prefer(cls, value: object) -> str:
+        normalized = "auto" if value is None else str(value).strip().lower()
+        if normalized not in {"auto", "local", "p2p", "disk"}:
+            raise ValueError(
+                "GetArtifactOptions.prefer must be one of: auto, local, p2p, disk"
+            )
+        return normalized
 
 
 __all__ = [

--- a/tensorcast/api/_config.py
+++ b/tensorcast/api/_config.py
@@ -78,7 +78,7 @@ class PlanType(Enum):
 class RegisterArtifactOptions(BaseModel):
     model_config = ConfigDict(frozen=True)
 
-    plan: PlanType = PlanType.VRAM_COALESCED
+    plan: PlanType = PlanType.VRAM_LEASED
     p2p_prefer: str = "vram"
     max_inflight_bytes: int = 512 * 1024 * 1024
     release_on_tensor_commit: bool = True

--- a/tensorcast/api/_materialize.py
+++ b/tensorcast/api/_materialize.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import threading
 from collections.abc import Callable, Iterator, Mapping, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 
 import torch
 from opentelemetry import trace
@@ -120,11 +120,12 @@ def materialize_artifact_v2(
         runtime_address=daemon_address,
     )
 
-    opts = replace(
-        opts,
-        pinned_allocation_timeout_ms=pinned_ms,
-        enable_verification=enable_ver,
-        wait_for_completion=wait_for_completion,
+    opts = opts.model_copy(
+        update={
+            "pinned_allocation_timeout_ms": pinned_ms,
+            "enable_verification": enable_ver,
+            "wait_for_completion": wait_for_completion,
+        }
     )
 
     replica_uuid_value = replica_uuid or new_uuid()

--- a/tensorcast/api/_register.py
+++ b/tensorcast/api/_register.py
@@ -775,7 +775,7 @@ def _materialize_canonical_tensors(
 def make_plan_model(
     options: RegisterArtifactOptions, total_size_bytes: int | None = None
 ) -> CoalescedPlan | LeasePlan:
-    plan_type = options.plan
+    plan_type: PlanType = options.plan
     if plan_type is PlanType.VRAM_COALESCED:
         return CoalescedPlan(
             kind="coalesced",
@@ -1056,7 +1056,7 @@ def _register_artifact_core(
     tracer = trace.get_tracer(__name__)
 
     if force_lease_in_place:
-        plan_type = PlanType.VRAM_LEASED
+        plan_type: PlanType = PlanType.VRAM_LEASED
         plan_model = LeasePlan(
             kind="lease",
             min_tensor_bytes=options.min_tensor_bytes,

--- a/tensorcast/api/store/README.md
+++ b/tensorcast/api/store/README.md
@@ -11,6 +11,10 @@ managing clients manually.
   bound to the process `Store`. Handles support metadata accessors
   (`tensor_names`, `tensor_meta`, `describe`), existence checks (`exists`), and
   selective materialization via `tensor_dict(names=...)` and `tensor(name, ...)`.
+- `artifact.tensor_into(name, target_tensor, device=None)` materializes a single
+  tensor directly into the provided buffer. Only the requested tensor must be
+  present in the target mapping, so multi-tensor artifacts no longer require
+  pre-allocating placeholders for every entry when using the helper.
 - Handles retain whichever identifiers are available (`artifact_id`, `key`,
   `disk_path`). At least one identifier is required when instantiating or
   rehydrating a handle, but resolved handles may keep both `artifact_id` and
@@ -51,8 +55,12 @@ managing clients manually.
   `await artifact.tensor_dict_async(...)`; calls are coalesced by the process
   `MaterializationBatcher` (1ms window) on the store event loop.
 - `artifact.prefetch(device=...)` issues background materialization
-  (`wait_for_completion=False`) and returns a `PrefetchTicket`; the handle
-  carries the ticket’s `replica_uuid` via `FallbackOptions` for the next fetch.
+  (`wait_for_completion=False`) and returns a tuple of
+  `(prefetched_handle, PrefetchTicket)`. The returned handle is a clone whose
+  fallback carries the ticket’s `replica_uuid`, allowing callers to opt into the
+  hint without mutating the original handle. Use the ticket to `wait()` or
+  `cancel()` the staged replica before materializing tensors from the cloned
+  handle.
 
 ## Fallback Preferences
 

--- a/tensorcast/api/store/__init__.py
+++ b/tensorcast/api/store/__init__.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Mapping, Sequence
 import torch
 
 from tensorcast._C import get_cuda_memory_handle
-from tensorcast.api._config import GetArtifactOptions, PlanType, RegisterArtifactOptions
+from tensorcast.api._config import RegisterArtifactOptions
 from tensorcast.api._materialize import (
     MaterializationPayload,
     materialize_artifact_v2,
@@ -216,11 +216,11 @@ class Store:
         artifact_id: str | None = None,
         key: str | None = None,
         disk_path: str | None = None,
-        fallback: FallbackOptions | None = None,
+        fallback: FallbackOptions | str | None = None,
     ) -> Artifact:
-        effective_fallback = fallback
-        if disk_path and fallback is None:
-            effective_fallback = FallbackOptions.for_disk(disk_path)
+        effective_fallback = FallbackOptions.parse(fallback)
+        if disk_path and effective_fallback is None:
+            effective_fallback = FallbackOptions.for_disk(str(disk_path))
         return Artifact(
             store_ref=weakref.ref(self),
             artifact_id=artifact_id,
@@ -235,7 +235,7 @@ class Store:
         artifact_id: str | None = None,
         key: str | None = None,
         disk_path: str | None = None,
-        fallback: FallbackOptions | None = None,
+        fallback: FallbackOptions | str | None = None,
     ) -> Artifact:
         return self.artifact(
             artifact_id=artifact_id,
@@ -245,133 +245,13 @@ class Store:
         )
 
     def from_disk(
-        self, path: str, *, fallback: FallbackOptions | None = None
+        self, path: str, *, fallback: FallbackOptions | str | None = None
     ) -> Artifact:
         disk_path = os.fspath(path)
-        effective_fallback = fallback or FallbackOptions.for_disk(str(disk_path))
+        effective_fallback = FallbackOptions.parse(fallback)
+        if effective_fallback is None:
+            effective_fallback = FallbackOptions.for_disk(str(disk_path))
         return self.artifact(disk_path=str(disk_path), fallback=effective_fallback)
-
-    def get(
-        self,
-        *,
-        artifact_id: str | None = None,
-        key: str | None = None,
-        device: torch.device | str | None = None,
-        fallback: FallbackOptions | None = None,
-        options: GetArtifactOptions | None = None,
-    ) -> dict[str, torch.Tensor]:
-        return self._materialization.get(
-            artifact_id=artifact_id,
-            key=key,
-            device=device,
-            fallback=fallback,
-            options=options,
-        )
-
-    def get_view(
-        self,
-        *,
-        artifact_id: str | None = None,
-        key: str | None = None,
-        slices: Mapping[str, Sequence[object]] | None = None,
-        transpose: Mapping[str, Sequence[tuple[int, int]]] | None = None,
-        view_id: str | None = None,
-        placement: str | None = None,
-        device: torch.device | str | None = None,
-        options: GetArtifactOptions | None = None,
-    ) -> dict[str, torch.Tensor]:
-        return self._materialization.get_view(
-            artifact_id=artifact_id,
-            key=key,
-            slices=slices,
-            transpose=transpose,
-            view_id=view_id,
-            placement=placement,
-            device=device,
-            options=options,
-            resolver=self._views.resolve_view_inputs,
-        )
-
-    def get_view_into(
-        self,
-        target: dict[str, torch.Tensor],
-        *,
-        artifact_id: str | None = None,
-        key: str | None = None,
-        slices: Mapping[str, Sequence[object]] | None = None,
-        transpose: Mapping[str, Sequence[tuple[int, int]]] | None = None,
-        view_id: str | None = None,
-        placement: str | None = None,
-        device: torch.device | str | None = None,
-        options: GetArtifactOptions | None = None,
-    ) -> None:
-        self._materialization.get_view_into(
-            target,
-            artifact_id=artifact_id,
-            key=key,
-            slices=slices,
-            transpose=transpose,
-            view_id=view_id,
-            placement=placement,
-            device=device,
-            options=options,
-            resolver=self._views.resolve_view_inputs,
-        )
-
-    def get_async(
-        self,
-        *,
-        artifact_id: str | None = None,
-        key: str | None = None,
-        device: torch.device | str | None = None,
-        fallback: FallbackOptions | None = None,
-        options: GetArtifactOptions | None = None,
-    ) -> ArtifactFuture[dict[str, torch.Tensor]]:
-        return self._materialization.get_async(
-            artifact_id=artifact_id,
-            key=key,
-            device=device,
-            fallback=fallback,
-            options=options,
-        )
-
-    def get_into(
-        self,
-        target: dict[str, torch.Tensor],
-        *,
-        artifact_id: str | None = None,
-        key: str | None = None,
-        device: torch.device | str | None = None,
-        fallback: FallbackOptions | None = None,
-        options: GetArtifactOptions | None = None,
-    ) -> None:
-        self._materialization.get_into(
-            target,
-            artifact_id=artifact_id,
-            key=key,
-            device=device,
-            fallback=fallback,
-            options=options,
-        )
-
-    def get_into_async(
-        self,
-        target: dict[str, torch.Tensor],
-        *,
-        artifact_id: str | None = None,
-        key: str | None = None,
-        device: torch.device | str | None = None,
-        fallback: FallbackOptions | None = None,
-        options: GetArtifactOptions | None = None,
-    ) -> ArtifactFuture[None]:
-        return self._materialization.get_into_async(
-            target,
-            artifact_id=artifact_id,
-            key=key,
-            device=device,
-            fallback=fallback,
-            options=options,
-        )
 
     # ------------------------------------------------------------------
     # Region-backed registration
@@ -582,22 +462,6 @@ def register_async(
     )
 
 
-def register_kv_block(
-    tensor: torch.Tensor,
-    block_hash: str,
-    *,
-    ttl_ms: int | None = None,
-) -> RegisteredArtifact:
-    artifact_id = f"cgid:kv:{block_hash}"
-    opts = RegisterArtifactOptions(
-        plan=PlanType.VRAM_LEASED,
-        lease_in_place=True,
-    )
-    return _coerce_store().register(
-        {"kv": tensor}, artifact_id=artifact_id, options=opts, ttl_ms=ttl_ms
-    )
-
-
 def register_view(
     tensors: TensorDict,
     *,
@@ -697,132 +561,12 @@ def put_async(
     )
 
 
-def get(
-    *,
-    artifact_id: str | None = None,
-    key: str | None = None,
-    device: torch.device | str | None = None,
-    fallback: FallbackOptions | None = None,
-    options: GetArtifactOptions | None = None,
-) -> dict[str, torch.Tensor]:
-    return _coerce_store().get(
-        artifact_id=artifact_id,
-        key=key,
-        device=device,
-        fallback=fallback,
-        options=options,
-    )
-
-
-def get_view(
-    *,
-    artifact_id: str | None = None,
-    key: str | None = None,
-    slices: Mapping[str, Sequence[object]] | None = None,
-    transpose: Mapping[str, Sequence[tuple[int, int]]] | None = None,
-    view_id: str | None = None,
-    placement: str | None = None,
-    device: torch.device | str | None = None,
-    options: GetArtifactOptions | None = None,
-) -> dict[str, torch.Tensor]:
-    return _coerce_store().get_view(
-        artifact_id=artifact_id,
-        key=key,
-        slices=slices,
-        transpose=transpose,
-        view_id=view_id,
-        placement=placement,
-        device=device,
-        options=options,
-    )
-
-
-def get_view_into(
-    target: dict[str, torch.Tensor],
-    *,
-    artifact_id: str | None = None,
-    key: str | None = None,
-    slices: Mapping[str, Sequence[object]] | None = None,
-    transpose: Mapping[str, Sequence[tuple[int, int]]] | None = None,
-    view_id: str | None = None,
-    placement: str | None = None,
-    device: torch.device | str | None = None,
-    options: GetArtifactOptions | None = None,
-) -> None:
-    _coerce_store().get_view_into(
-        target,
-        artifact_id=artifact_id,
-        key=key,
-        slices=slices,
-        transpose=transpose,
-        view_id=view_id,
-        placement=placement,
-        device=device,
-        options=options,
-    )
-
-
-def get_async(
-    *,
-    artifact_id: str | None = None,
-    key: str | None = None,
-    device: torch.device | str | None = None,
-    fallback: FallbackOptions | None = None,
-    options: GetArtifactOptions | None = None,
-) -> ArtifactFuture[dict[str, torch.Tensor]]:
-    return _coerce_store().get_async(
-        artifact_id=artifact_id,
-        key=key,
-        device=device,
-        fallback=fallback,
-        options=options,
-    )
-
-
-def get_into(
-    target: dict[str, torch.Tensor],
-    *,
-    artifact_id: str | None = None,
-    key: str | None = None,
-    device: torch.device | str | None = None,
-    fallback: FallbackOptions | None = None,
-    options: GetArtifactOptions | None = None,
-) -> None:
-    _coerce_store().get_into(
-        target,
-        artifact_id=artifact_id,
-        key=key,
-        device=device,
-        fallback=fallback,
-        options=options,
-    )
-
-
-def get_into_async(
-    target: dict[str, torch.Tensor],
-    *,
-    artifact_id: str | None = None,
-    key: str | None = None,
-    device: torch.device | str | None = None,
-    fallback: FallbackOptions | None = None,
-    options: GetArtifactOptions | None = None,
-) -> ArtifactFuture[None]:
-    return _coerce_store().get_into_async(
-        target,
-        artifact_id=artifact_id,
-        key=key,
-        device=device,
-        fallback=fallback,
-        options=options,
-    )
-
-
 def artifact(
     *,
     artifact_id: str | None = None,
     key: str | None = None,
     disk_path: str | None = None,
-    fallback: FallbackOptions | None = None,
+    fallback: FallbackOptions | str | None = None,
 ) -> Artifact:
     return _coerce_store().artifact(
         artifact_id=artifact_id,
@@ -837,7 +581,7 @@ async def artifact_async(
     artifact_id: str | None = None,
     key: str | None = None,
     disk_path: str | None = None,
-    fallback: FallbackOptions | None = None,
+    fallback: FallbackOptions | str | None = None,
 ) -> Artifact:
     return await _coerce_store().artifact_async(
         artifact_id=artifact_id,
@@ -847,7 +591,7 @@ async def artifact_async(
     )
 
 
-def from_disk(path: str, *, fallback: FallbackOptions | None = None) -> Artifact:
+def from_disk(path: str, *, fallback: FallbackOptions | str | None = None) -> Artifact:
     return _coerce_store().from_disk(path, fallback=fallback)
 
 
@@ -883,14 +627,7 @@ __all__ = [
     "register_async",
     "put",
     "put_async",
-    "get",
-    "get_async",
-    "get_view",
-    "get_view_into",
-    "get_into",
-    "get_into_async",
     "register_view",
-    "register_kv_block",
     "register_vram_region",
     "unregister_vram_region",
     "deregister_artifact",

--- a/tensorcast/api/store/artifact.py
+++ b/tensorcast/api/store/artifact.py
@@ -7,8 +7,8 @@ import base64
 import threading
 import time
 import weakref
-from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Mapping, Sequence, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Mapping, Sequence, TypedDict, cast
 
 import torch
 
@@ -27,6 +27,7 @@ from tensorcast.api.store.types import (
     CanonicalIndex,
     CanonicalIndexEntry,
     FallbackOptions,
+    FallbackPreference,
 )
 from tensorcast.api.store.view_composer import (
     ViewBuilder,
@@ -59,7 +60,27 @@ class ArtifactDescriptor:
     generation: int | None
 
 
-def _fallback_to_dict(fallback: FallbackOptions | None) -> dict[str, object] | None:
+class ArtifactSerializedFallback(TypedDict):
+    prefer: FallbackPreference
+    disk_path: str | None
+    prefer_disk: bool | None
+    allow_p2p: bool
+    verify_checksums: bool
+    replica_uuid: str | None
+
+
+class ArtifactSerialized(TypedDict):
+    artifact_id: str | None
+    key: str | None
+    disk_path: str | None
+    fallback: ArtifactSerializedFallback | None
+    canonical_index: str | None
+    generation: int | None
+
+
+def _fallback_to_dict(
+    fallback: FallbackOptions | None,
+) -> ArtifactSerializedFallback | None:
     if fallback is None:
         return None
     return {
@@ -74,7 +95,9 @@ def _fallback_to_dict(fallback: FallbackOptions | None) -> dict[str, object] | N
     }
 
 
-def _fallback_from_dict(data: Mapping[str, object] | None) -> FallbackOptions | None:
+def _fallback_from_dict(
+    data: ArtifactSerializedFallback | Mapping[str, object] | None,
+) -> FallbackOptions | None:
     if data is None:
         return None
     prefer_value = data.get("prefer")
@@ -137,10 +160,12 @@ class Artifact:
                 status_code="INVALID_ARGUMENT",
                 retryable=False,
             )
+        self._fallback = FallbackOptions.parse(fallback)
         self._artifact_id = artifact_id
         self._key_hint = key
-        self._disk_path_hint = disk_path
-        self._fallback = FallbackOptions.parse(fallback)
+        self._disk_path_hint = disk_path or (
+            self._fallback.disk_path if self._fallback else None
+        )
         self._canonical_index_bytes = canonical_index_bytes
         self._canonical_index = canonical_index
         self._tensor_metas: dict[str, TensorMeta] | None = None
@@ -308,7 +333,30 @@ class Artifact:
                 status_code="INVALID_ARGUMENT",
                 retryable=False,
             )
-        self.tensor_dict_into({name: target_tensor}, device=device)
+        artifact_id = self._ensure_identified()
+        _, _, pipeline = self._require_components()
+        requested_names = (name,)
+        view_spec_proto = self._view_spec.proto if self._view_spec else None
+        view_data_hash = (
+            self._view_metadata.view_data_hash if self._view_metadata else None
+        )
+        view_index_hint = (
+            self._view_metadata.view_index_bytes if self._view_metadata else None
+        )
+        replica_uuid = self._fallback.replica_uuid if self._fallback else None
+        resolved_device = device if device is not None else target_tensor.device
+        pipeline.get_into(
+            {requested_names[0]: target_tensor},
+            artifact_id=artifact_id,
+            key=None,
+            device=resolved_device,
+            fallback=self._fallback,
+            view_spec=view_spec_proto,
+            view_data_hash=view_data_hash,
+            view_index_hint=view_index_hint,
+            replica_uuid=replica_uuid,
+            tensor_names=requested_names,
+        )
 
     def view(
         self,
@@ -381,7 +429,9 @@ class Artifact:
             None, lambda: self.tensor_dict(device=device, names=names)
         )
 
-    def prefetch(self, *, device: torch.device | str) -> "PrefetchTicket":
+    def prefetch(
+        self, *, device: torch.device | str
+    ) -> tuple["Artifact", "PrefetchTicket"]:
         from tensorcast.api._config import GetArtifactOptions
 
         artifact_id = self._ensure_identified()
@@ -424,11 +474,11 @@ class Artifact:
         from tensorcast.api.store.batch_context import PrefetchTicket
 
         fallback_with_ticket = (
-            replace(self._fallback, replica_uuid=replica)
+            self._fallback.model_copy(update={"replica_uuid": replica})
             if self._fallback is not None
             else FallbackOptions(replica_uuid=replica)
         )
-        self._fallback = fallback_with_ticket
+        prefetched_handle = self.with_fallback(fallback_with_ticket)
         try:
             from tensorcast.api import _metrics as store_metrics
 
@@ -437,7 +487,7 @@ class Artifact:
             )
         except Exception:  # noqa: BLE001
             pass
-        return PrefetchTicket(
+        ticket = PrefetchTicket(
             replica_uuid=replica,
             artifact_id=artifact_id,
             device=torch.device(device),
@@ -446,6 +496,7 @@ class Artifact:
             view_hash=view_data_hash,
             runtime_ref=weakref.ref(runtime),
         )
+        return prefetched_handle, ticket
 
     def with_fallback(self, fallback: FallbackOptions | str) -> Artifact:
         parsed = FallbackOptions.parse(fallback)
@@ -488,6 +539,18 @@ class Artifact:
             with self._lock:
                 self._hydrate_from_cache_entry(cached)
             return True
+        disk_path_hint = self._disk_path_hint or (
+            self._fallback.disk_path if self._fallback else None
+        )
+        if disk_path_hint:
+            try:
+                disk_index = self._resolve_metadata_from_disk(runtime, disk_path_hint)
+            except ArtifactError as disk_error:
+                if disk_error.status_code != "NOT_FOUND":
+                    raise
+            else:
+                if disk_index is not None:
+                    return True
         try:
             canonical_index_bytes = runtime.ensure_client().get_artifact_index_by_id(
                 artifact_id
@@ -530,7 +593,7 @@ class Artifact:
         with self._lock:
             self._released = True
 
-    def to_dict(self) -> dict[str, object]:
+    def to_dict(self) -> ArtifactSerialized:
         encoded_index: str | None = None
         if self._canonical_index_bytes:
             encoded_index = base64.b64encode(self._canonical_index_bytes).decode(
@@ -692,6 +755,74 @@ class Artifact:
                 retryable=False,
             )
 
+    def _resolve_metadata_from_disk(
+        self, runtime: "StoreRuntimeContext", disk_path: str
+    ) -> CanonicalIndex | None:
+        cached = runtime.get_artifact_index_by_disk_path(disk_path)
+        if cached:
+            with self._lock:
+                self._hydrate_from_cache_entry(cached)
+                if (
+                    self._canonical_index is not None
+                    and self._canonical_index_bytes is not None
+                ):
+                    return self._canonical_index
+
+        verify_checksums = True
+        if self._fallback is not None:
+            verify_checksums = bool(self._fallback.verify_checksums)
+        try:
+            resolved = runtime.ensure_client().resolve_artifact_from_disk_v2(
+                disk_path=disk_path,
+                verify_checksums=verify_checksums,
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise map_materialization_error(exc) from exc
+
+        resolved_artifact_id = (
+            getattr(resolved, "artifact_id", "") or self._artifact_id or None
+        )
+        resolved_disk_path = getattr(resolved, "disk_path", "") or disk_path
+        canonical_index_bytes = bytes(
+            getattr(resolved, "canonical_index_bytes", b"") or b""
+        )
+        generation_raw = getattr(resolved, "generation", 0)
+        generation = int(generation_raw) if generation_raw else None
+
+        canonical_index = (
+            canonical_index_from_bytes(canonical_index_bytes)
+            if canonical_index_bytes
+            else None
+        )
+        with self._lock:
+            if resolved_artifact_id and not self._artifact_id:
+                self._artifact_id = resolved_artifact_id
+            if resolved_disk_path:
+                self._disk_path_hint = resolved_disk_path
+            if canonical_index is not None:
+                self._set_metadata(
+                    canonical_index_bytes,
+                    canonical_index,
+                    generation=self._generation or generation,
+                    disk_path=resolved_disk_path,
+                )
+            elif generation is not None and self._generation is None:
+                self._generation = generation
+
+        if canonical_index is not None and resolved_artifact_id:
+            runtime.cache_artifact_index(
+                ArtifactCacheEntry(
+                    artifact_id=resolved_artifact_id,
+                    canonical_index_bytes=canonical_index_bytes,
+                    parsed_index=canonical_index,
+                    generation=generation,
+                    disk_path=resolved_disk_path,
+                    expires_at=time.monotonic(),
+                )
+            )
+            return canonical_index
+        return None
+
     def _ensure_metadata(self) -> CanonicalIndex:
         if (
             self._canonical_index is not None
@@ -710,6 +841,7 @@ class Artifact:
         cache_disk_path: str | None = None
         generation_hint: int | None = None
         disk_path_hint: str | None = None
+        force_remote_fetch = False
         with self._lock:
             if (
                 self._canonical_index is not None
@@ -728,7 +860,8 @@ class Artifact:
                     and cached.generation is not None
                     and cached.generation != self._generation
                 )
-                if has_disk_mismatch or has_generation_mismatch:
+                force_remote_fetch = bool(has_disk_mismatch or has_generation_mismatch)
+                if force_remote_fetch:
                     runtime.invalidate_artifact(
                         artifact_id,
                         reason="disk_path_mismatch"
@@ -740,7 +873,18 @@ class Artifact:
                     assert self._canonical_index is not None
                     return self._canonical_index
             generation_hint = self._generation
-            disk_path_hint = self._disk_path_hint
+            disk_path_hint = self._disk_path_hint or (
+                self._fallback.disk_path if self._fallback else None
+            )
+        if disk_path_hint and not force_remote_fetch:
+            try:
+                disk_index = self._resolve_metadata_from_disk(runtime, disk_path_hint)
+            except ArtifactError as disk_error:
+                if disk_error.status_code != "NOT_FOUND":
+                    raise
+            else:
+                if disk_index is not None:
+                    return disk_index
         try:
             canonical_index_bytes = runtime.ensure_client().get_artifact_index_by_id(
                 artifact_id

--- a/tensorcast/api/store/artifact.py
+++ b/tensorcast/api/store/artifact.py
@@ -107,7 +107,13 @@ def _meta_from_entry(entry: CanonicalIndexEntry) -> TensorMeta:
 
 
 class Artifact:
-    """Lazy handle to a TensorCast artifact."""
+    """Lazy handle to a TensorCast artifact.
+
+    Construction is non-blocking and does not trigger RPCs; identity and
+    metadata are resolved lazily on first materialization (`tensor*`,
+    `tensor_dict*`, or `exists()`), and view composition is purely local until
+    then.
+    """
 
     def __init__(
         self,
@@ -116,7 +122,7 @@ class Artifact:
         artifact_id: str | None = None,
         key: str | None = None,
         disk_path: str | None = None,
-        fallback: FallbackOptions | None = None,
+        fallback: FallbackOptions | str | None = None,
         canonical_index_bytes: bytes | None = None,
         canonical_index: CanonicalIndex | None = None,
         generation: int | None = None,
@@ -134,7 +140,7 @@ class Artifact:
         self._artifact_id = artifact_id
         self._key_hint = key
         self._disk_path_hint = disk_path
-        self._fallback = fallback
+        self._fallback = FallbackOptions.parse(fallback)
         self._canonical_index_bytes = canonical_index_bytes
         self._canonical_index = canonical_index
         self._tensor_metas: dict[str, TensorMeta] | None = None
@@ -289,6 +295,21 @@ class Artifact:
             replica_uuid=replica_uuid,
         )
 
+    def tensor_into(
+        self,
+        name: str,
+        target_tensor: torch.Tensor,
+        *,
+        device: torch.device | str | None = None,
+    ) -> None:
+        if not isinstance(target_tensor, torch.Tensor):
+            raise ArtifactError(
+                "tensor_into target must be a torch.Tensor",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        self.tensor_dict_into({name: target_tensor}, device=device)
+
     def view(
         self,
         *,
@@ -296,6 +317,7 @@ class Artifact:
         transpose: Mapping[str, Sequence[tuple[int, int]]] | None = None,
         names: Sequence[str] | None = None,
     ) -> Artifact:
+        """Return a derived lazy view; no RPCs occur until materialization or exists()."""
         return self._derive_view(
             slices=slices,
             transpose=transpose,
@@ -425,13 +447,14 @@ class Artifact:
             runtime_ref=weakref.ref(runtime),
         )
 
-    def with_fallback(self, fallback: FallbackOptions) -> Artifact:
+    def with_fallback(self, fallback: FallbackOptions | str) -> Artifact:
+        parsed = FallbackOptions.parse(fallback)
         clone = Artifact(
             store_ref=self._store_ref,
             artifact_id=self._artifact_id,
             key=self._key_hint,
             disk_path=self._disk_path_hint,
-            fallback=fallback,
+            fallback=parsed,
             canonical_index_bytes=self._canonical_index_bytes,
             canonical_index=self._canonical_index,
             generation=self._generation,
@@ -444,6 +467,7 @@ class Artifact:
         return clone
 
     def exists(self) -> bool:
+        """Check existence lazily, surfacing ArtifactError on failures."""
         if self._canonical_index is not None:
             return True
         runtime = self._runtime_if_available()

--- a/tensorcast/api/store/common.py
+++ b/tensorcast/api/store/common.py
@@ -173,24 +173,43 @@ def validate_targets(
     target: Mapping[str, torch.Tensor],
     source: Mapping[str, torch.Tensor],
     device_id: int,
+    required_names: Sequence[str] | None = None,
 ) -> list[tuple[torch.Tensor, torch.Tensor]]:
     validated: list[tuple[torch.Tensor, torch.Tensor]] = []
     device = torch.device("cuda", device_id)
-    for entry in canonical_index.entries:
-        if entry.name not in target:
+    entries_by_name = {entry.name: entry for entry in canonical_index.entries}
+    if required_names is None:
+        ordered_names = [entry.name for entry in canonical_index.entries]
+    else:
+        ordered_names = []
+        seen: set[str] = set()
+        for name in required_names:
+            if name in seen:
+                continue
+            if name not in entries_by_name:
+                raise ArtifactError(
+                    f"Tensor '{name}' not found in artifact",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            ordered_names.append(name)
+            seen.add(name)
+    for name in ordered_names:
+        entry = entries_by_name[name]
+        if name not in target:
             raise ArtifactError(
-                f"Target tensor '{entry.name}' missing",
+                f"Target tensor '{name}' missing",
                 status_code="INVALID_ARGUMENT",
                 retryable=False,
             )
-        if entry.name not in source:
+        if name not in source:
             raise ArtifactError(
-                f"Source tensor '{entry.name}' missing",
+                f"Source tensor '{name}' missing",
                 status_code="DATA_LOSS",
                 retryable=False,
             )
-        tgt = target[entry.name]
-        src = source[entry.name]
+        tgt = target[name]
+        src = source[name]
         if not isinstance(tgt, torch.Tensor):
             raise ArtifactError(
                 f"Target '{entry.name}' must be a tensor",

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -365,11 +365,13 @@ class MaterializationPipeline:
         try:
             layout_bytes = payload.view_index_bytes or payload.canonical_index_bytes
             canonical_index = canonical_index_from_bytes(layout_bytes)
+            requested = tuple(tensor_names) if tensor_names else None
             pairs = validate_targets(
                 canonical_index=canonical_index,
                 target=target,
                 source=self._payload_state_dict(payload),
                 device_id=device_id,
+                required_names=requested,
             )
             for tgt, src in pairs:
                 tgt.copy_(src)
@@ -421,11 +423,13 @@ class MaterializationPipeline:
                     )
                     canonical_index = canonical_index_from_bytes(layout_bytes)
                     source_map = self._payload_state_dict(materialized)
+                    requested = tuple(tensor_names) if tensor_names else None
                     pairs = validate_targets(
                         canonical_index=canonical_index,
                         target=target,
                         source=source_map,
                         device_id=device_id,
+                        required_names=requested,
                     )
                     for tgt, src in pairs:
                         if cancel_event.is_set():
@@ -796,7 +800,7 @@ class MaterializationPipeline:
                     resolved_artifact_id = cached_entry.artifact_id
 
         if fallback_opts and (requested_disk or not allow_p2p):
-            disk_path, resolved_artifact_id, disk_error = (
+            resolved_path, resolved_artifact_id, disk_error = (
                 self._fallback.resolve_disk_path(
                     fallback=fallback_opts,
                     client=client,
@@ -804,6 +808,8 @@ class MaterializationPipeline:
                     artifact_id=artifact_id,
                 )
             )
+            if resolved_path:
+                disk_path = resolved_path
             if disk_path:
                 requested_disk = True
                 disk_required = True

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -131,7 +131,7 @@ class FallbackResolver:
 
 
 class MaterializationPipeline:
-    """Retrieval orchestration for get/get_into/get_view flows."""
+    """Retrieval orchestration for artifact materialization and view flows."""
 
     def __init__(
         self,
@@ -615,6 +615,8 @@ class MaterializationPipeline:
                     retryable=False,
                 )
             return {d.name: payload.state_dict[d.name] for d in payload.descriptors}
+        if payload.state_dict is not None:
+            return dict(payload.state_dict)
         state: dict[str, torch.Tensor] = {}
         for desc, tensor in payload.payload_iter():
             state[desc.name] = tensor

--- a/tensorcast/api/store/registration.py
+++ b/tensorcast/api/store/registration.py
@@ -323,8 +323,9 @@ class RegistrationPipeline:
                 retryable=False,
             )
         resolved_key = key
-        options = options_override
-        if options is not None:
+        options: RegisterArtifactOptions
+        if options_override is not None:
+            options = options_override
             if options.plan is not plan:
                 options = options.model_copy(update={"plan": plan})
             if plan is PlanType.VRAM_LEASED and not options.lease_in_place:

--- a/tensorcast/api/store/registration.py
+++ b/tensorcast/api/store/registration.py
@@ -7,7 +7,6 @@ import logging
 import threading
 import time
 from collections.abc import Mapping
-from dataclasses import replace
 from typing import Callable, Sequence
 
 import torch
@@ -327,13 +326,13 @@ class RegistrationPipeline:
         options = options_override
         if options is not None:
             if options.plan is not plan:
-                options = replace(options, plan=plan)
+                options = options.model_copy(update={"plan": plan})
             if plan is PlanType.VRAM_LEASED and not options.lease_in_place:
-                options = replace(options, lease_in_place=True)
+                options = options.model_copy(update={"lease_in_place": True})
             if resolved_key is None:
                 resolved_key = options.key
             elif options.key != resolved_key:
-                options = replace(options, key=resolved_key)
+                options = options.model_copy(update={"key": resolved_key})
         else:
             options = RegisterArtifactOptions(
                 plan=plan,

--- a/tensorcast/api/store/types.py
+++ b/tensorcast/api/store/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Mapping, TypeAlias
+from typing import Literal, Mapping
 
 import torch
 from pydantic import BaseModel, ConfigDict, field_validator
@@ -14,6 +14,9 @@ from tensorcast.types import ServerConfig
 TensorDict = Mapping[str, torch.Tensor]
 
 SpanAttributeValue = bool | int | float | str
+
+
+FallbackPreference = Literal["auto", "local", "p2p", "disk"]
 
 ArtifactStatusCode = Literal[
     "OK",
@@ -65,8 +68,6 @@ class FallbackOptions(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    FallbackPreference: TypeAlias = Literal["auto", "local", "p2p", "disk"]
-
     prefer: FallbackPreference = "auto"
     disk_path: str | None = None
     allow_p2p: bool = True
@@ -75,7 +76,7 @@ class FallbackOptions(BaseModel):
     replica_uuid: str | None = None
 
     @staticmethod
-    def _to_prefer_literal(value: str) -> "FallbackPreference":
+    def _to_prefer_literal(value: str) -> FallbackPreference:
         normalized = value.strip().lower()
         if normalized == "auto":
             return "auto"
@@ -93,7 +94,7 @@ class FallbackOptions(BaseModel):
 
     @field_validator("prefer", mode="before")
     @classmethod
-    def _normalize_prefer(cls, value: object) -> "FallbackPreference":
+    def _normalize_prefer(cls, value: object) -> FallbackPreference:
         normalized = "auto" if value is None else str(value).strip().lower()
         return cls._to_prefer_literal(normalized)
 
@@ -225,6 +226,7 @@ class StoreCapabilities:
 __all__ = [
     "ArtifactError",
     "ArtifactStatusCode",
+    "FallbackPreference",
     "CanonicalIndex",
     "CanonicalIndexEntry",
     "FallbackOptions",

--- a/tensorcast/api/store/types.py
+++ b/tensorcast/api/store/types.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Mapping
+from typing import Literal, Mapping, TypeAlias
 
 import torch
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from tensorcast.api._config import PlanType
 from tensorcast.types import ServerConfig
@@ -59,16 +60,50 @@ class RetryPolicy:
     jitter: float
 
 
-@dataclass(frozen=True)
-class FallbackOptions:
+class FallbackOptions(BaseModel):
     """Source selection and replica hints for materialization."""
 
-    prefer: Literal["auto", "local", "p2p", "disk"] = "auto"
+    model_config = ConfigDict(frozen=True)
+
+    FallbackPreference: TypeAlias = Literal["auto", "local", "p2p", "disk"]
+
+    prefer: FallbackPreference = "auto"
     disk_path: str | None = None
     allow_p2p: bool = True
     verify_checksums: bool = True
     prefer_disk: bool | None = None  # Deprecated compatibility flag
     replica_uuid: str | None = None
+
+    @staticmethod
+    def _to_prefer_literal(value: str) -> "FallbackPreference":
+        normalized = value.strip().lower()
+        if normalized == "auto":
+            return "auto"
+        if normalized == "local":
+            return "local"
+        if normalized == "p2p":
+            return "p2p"
+        if normalized == "disk":
+            return "disk"
+        raise ArtifactError(
+            f"Unknown fallback preference '{value}' (expected auto, local, p2p, or disk)",
+            status_code="INVALID_ARGUMENT",
+            retryable=False,
+        )
+
+    @field_validator("prefer", mode="before")
+    @classmethod
+    def _normalize_prefer(cls, value: object) -> "FallbackPreference":
+        normalized = "auto" if value is None else str(value).strip().lower()
+        return cls._to_prefer_literal(normalized)
+
+    @field_validator("disk_path", mode="before")
+    @classmethod
+    def _normalize_disk_path(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        path = str(value).strip()
+        return path or None
 
     @classmethod
     def for_disk(cls, path: str, *, verify: bool = True) -> "FallbackOptions":
@@ -89,11 +124,54 @@ class FallbackOptions:
             prefer_disk=False,
         )
 
+    @classmethod
+    def parse(cls, value: object) -> "FallbackOptions | None":
+        """Accept either a FallbackOptions instance or a string shortcut."""
+        if value is None:
+            return None
+        if isinstance(value, FallbackOptions):
+            return value
+        if isinstance(value, str):
+            raw = value.strip()
+            if raw.lower().startswith("disk:"):
+                path = raw.split(":", 1)[1]
+                if path.strip() == "":
+                    raise ArtifactError(
+                        "Fallback string 'disk:' requires a path, e.g. 'disk:/tmp/artifacts'",
+                        status_code="INVALID_ARGUMENT",
+                        retryable=False,
+                    )
+                return cls.for_disk(path)
+            normalized = raw.lower()
+            if normalized in {"auto", "local", "p2p", "disk"}:
+                if normalized == "local":
+                    return cls.local_only()
+                if normalized == "disk":
+                    return cls(
+                        prefer="disk",
+                        allow_p2p=False,
+                        prefer_disk=True,
+                    )
+                prefer_literal = cls._to_prefer_literal(normalized)
+                return cls(prefer=prefer_literal)
+        raise ArtifactError(
+            "Fallback must be a FallbackOptions instance or string "
+            "('auto', 'local', 'p2p', 'disk:/path')",
+            status_code="INVALID_ARGUMENT",
+            retryable=False,
+        )
 
-@dataclass(frozen=True)
-class StoreOptions:
+
+class StoreOptions(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     fallback: FallbackOptions | None = None
     retry_overrides: Mapping[str, RetryPolicy] | None = None
+
+    @field_validator("fallback", mode="before")
+    @classmethod
+    def _coerce_fallback(cls, value: object) -> FallbackOptions | None:
+        return FallbackOptions.parse(value)
 
 
 @dataclass(frozen=True)

--- a/tensorcast/startup.py
+++ b/tensorcast/startup.py
@@ -41,6 +41,7 @@ from tensorcast.daemon_ctl import (
 )
 from tensorcast.daemon_runtime_config import dump_daemon_config, load_daemon_config
 from tensorcast.logger import init_logger, setup_logging
+from tensorcast.proto.config.v1 import common_pb2 as cfg_common_pb
 from tensorcast.proto.config.v1 import daemon_config_pb2 as cfg_pb
 
 _current_ctx: Context | None = None
@@ -183,7 +184,9 @@ def _build_embedded_daemon_config(
     cfg.checkpoint.streaming.num_buffers = 2
     cfg.checkpoint.streaming.io_chunk_bytes = 128 * 1024 * 1024
     cfg.checkpoint.streaming.pinned_pool_bytes = 512 * 1024 * 1024
-    cfg.observability.logging.level = cfg_pb.Observability.LOG_LEVEL_INFO
+    cfg.observability.logging.level = (
+        cfg_common_pb.Observability.LogLevel.LOG_LEVEL_INFO
+    )
     cfg.meta.description = "Embedded default daemon config (tensorcast.startup)"
     return cfg
 

--- a/tensorcast/startup.py
+++ b/tensorcast/startup.py
@@ -20,6 +20,7 @@ import atexit
 import contextlib
 import os
 import signal
+import tempfile
 import threading
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,12 +39,14 @@ from tensorcast.daemon_ctl import (
     get_daemon_client,
     release_daemon_client,
 )
-from tensorcast.daemon_runtime_config import load_daemon_config
+from tensorcast.daemon_runtime_config import dump_daemon_config, load_daemon_config
 from tensorcast.logger import init_logger, setup_logging
+from tensorcast.proto.config.v1 import daemon_config_pb2 as cfg_pb
 
 _current_ctx: Context | None = None
 _atexit_registered = False
 _ctx_lock: "threading.Lock" = threading.Lock()
+_EMBEDDED_CONFIG_PATH: Path | None = None
 
 
 @dataclass(slots=True)
@@ -136,6 +139,73 @@ def _current_session_address() -> str | None:
     return get_session_address()
 
 
+def _select_cache_root() -> Path:
+    preferred = Path.home() / ".tensorcast"
+    try:
+        preferred.mkdir(parents=True, exist_ok=True)
+        probe = preferred / ".write_test"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+        return preferred
+    except Exception:
+        return Path(tempfile.mkdtemp(prefix="tensorcast-cache-"))
+
+
+def _build_embedded_daemon_config(
+    storage_dir: Path, fallback_dir: Path
+) -> cfg_pb.DaemonConfig:
+    cfg = cfg_pb.DaemonConfig()
+    cfg.server.listen.host = "127.0.0.1"
+    cfg.server.listen.port = 0
+    cfg.server.storage_path = str(storage_dir)
+    cfg.server.num_threads = max(4, min(8, os.cpu_count() or 4))
+
+    cfg.engine.mem_pool_size_bytes = 1 * 1024 * 1024 * 1024
+    cfg.engine.tx_slice_bytes = 256 * 1024 * 1024
+    cfg.engine.artifact_chunk_bytes = 256 * 1024 * 1024
+    cfg.engine.streaming_buffer_max_concurrent_sessions = 1
+    cfg.engine.p2p_fallback_disk_dir = str(fallback_dir)
+    cfg.engine.disk_path_whitelist.extend([str(storage_dir), str(fallback_dir)])
+    cfg.engine.pinned_allocation_timeout.FromSeconds(30)
+
+    cfg.lifecycle.gpu_memory_limit_fraction = 0.75
+    cfg.lifecycle.enable_periodic_eviction = False
+    cfg.lifecycle.eviction_loop_interval.FromSeconds(1)
+    cfg.lifecycle.proc_check_interval.FromSeconds(5)
+    cfg.lifecycle.sessions_sweep_interval.FromSeconds(10)
+    cfg.lifecycle.locks_sweep_interval.FromSeconds(10)
+    cfg.lifecycle.verification_sweep_interval.FromMilliseconds(500)
+    cfg.lifecycle.sessions_ttl.FromSeconds(60)
+    cfg.lifecycle.locks_ttl.FromSeconds(120)
+
+    cfg.high_availability.enabled = False
+    cfg.communicator.enable_rdma = False
+    cfg.checkpoint.streaming.num_buffers = 2
+    cfg.checkpoint.streaming.io_chunk_bytes = 128 * 1024 * 1024
+    cfg.checkpoint.streaming.pinned_pool_bytes = 512 * 1024 * 1024
+    cfg.observability.logging.level = cfg_pb.Observability.LOG_LEVEL_INFO
+    cfg.meta.description = "Embedded default daemon config (tensorcast.startup)"
+    return cfg
+
+
+def _ensure_embedded_daemon_config_path() -> Path:
+    global _EMBEDDED_CONFIG_PATH
+    if _EMBEDDED_CONFIG_PATH and _EMBEDDED_CONFIG_PATH.exists():
+        return _EMBEDDED_CONFIG_PATH
+
+    cache_root = _select_cache_root()
+    storage_dir = cache_root / "cache"
+    fallback_dir = cache_root / "p2p_cache"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    fallback_dir.mkdir(parents=True, exist_ok=True)
+
+    cfg = _build_embedded_daemon_config(storage_dir, fallback_dir)
+    cfg_path = cache_root / "embedded_store_daemon.yaml"
+    dump_daemon_config(cfg, cfg_path)
+    _EMBEDDED_CONFIG_PATH = cfg_path
+    return cfg_path
+
+
 def init(
     *,
     address: str | None = None,
@@ -152,9 +222,13 @@ def init(
     - Connect: `init(address="host:port" | "auto" | "local")`
     - Launch:  `init(address="local", daemon_config_path="/path/to/config.yaml")`
 
-    When launching, a daemon config file is required. If `address` is None and
-    there is a current session, connects to it; otherwise `address="local"`
-    requires `daemon_config_path` (or a discoverable default).
+    When launching, the SDK will pick a config in the following order:
+    1) user-provided `daemon_config_path`
+    2) discovered default via `discover_default_config_path()`
+    3) embedded minimal config (loopback bind, ephemeral port, writable cache
+       under ~/.tensorcast or a tempdir).
+    If `address` is None and there is a current session, connects to it;
+    otherwise `address="local"` launches a daemon with the resolved config.
 
     Args:
         address: Target daemon address or resolution mode.
@@ -209,18 +283,20 @@ def init(
             return ctx
 
         # Launch requires a config file (try discovery if not provided)
+        used_embedded_config = False
         if not daemon_config_path:
             cfg_path_opt = discover_default_config_path()
             if not cfg_path_opt:
-                raise RuntimeError(
-                    "Launching locally requires daemon_config_path (--config) or a default config at "
-                    "$TENSORCAST_DAEMON_CONFIG, ~/.tensorcast/store_daemon_config.yaml, or examples/config/store_daemon_config.yaml."
-                )
-            cfg_path = Path(cfg_path_opt)
+                cfg_path = _ensure_embedded_daemon_config_path()
+                used_embedded_config = True
+            else:
+                cfg_path = Path(cfg_path_opt)
         else:
             cfg_path = Path(daemon_config_path)
 
         cfg = load_daemon_config(cfg_path)
+        if used_embedded_config:
+            logger.info("ℹ️ Using embedded default daemon config at %s", cfg_path)
         restrict_localhost = True
         if cfg.server.HasField("p2p_listen"):
             p2p_host = cfg.server.p2p_listen.host.strip()

--- a/tests/python/api/test_artifact_handle.py
+++ b/tests/python/api/test_artifact_handle.py
@@ -6,7 +6,8 @@ import json
 import threading
 import time
 import weakref
-from typing import cast
+from dataclasses import replace
+from typing import Sequence, cast
 
 import pytest
 import torch
@@ -16,8 +17,8 @@ from tensorcast.api.store import Store
 from tensorcast.api.store.artifact import Artifact
 from tensorcast.api.store.cache import ArtifactCache, ArtifactCacheEntry
 from tensorcast.api.store.common import canonical_index_from_bytes
-from tensorcast.api.store.types import ArtifactError, FallbackOptions, StoreOptions
 from tensorcast.api.store.retry import build_retry_policies
+from tensorcast.api.store.types import ArtifactError, FallbackOptions, StoreOptions
 
 
 def _build_payload(tensors: dict[str, torch.Tensor]) -> tuple[bytes, MaterializationPayload]:
@@ -136,6 +137,7 @@ class _PipelineStub:
     def __init__(self, payload: MaterializationPayload) -> None:
         self.payload = payload
         self.calls: list[dict[str, object]] = []
+        self.get_into_calls: list[dict[str, object]] = []
         self.released: list[str] = []
 
     def materialize_subset(self, **kwargs):
@@ -162,7 +164,25 @@ class _PipelineStub:
         key: str | None,
         device,
         fallback,
+        options=None,
+        tensor_names: Sequence[str] | None = None,
+        view_spec=None,
+        view_data_hash=None,
+        view_index_hint=None,
+        replica_uuid=None,
     ) -> None:
+        self.get_into_calls.append(
+            {
+                "artifact_id": artifact_id,
+                "key": key,
+                "device": device,
+                "tensor_names": tuple(tensor_names) if tensor_names else None,
+                "view_spec": view_spec,
+                "view_data_hash": view_data_hash,
+                "view_index_hint": view_index_hint,
+                "replica_uuid": replica_uuid,
+            }
+        )
         state = self._payload_state_dict(self.payload)
         for name, tensor in state.items():
             if name in target:
@@ -200,6 +220,59 @@ def test_tensor_subset_materialization_and_release():
     assert set(result.keys()) == {"bar"}
     assert pipeline.calls and pipeline.calls[0]["tensor_names"] == ("bar",)
     assert ("replica-1", "") in runtime._client.unloaded
+
+
+def test_tensor_into_materializes_subset_only():
+    tensors = {
+        "foo": torch.zeros(2, dtype=torch.float32),
+        "bar": torch.ones(2, dtype=torch.float32),
+    }
+    canonical_bytes, payload = _build_payload(tensors)
+    runtime = _RuntimeStub(_ClientStub(canonical_bytes))
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(
+        store_ref=_store_ref(store),
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+    )
+
+    target = torch.zeros(2, dtype=torch.float32)
+    artifact.tensor_into("bar", target, device=torch.device("cpu"))
+
+    assert torch.allclose(target, tensors["bar"])
+    assert pipeline.get_into_calls
+    assert pipeline.get_into_calls[0]["tensor_names"] == ("bar",)
+
+
+def test_prefetch_returns_clone_and_ticket():
+    tensors = {"foo": torch.ones(1, dtype=torch.float32)}
+    canonical_bytes, payload = _build_payload(tensors)
+    payload = replace(
+        payload,
+        ticket_replica_uuid="prefetch-replica",
+        ticket_created_at_ts=time.monotonic(),
+        ticket_expires_at_ts=time.monotonic() + 5.0,
+    )
+    runtime = _RuntimeStub(_ClientStub(canonical_bytes))
+    pipeline = _PipelineStub(payload)
+    store = _StoreStub(runtime, pipeline)
+    artifact = Artifact(
+        store_ref=_store_ref(store),
+        artifact_id="aid",
+        canonical_index_bytes=canonical_bytes,
+    )
+
+    prefetched, ticket = artifact.prefetch(device="cpu")
+
+    assert prefetched is not artifact
+    assert prefetched.artifact_id == "aid"
+    assert ticket.replica_uuid == "prefetch-replica"
+    prefetched_snapshot = prefetched.to_dict()
+    fallback_snapshot = prefetched_snapshot["fallback"]
+    assert fallback_snapshot is not None
+    assert fallback_snapshot["replica_uuid"] == ticket.replica_uuid
+    assert artifact.to_dict()["fallback"] is None
 
 
 def test_release_blocks_materialization():

--- a/tests/python/api/test_config_models.py
+++ b/tests/python/api/test_config_models.py
@@ -1,0 +1,56 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+# Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tensorcast.api._config import GetArtifactOptions, RegisterArtifactOptions
+from tensorcast.api._errors import InvalidPlan
+from tensorcast.api.store.types import FallbackOptions, StoreOptions
+from tensorcast.api._config import PlanType
+
+
+def test_register_options_coerce_plan_string() -> None:
+    opts = RegisterArtifactOptions(plan="copy")
+    assert opts.plan is PlanType.VRAM_COALESCED
+
+    lease_opts = RegisterArtifactOptions(plan="lease")
+    assert lease_opts.plan is PlanType.VRAM_LEASED
+
+
+def test_register_options_reject_unknown_plan() -> None:
+    with pytest.raises(InvalidPlan):
+        RegisterArtifactOptions(plan="gpu-only")
+
+
+def test_register_options_are_frozen() -> None:
+    opts = RegisterArtifactOptions()
+    with pytest.raises(TypeError):
+        opts.plan = PlanType.VRAM_LEASED
+
+
+def test_get_options_validate_prefer_values() -> None:
+    valid = GetArtifactOptions(prefer="p2p")
+    assert valid.prefer == "p2p"
+
+    with pytest.raises(ValidationError):
+        GetArtifactOptions(prefer="bluetooth")
+
+
+def test_store_options_parse_fallback_string() -> None:
+    opts = StoreOptions(fallback="disk:/tmp/cache")
+    assert isinstance(opts.fallback, FallbackOptions)
+    assert opts.fallback.prefer == "disk"
+    assert opts.fallback.disk_path == "/tmp/cache"
+    # Ensure frozen model cannot be mutated
+    with pytest.raises(TypeError):
+        opts.fallback.disk_path = "/other"
+
+
+def test_fallback_parse_accepts_existing_instance() -> None:
+    instance = FallbackOptions(prefer="local")
+    parsed = FallbackOptions.parse(instance)
+    assert parsed is instance

--- a/tests/python/api/test_config_models.py
+++ b/tests/python/api/test_config_models.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from tensorcast.api._config import GetArtifactOptions, RegisterArtifactOptions
+from tensorcast.api._config import (
+    GetArtifactOptions,
+    PlanType,
+    RegisterArtifactOptions,
+)
 from tensorcast.api._errors import InvalidPlan
 from tensorcast.api.store.types import FallbackOptions, StoreOptions
-from tensorcast.api._config import PlanType
 
 
 def test_register_options_coerce_plan_string() -> None:
@@ -28,7 +31,8 @@ def test_register_options_reject_unknown_plan() -> None:
 
 def test_register_options_are_frozen() -> None:
     opts = RegisterArtifactOptions()
-    with pytest.raises(TypeError):
+    assert opts.plan is PlanType.VRAM_LEASED
+    with pytest.raises((TypeError, ValidationError)):
         opts.plan = PlanType.VRAM_LEASED
 
 
@@ -46,7 +50,7 @@ def test_store_options_parse_fallback_string() -> None:
     assert opts.fallback.prefer == "disk"
     assert opts.fallback.disk_path == "/tmp/cache"
     # Ensure frozen model cannot be mutated
-    with pytest.raises(TypeError):
+    with pytest.raises((TypeError, ValidationError)):
         opts.fallback.disk_path = "/other"
 
 

--- a/tests/python/api/test_fallback_options.py
+++ b/tests/python/api/test_fallback_options.py
@@ -1,6 +1,9 @@
 #  Copyright (c) 2025, TensorCast Team.
 
-from tensorcast.api.store.types import FallbackOptions
+import pytest
+
+from tensorcast.api._config import PlanType, RegisterArtifactOptions
+from tensorcast.api.store.types import ArtifactError, FallbackOptions, StoreOptions
 
 
 def test_fallback_options_compat_prefer_disk():
@@ -17,3 +20,39 @@ def test_fallback_options_local_only():
     opts = FallbackOptions.local_only()
     assert opts.prefer == "local"
     assert opts.allow_p2p is False
+
+
+def test_fallback_options_parse_shortcuts():
+    disk = FallbackOptions.parse("disk:/tmp/x")
+    assert disk is not None
+    assert disk.prefer == "disk"
+    assert disk.disk_path == "/tmp/x"
+    assert disk.allow_p2p is False
+
+    local = FallbackOptions.parse("local")
+    assert local is not None
+    assert local.prefer == "local"
+    assert local.allow_p2p is False
+
+    auto = FallbackOptions.parse("auto")
+    assert auto is not None
+    assert auto.prefer == "auto"
+
+
+def test_fallback_options_parse_rejects_unknown():
+    with pytest.raises(ArtifactError):
+        FallbackOptions.parse("unknown-mode")
+
+
+def test_store_options_coerces_fallback_strings():
+    opts = StoreOptions(fallback="disk:/tmp/cache")
+    assert isinstance(opts.fallback, FallbackOptions)
+    assert opts.fallback.prefer == "disk"
+    assert opts.fallback.disk_path == "/tmp/cache"
+
+
+def test_register_options_accepts_plan_strings():
+    lease = RegisterArtifactOptions(plan="lease")
+    assert lease.plan is PlanType.VRAM_LEASED
+    copy = RegisterArtifactOptions(plan="copy")
+    assert copy.plan is PlanType.VRAM_COALESCED

--- a/tests/python/api/test_materialization_pipeline_v2.py
+++ b/tests/python/api/test_materialization_pipeline_v2.py
@@ -33,9 +33,17 @@ def _force_cuda(monkeypatch):
 def _patch_validate_targets(monkeypatch):
     from tensorcast.api.store import materialization as mat_mod
 
-    def _pair(*, canonical_index, target, source, device_id):
+    def _pair(
+        *, canonical_index, target, source, device_id, required_names=None
+    ):
         pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
-        for entry in canonical_index.entries:
+        names = (
+            required_names
+            if required_names is not None
+            else [entry.name for entry in canonical_index.entries]
+        )
+        for name in names:
+            entry = next(e for e in canonical_index.entries if e.name == name)
             pairs.append((target[entry.name], source[entry.name]))
         return pairs
 

--- a/tests/python/api/test_public_surface.py
+++ b/tests/python/api/test_public_surface.py
@@ -1,0 +1,13 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+import tensorcast as tc
+
+
+def test_tensorcast_exports_artifact_helpers() -> None:
+    assert hasattr(tc, "artifact")
+    assert callable(tc.artifact)
+    assert hasattr(tc, "artifact_async")
+    assert callable(tc.artifact_async)
+

--- a/tests/python/api/test_startup_embedded_config.py
+++ b/tests/python/api/test_startup_embedded_config.py
@@ -1,0 +1,27 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+# Copyright (c) 2025, TensorCast Team.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tensorcast import startup
+from tensorcast.daemon_runtime_config import load_daemon_config
+
+
+def test_embedded_daemon_config_is_materialized(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(startup, "_EMBEDDED_CONFIG_PATH", None)
+    monkeypatch.setattr(startup, "_select_cache_root", lambda: tmp_path)
+
+    cfg_path = startup._ensure_embedded_daemon_config_path()
+    cfg = load_daemon_config(cfg_path)
+
+    assert cfg.server.listen.host == "127.0.0.1"
+    assert int(cfg.server.listen.port) == 0
+    assert cfg.high_availability.enabled is False
+    assert str(tmp_path) in cfg.server.storage_path

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -13,6 +13,7 @@ import duckdb
 import pytest
 
 from tests.python.utils.ports import get_free_port, get_free_port_pair
+from tests.python.utils.hardware import has_cuda_or_fake
 
 # Configure logging for tests
 logging.basicConfig(
@@ -29,6 +30,16 @@ def pytest_configure(config: pytest.Config) -> None:
     clean even when those plugins are not installed in the environment.
     """
     config.addinivalue_line("markers", "timeout: per-test timeout in seconds")
+    config.addinivalue_line(
+        "markers",
+        "requires_cuda_or_fake: skip test when neither CUDA nor the fake CUDA backend is available",
+    )
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Skip tests that require CUDA when neither real nor fake backend is present."""
+    if "requires_cuda_or_fake" in item.keywords and not has_cuda_or_fake():
+        pytest.skip("CUDA driver unavailable and fake CUDA backend not enabled")
 
 
 @pytest.fixture(scope="function")

--- a/tests/python/daemon/test_cpp_daemon_lifecycle.py
+++ b/tests/python/daemon/test_cpp_daemon_lifecycle.py
@@ -19,9 +19,10 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
+
+import pytest
 import yaml
 import grpc
-import pytest
 
 from tensorcast.cli_utils.proc import (
     build_daemon_process_env,
@@ -40,6 +41,7 @@ from tensorcast.proto.global_store.v1 import (
 )
 from concurrent.futures import ThreadPoolExecutor
 
+pytestmark = pytest.mark.requires_cuda_or_fake
 
 def _get_free_port() -> int:
     with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:

--- a/tests/python/test_load_save_state_dict.py
+++ b/tests/python/test_load_save_state_dict.py
@@ -3,12 +3,7 @@
 import torch
 from typing import Any
 
-from tensorcast import (
-    FallbackOptions,
-    GetArtifactOptions,
-    get,
-    startup,
-)
+from tensorcast import FallbackOptions, artifact, startup
 
 
 def compare_tensor_dicts(
@@ -103,13 +98,11 @@ if __name__ == "__main__":
                 allow_p2p=False,
                 verify_checksums=False,
             )
-            options = GetArtifactOptions(enable_verification=False)
             device_selector = "cuda:0" if torch.cuda.is_available() else "cpu"
-            sc_state_dict = get(
-                device=device_selector,
+            sc_state_dict = artifact(
+                disk_path=path_to_sc_model_dir,
                 fallback=fallback,
-                options=options,
-            )
+            ).tensor_dict(device=device_selector)
         finally:
             startup.shutdown()
 

--- a/tests/python/test_shared_storage.py
+++ b/tests/python/test_shared_storage.py
@@ -1,20 +1,16 @@
 #  Copyright (c) 2025, TensorCast Team.
 
-import os
 from pathlib import Path
-from typing import Sequence, cast
+from typing import Sequence
 
+import pytest
 import torch
 
-from tensorcast import (
-    FallbackOptions,
-    GetArtifactOptions,
-    get,
-    save_dict,
-    startup,
-)
+from tensorcast import FallbackOptions, artifact, save_dict, startup
 from tests.python.utils.daemon import start_daemon_binary
 from tests.python.utils.ports import get_free_port
+
+pytestmark = pytest.mark.requires_cuda_or_fake
 
 
 def test_shared_storage_roundtrip(tmp_path):
@@ -66,14 +62,11 @@ def test_shared_storage_roundtrip(tmp_path):
                 allow_p2p=False,
                 verify_checksums=False,
             )
-            options = GetArtifactOptions(enable_verification=False)
             device_selector = "cuda:0" if torch.cuda.is_available() else "cpu"
-            loaded_state_dict = get(
+            loaded_state_dict = artifact(
                 artifact_id=descriptor["artifact_id"],
-                device=device_selector,
                 fallback=fallback,
-                options=options,
-            )
+            ).tensor_dict(device=device_selector)
         finally:
             startup.shutdown()
     finally:

--- a/tests/python/test_store_session_api.py
+++ b/tests/python/test_store_session_api.py
@@ -396,7 +396,7 @@ def test_store_put_async_cancel_triggers_abort(store_env: tuple[Store, FakeEnvir
         future.result(timeout=1.0)
 
 
-def test_store_get_into_copies_tensors(
+def test_artifact_tensor_dict_into_copies_tensors(
     store_env: tuple[Store, FakeEnvironment], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, env = store_env
@@ -416,11 +416,12 @@ def test_store_get_into_copies_tensors(
 
     monkeypatch.setattr(materialization_mod, "validate_targets", fake_validate)
 
-    store.get_into(target, artifact_id="artifact-1", device=torch.device("cuda", 0))
+    artifact = store.artifact(artifact_id="artifact-1")
+    artifact.tensor_dict_into(target, device=torch.device("cuda", 0))
     assert torch.allclose(target["bias"], state["bias"])
 
 
-def test_store_get_into_unloads_replica(
+def test_artifact_tensor_dict_into_unloads_replica(
     store_env: tuple[Store, FakeEnvironment], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, env = store_env
@@ -439,13 +440,14 @@ def test_store_get_into_unloads_replica(
 
     monkeypatch.setattr(materialization_mod, "validate_targets", fake_validate)
 
-    store.get_into(target, artifact_id="artifact-release", device=torch.device("cuda", 0))
+    artifact = store.artifact(artifact_id="artifact-release")
+    artifact.tensor_dict_into(target, device=torch.device("cuda", 0))
 
     assert torch.allclose(target["bias"], state["bias"])
     assert env.client.unload_calls == [("rep-unload-1", "")]
 
 
-def test_store_get_into_unloads_on_validation_error(
+def test_artifact_tensor_dict_into_unloads_on_validation_error(
     store_env: tuple[Store, FakeEnvironment], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, env = store_env
@@ -465,69 +467,47 @@ def test_store_get_into_unloads_on_validation_error(
     monkeypatch.setattr(materialization_mod, "validate_targets", failing_validate)
 
     with pytest.raises(ArtifactError):
-        store.get_into(target, artifact_id="artifact-invalid", device=torch.device("cuda", 0))
+        store.artifact(artifact_id="artifact-invalid").tensor_dict_into(
+            target, device=torch.device("cuda", 0)
+        )
 
     assert env.client.unload_calls == [("rep-unload-2", "")]
 
 
-def test_store_get_into_enforces_device(store_env: tuple[Store, FakeEnvironment]) -> None:
+def test_artifact_tensor_dict_into_enforces_device(
+    store_env: tuple[Store, FakeEnvironment]
+) -> None:
     store, env = store_env
     state = {"bias": torch.arange(3, dtype=torch.float32)}
     env.add_materialized("artifact-err", state)
     target = {"bias": torch.zeros(3, dtype=torch.float32)}
     with pytest.raises(ArtifactError):
-        store.get_into(target, artifact_id="artifact-err", device=torch.device("cuda", 0))
+        store.artifact(artifact_id="artifact-err").tensor_dict_into(
+            target, device=torch.device("cuda", 0)
+        )
 
 
-def test_store_get_async_cancel_unloads_replica(
+def test_artifact_tensor_dict_async_releases_replica(
     store_env: tuple[Store, FakeEnvironment], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, env = store_env
     artifact_id = "artifact-cancel"
     env.add_materialized(artifact_id, {"w": torch.ones(2, dtype=torch.float32)}, replica_uuid="rep-100")
 
-    cancel_ready = threading.Event()
-
-    def slow_materialize(
-        self: Store,
-        *,
-        artifact_id: str | None,
-        key: str | None,
-        device_id: int,
-        options: GetArtifactOptions,
-        fallback: FallbackOptions | None,
-        cancel_event: threading.Event | None,
-        span: Any = None,
-        **kwargs: Any,
-    ) -> MaterializationPayload:
-        cancel_ready.set()
-        assert cancel_event is not None
-        while not cancel_event.is_set():
-            time.sleep(0.01)
-        assert artifact_id is not None
-        return env.materialized_by_id[artifact_id]
-
-    monkeypatch.setattr(
-        store._materialization,
-        "_materialize",
-        slow_materialize.__get__(store._materialization, store._materialization.__class__),
-    )
-
-    future = store.get_async(artifact_id=artifact_id, device=torch.device("cuda", 0))
-    assert cancel_ready.wait(timeout=1.0)
-    assert future.cancel() is True
-    with pytest.raises(ArtifactError):
-        future.result(timeout=1.0)
+    artifact = store.artifact(artifact_id=artifact_id)
+    future = artifact.tensor_dict_async(device=torch.device("cuda", 0))
+    result = future.result(timeout=1.0)
+    assert torch.allclose(result["w"], torch.ones(2, dtype=torch.float32))
     assert ("rep-100", "") in env.client.unload_calls
 
 
-def test_store_get_into_async_unloads_replica(
+def test_artifact_tensor_into_unloads_replica(
     store_env: tuple[Store, FakeEnvironment], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, env = store_env
     state = {"bias": torch.arange(3, dtype=torch.float32)}
     env.add_materialized("artifact-async", state, replica_uuid="rep-unload-3")
-    target = {"bias": torch.zeros(3, dtype=torch.float32)}
+    target = torch.zeros(3, dtype=torch.float32)
 
     def fake_validate(
         *,
@@ -540,24 +520,20 @@ def test_store_get_into_async_unloads_replica(
 
     monkeypatch.setattr(materialization_mod, "validate_targets", fake_validate)
 
-    future = store.get_into_async(
-        target,
-        artifact_id="artifact-async",
-        device=torch.device("cuda", 0),
-    )
+    artifact = store.artifact(artifact_id="artifact-async")
+    artifact.tensor_into("bias", target, device=torch.device("cuda", 0))
 
-    assert future.result(timeout=1.0) is None
-    assert torch.allclose(target["bias"], state["bias"])
+    assert torch.allclose(target, state["bias"])
     assert env.client.unload_calls == [("rep-unload-3", "")]
 
 
-def test_store_get_into_async_unloads_on_validation_error(
+def test_artifact_tensor_into_unloads_on_validation_error(
     store_env: tuple[Store, FakeEnvironment], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, env = store_env
     state = {"bias": torch.arange(3, dtype=torch.float32)}
     env.add_materialized("artifact-async-invalid", state, replica_uuid="rep-unload-4")
-    target = {"bias": torch.zeros(3, dtype=torch.float32)}
+    target = torch.zeros(3, dtype=torch.float32)
 
     def failing_validate(
         *,
@@ -570,14 +546,10 @@ def test_store_get_into_async_unloads_on_validation_error(
 
     monkeypatch.setattr(materialization_mod, "validate_targets", failing_validate)
 
-    future = store.get_into_async(
-        target,
-        artifact_id="artifact-async-invalid",
-        device=torch.device("cuda", 0),
-    )
-
     with pytest.raises(ArtifactError):
-        future.result(timeout=1.0)
+        store.artifact(artifact_id="artifact-async-invalid").tensor_into(
+            "bias", target, device=torch.device("cuda", 0)
+        )
 
     assert env.client.unload_calls == [("rep-unload-4", "")]
 
@@ -628,11 +600,11 @@ def test_store_get_prefers_disk_when_available(
 
     store.set_materialize_fn(fake_materialize)
 
-    result = store.get(
+    artifact = store.artifact(
         key="does-not-matter",
-        fallback=FallbackOptions(disk_path="/tmp/artifact", prefer_disk=True, allow_p2p=False),
-        device=torch.device("cuda", 0),
+        fallback="disk:/tmp/artifact",
     )
+    result = artifact.tensor_dict(device=torch.device("cuda", 0))
     assert disk_called["path"] == "/tmp/artifact"
     assert disk_called["preference"] == store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
     assert "t" in result
@@ -668,8 +640,9 @@ def test_store_key_resolution_cache_reuses_mapping(
 
     fallback = FallbackOptions(prefer_disk=True, allow_p2p=False, verify_checksums=False)
 
-    first = store.get(key=key, fallback=fallback, device=torch.device("cuda", 0))
-    second = store.get(key=key, fallback=fallback, device=torch.device("cuda", 0))
+    artifact = store.artifact(key=key, fallback=fallback)
+    first = artifact.tensor_dict(device=torch.device("cuda", 0))
+    second = artifact.tensor_dict(device=torch.device("cuda", 0))
 
     assert torch.allclose(first["weight"], tensor)
     assert torch.allclose(second["weight"], tensor)
@@ -772,81 +745,59 @@ def test_get_function_delegates_to_session(
     class DummyStore:
         def __init__(self) -> None:
             self.kwargs: dict[str, object] | None = None
-            self.result = {"value": torch.ones(1)}
+            self.result: object = {"value": torch.ones(1)}
 
-        def get(
+        def artifact(
             self,
             *,
             artifact_id: str | None = None,
             key: str | None = None,
-            device: torch.device | str | None = None,
-            fallback: FallbackOptions | None = None,
-            options: GetArtifactOptions | None = None,
-        ) -> dict[str, torch.Tensor]:
+            disk_path: str | None = None,
+            fallback: FallbackOptions | str | None = None,
+        ) -> object:
             self.kwargs = {
                 "artifact_id": artifact_id,
                 "key": key,
-                "device": device,
+                "disk_path": disk_path,
                 "fallback": fallback,
-                "options": options,
             }
             return self.result
 
     session = DummyStore()
     monkeypatch.setattr(store_mod, "store", lambda: session)
-    outcome = store_mod.get(
-        key="demo",
-        device="cuda:0",
-        fallback=FallbackOptions(prefer_disk=True),
-    )
+    outcome: object = store_mod.artifact(key="demo", fallback="disk:/tmp/a")
 
     assert outcome is session.result
     assert session.kwargs is not None
     assert session.kwargs["key"] == "demo"
-    assert session.kwargs["device"] == "cuda:0"
+    assert session.kwargs["fallback"] == "disk:/tmp/a"
 
 
-def test_get_into_async_function_delegates_to_session(
+def test_from_disk_function_delegates_to_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    tensor = torch.zeros(1)
-
     class DummyStore:
         def __init__(self) -> None:
             self.kwargs: dict[str, object] | None = None
-            self.target: dict[str, torch.Tensor] | None = None
-            self.future = object()
+            self.result = object()
 
-        def get_into_async(
+        def from_disk(
             self,
-            target: dict[str, torch.Tensor],
+            path: str,
             *,
-            artifact_id: str | None = None,
-            key: str | None = None,
-            device: torch.device | str | None = None,
-            fallback: FallbackOptions | None = None,
-            options: GetArtifactOptions | None = None,
-        ) -> object:
-            self.target = target
-            self.kwargs = {
-                "artifact_id": artifact_id,
-                "key": key,
-                "device": device,
-                "fallback": fallback,
-                "options": options,
-            }
-            return self.future
+            fallback: FallbackOptions | str | None = None,
+        ):
+            self.kwargs = {"path": path, "fallback": fallback}
+            return self.result
 
     session = DummyStore()
     monkeypatch.setattr(store_mod, "store", lambda: session)
-    buffers = {"w": tensor}
-    result = store_mod.get_into_async(buffers, key="demo", device="cuda:0")
+    result = store_mod.from_disk("/tmp/data", fallback="disk:/tmp/data")
 
-    assert result is session.future
-    assert session.target is buffers
+    assert result is session.result
     assert session.kwargs is not None
-    assert session.kwargs["key"] == "demo"
-    assert session.kwargs["device"] == "cuda:0"
+    assert session.kwargs["path"] == "/tmp/data"
+    assert session.kwargs["fallback"] == "disk:/tmp/data"
 
 
 def test_store_singleton_reuse(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/python/test_store_session_api.py
+++ b/tests/python/test_store_session_api.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import concurrent.futures
 import json
 import threading
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, field
 from types import SimpleNamespace
 from typing import Any, Callable, Sequence, cast
 
@@ -14,6 +15,7 @@ import pytest
 import torch
 
 import tensorcast.api.store as store_mod
+from tensorcast import daemon_ctl
 from tensorcast.api._config import GetArtifactOptions, PlanType, RegisterArtifactOptions
 from tensorcast.api._materialize import MaterializationPayload, TensorPayloadDescriptor
 from tensorcast.api._register import (
@@ -31,9 +33,8 @@ from tensorcast.api.store import (
 )
 from tensorcast.api.store import materialization as materialization_mod
 from tensorcast.common.identity import ArtifactIdKind
-from tensorcast import daemon_ctl
-from tensorcast.types import ArtifactDescriptor, ServerConfig
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
+from tensorcast.types import ArtifactDescriptor, ServerConfig
 
 
 class FakeHandle:
@@ -48,6 +49,7 @@ class FakeHandle:
 @dataclass
 class FakeDaemonCtl:
     resolves: dict[str, tuple[str | None, str | None]]
+    materialized_by_id: dict[str, MaterializationPayload] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         self.unload_calls: list[tuple[str, str]] = []
@@ -56,6 +58,7 @@ class FakeDaemonCtl:
         self.server_address = "fake://daemon"
         self.resolve_calls: list[str] = []
         self.resolve_disk_calls: list[tuple[str, bool]] = []
+        self.index_by_id: dict[str, bytes] = {}
 
     def get_server_config(self) -> ServerConfig:
         return ServerConfig(tx_slice_bytes=4096, mem_pool_size=1 << 20, artifact_chunk_bytes=1 << 18)
@@ -92,6 +95,14 @@ class FakeDaemonCtl:
         self.unload_calls.append((replica_uuid, disk_path))
         return True
 
+    def get_artifact_index_by_id(self, artifact_id: str) -> bytes:
+        if artifact_id in self.index_by_id:
+            return self.index_by_id[artifact_id]
+        materialized = self.materialized_by_id.get(artifact_id)
+        if materialized is not None:
+            return materialized.canonical_index_bytes
+        raise RuntimeError(f"artifact index not found for {artifact_id}")
+
     def close(self) -> None:
         self.closed = True
 
@@ -103,6 +114,9 @@ class FakeEnvironment:
     block_registration: bool
     register_started: threading.Event
     materialized_by_id: dict[str, MaterializationPayload]
+
+    def __post_init__(self) -> None:
+        self.client.materialized_by_id = self.materialized_by_id
 
     def add_materialized(
         self,
@@ -140,6 +154,7 @@ class FakeEnvironment:
             offset += size_bytes
         canonical = json.dumps(index, separators=(",", ":"), sort_keys=True).encode("utf-8")
         canonical_index_bytes = canonical
+        self.client.index_by_id[artifact_id] = canonical_index_bytes
 
         def _iter():
             for desc in descriptors:
@@ -335,6 +350,7 @@ def store_env(monkeypatch: pytest.MonkeyPatch) -> tuple[Store, FakeEnvironment]:
         register_started=threading.Event(),
         materialized_by_id={},
     )
+    client.materialized_by_id = env.materialized_by_id
 
     monkeypatch.setattr(store_mod, "get_daemon_client", lambda endpoint: client)
     store = store_mod.Store(
@@ -411,6 +427,7 @@ def test_artifact_tensor_dict_into_copies_tensors(
         target: dict[str, torch.Tensor],
         source: dict[str, torch.Tensor],
         device_id: int,
+        required_names: Sequence[str] | None = None,
     ) -> list[tuple[torch.Tensor, torch.Tensor]]:
         return [(target["bias"], source["bias"])]
 
@@ -435,6 +452,7 @@ def test_artifact_tensor_dict_into_unloads_replica(
         target: dict[str, torch.Tensor],
         source: dict[str, torch.Tensor],
         device_id: int,
+        required_names: Sequence[str] | None = None,
     ) -> list[tuple[torch.Tensor, torch.Tensor]]:
         return [(target["bias"], source["bias"])]
 
@@ -461,6 +479,7 @@ def test_artifact_tensor_dict_into_unloads_on_validation_error(
         target: dict[str, torch.Tensor],
         source: dict[str, torch.Tensor],
         device_id: int,
+        required_names: Sequence[str] | None = None,
     ) -> list[tuple[torch.Tensor, torch.Tensor]]:
         raise ArtifactError("bad layout", status_code="FAILED_PRECONDITION", retryable=False)
 
@@ -495,8 +514,9 @@ def test_artifact_tensor_dict_async_releases_replica(
     env.add_materialized(artifact_id, {"w": torch.ones(2, dtype=torch.float32)}, replica_uuid="rep-100")
 
     artifact = store.artifact(artifact_id=artifact_id)
-    future = artifact.tensor_dict_async(device=torch.device("cuda", 0))
-    result = future.result(timeout=1.0)
+    result = asyncio.get_event_loop().run_until_complete(
+        artifact.tensor_dict_async(device=torch.device("cuda", 0))
+    )
     assert torch.allclose(result["w"], torch.ones(2, dtype=torch.float32))
     assert ("rep-100", "") in env.client.unload_calls
 
@@ -515,6 +535,7 @@ def test_artifact_tensor_into_unloads_replica(
         target: dict[str, torch.Tensor],
         source: dict[str, torch.Tensor],
         device_id: int,
+        required_names: Sequence[str] | None = None,
     ) -> list[tuple[torch.Tensor, torch.Tensor]]:
         return [(target["bias"], source["bias"])]
 
@@ -541,6 +562,7 @@ def test_artifact_tensor_into_unloads_on_validation_error(
         target: dict[str, torch.Tensor],
         source: dict[str, torch.Tensor],
         device_id: int,
+        required_names: Sequence[str] | None = None,
     ) -> list[tuple[torch.Tensor, torch.Tensor]]:
         raise ArtifactError("bad layout", status_code="FAILED_PRECONDITION", retryable=False)
 
@@ -559,6 +581,14 @@ def test_store_get_prefers_disk_when_available(
 ) -> None:
     store, env = store_env
     disk_called: dict[str, str | store_daemon_pb2.SourcePreference | None] = {}
+    tensor = torch.zeros(1, dtype=torch.float32)
+    size_bytes = int(tensor.element_size() * tensor.numel())
+    canonical_index_bytes = json.dumps(
+        {"t": [0, size_bytes, [1], [1], str(tensor.dtype), int(tensor.storage_offset())]},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    env.client.index_by_id["disk-artifact"] = canonical_index_bytes
+    env.client.resolves["does-not-matter"] = ("disk-artifact", "/tmp/artifact")
 
     def fake_materialize(
         *,
@@ -568,12 +598,6 @@ def test_store_get_prefers_disk_when_available(
     ) -> MaterializationPayload:
         disk_called["path"] = disk_path_hint
         disk_called["preference"] = preference
-        tensor = torch.zeros(1, dtype=torch.float32)
-        size_bytes = int(tensor.element_size() * tensor.numel())
-        canonical_index_bytes = json.dumps(
-            {"t": [0, size_bytes, [1], [1], str(tensor.dtype), int(tensor.storage_offset())]},
-            separators=(",", ":"),
-        ).encode("utf-8")
         descriptor = TensorPayloadDescriptor(
             name="t",
             dtype=str(tensor.dtype),
@@ -639,6 +663,9 @@ def test_store_key_resolution_cache_reuses_mapping(
     )
 
     fallback = FallbackOptions(prefer_disk=True, allow_p2p=False, verify_checksums=False)
+
+    # Warm the key mapping cache so disk fallback has a resolved path.
+    store._runtime.resolve_key_mapping_cached(key=key)
 
     artifact = store.artifact(key=key, fallback=fallback)
     first = artifact.tensor_dict(device=torch.device("cuda", 0))

--- a/tests/python/test_store_view_api.py
+++ b/tests/python/test_store_view_api.py
@@ -5,33 +5,32 @@ from __future__ import annotations
 import concurrent.futures
 import contextlib
 import json
-import threading
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Sequence
 
 import grpc
 import pytest
 import torch
 
 from tensorcast import _C
-from tensorcast.api.store import (
-    CanonicalIndex,
-    CanonicalIndexEntry,
-    Store,
-    StoreOptions,
-    ArtifactError,
-)
-from tensorcast.api.store import materialization as materialization_mod
-from tensorcast.api.store.materialization import MaterializationPipeline
-from tensorcast.api.store.retry import map_registration_error
-from tensorcast.api.store.views import ViewOrchestrator
+from tensorcast.api._materialize import MaterializationPayload, TensorPayloadDescriptor
 from tensorcast.api._view_ops import (
     NarrowOp,
     ResolvedViewInputs,
     TransposeOp,
     ViewSpecBuildResult,
 )
-from tensorcast.api._materialize import MaterializationPayload, TensorPayloadDescriptor
+from tensorcast.api.store import (
+    ArtifactError,
+    CanonicalIndex,
+    CanonicalIndexEntry,
+    Store,
+    StoreOptions,
+)
+from tensorcast.api.store import materialization as materialization_mod
+from tensorcast.api.store.materialization import MaterializationPipeline
+from tensorcast.api.store.retry import map_registration_error
+from tensorcast.api.store.views import ViewOrchestrator
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
 
 
@@ -363,6 +362,7 @@ def test_get_view_into_uses_layout_index(monkeypatch: pytest.MonkeyPatch) -> Non
         target: dict[str, torch.Tensor],
         source: dict[str, torch.Tensor],
         device_id: int,
+        required_names: Sequence[str] | None = None,
     ) -> list[tuple[torch.Tensor, torch.Tensor]]:
         captured_index["shapes"] = [entry.shape for entry in canonical_index.entries]
         return [(target["weights"], source["weights"])]
@@ -458,7 +458,7 @@ def test_register_view_client_placement_builds_canonical(monkeypatch: pytest.Mon
 
 
 def test_register_view_server_placement_error_guidance() -> None:
-    store = _fresh_store()
+    _fresh_store()
     failure = _PlacementRpcError(
         "SERVER placement for view registration requires GPU transpose support on device 0; "
         "retry with placement=CLIENT (mock device missing)"

--- a/tests/python/test_store_view_api.py
+++ b/tests/python/test_store_view_api.py
@@ -292,7 +292,11 @@ def test_get_view_invokes_perform_with_spec(monkeypatch: pytest.MonkeyPatch) -> 
         fake_perform.__get__(store._materialization, MaterializationPipeline),
     )
 
-    result = store.get_view(artifact_id="artifact-123", slices={"weights": (slice(0, 16),)})
+    result = store._materialization.get_view(
+        artifact_id="artifact-123",
+        slices={"weights": (slice(0, 16),)},
+        resolver=store._views.resolve_view_inputs,
+    )
     assert set(result.keys()) == {"weights"}
     assert payload.state_dict is not None
     assert result["weights"] is payload.state_dict["weights"]
@@ -366,7 +370,13 @@ def test_get_view_into_uses_layout_index(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(materialization_mod, "validate_targets", fake_validate)
 
     target = {"weights": torch.zeros(16)}
-    store.get_view_into(target, artifact_id="artifact-123", view_id=None, slices={"weights": (slice(0, 16),)})
+    store._materialization.get_view_into(
+        target,
+        artifact_id="artifact-123",
+        view_id=None,
+        slices={"weights": (slice(0, 16),)},
+        resolver=store._views.resolve_view_inputs,
+    )
     assert torch.allclose(target["weights"], torch.ones(16))
     assert captured_index["shapes"] == [(16,)]
     assert released.get("called") is True

--- a/tests/python/test_streaming_save.py
+++ b/tests/python/test_streaming_save.py
@@ -13,6 +13,8 @@ from tensorcast.api import save_dict
 from tensorcast.api._io_disk import load_dict_from_disk
 
 
+pytestmark = pytest.mark.requires_cuda_or_fake
+
 @pytest.fixture
 def has_cuda():
     """Whether CUDA is available on the test host."""

--- a/tests/python/utils/hardware.py
+++ b/tests/python/utils/hardware.py
@@ -1,0 +1,18 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+"""Hardware capability helpers for tests."""
+
+from __future__ import annotations
+
+import torch
+
+
+def has_cuda_or_fake() -> bool:
+    """Return True if either real CUDA is available or the fake backend is built."""
+    try:
+        from tensorcast._C import is_fake_cuda
+    except Exception:  # noqa: BLE001
+        is_fake = False
+    else:
+        is_fake = bool(is_fake_cuda())
+    return bool(torch.cuda.is_available() or is_fake)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ships a handle‑first Python SDK (Artifact APIs with tensor_into and cloned prefetch), adds embedded default daemon config for tc.init(), removes legacy eager get/get_into flows, and updates docs/tests accordingly.
> 
> - **SDK/API (Python)**:
>   - **Artifact-first surface**: `tc.artifact(...)` is canonical; remove module-level `get/get_into/get_view` (sync/async) and `register_kv_block`.
>   - **New helpers**: `Artifact.tensor_into(name, target, device=...)`; `Artifact.prefetch(device)` now returns `(handle_clone, PrefetchTicket)`.
>   - **Ergonomics**: accept fallback string shortcuts (e.g., `"disk:/path"`); `PlanType.parse` accepts `"lease"|"copy"`.
>   - **Options/models**: migrate `RegisterArtifactOptions`, `GetArtifactOptions`, `StoreOptions`, `FallbackOptions` to frozen Pydantic models.
>   - **Resolution/serialization**: improved disk-hint handling, `exists()` semantics, and `Artifact.to_dict()/from_dict()` typing.
> - **Startup**:
>   - **Embedded config**: `tc.init()` falls back to an auto-generated loopback daemon config with ephemeral ports and writable cache when no config is found; logs chosen path.
> - **Docs**:
>   - Update README, architecture/internals, and designs; add design/plan `0039-artifact-first-sdk`; align examples to handle-first API and prefetch semantics; deprecations noted.
> - **Tests**:
>   - Add/adjust tests for embedded init, new API surface (`artifact`, `tensor_into`, prefetch clone), fallback/plan coercion, and CUDA/fake markers; update suites to drop eager getters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc10774e186107292f1ab0dcd55d7a2333146bf1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->