### PR TITLE
feat(gs): enhance high availability with cluster token support and st…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,8 @@ use_repo(llvm, "llvm_toolchain")
 
 register_toolchains("@llvm_toolchain//:all")
 
-bazel_dep(name = "rules_cc", version = "0.2.0")
+bazel_dep(name = "rules_cc", version = "0.2.2")
+bazel_dep(name = "rules_python", version = "1.7.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "abseil-cpp", version = "20250512.1")
 bazel_dep(name = "catch2", version = "3.8.1")

--- a/core/store/components/global_store_client.cc
+++ b/core/store/components/global_store_client.cc
@@ -185,6 +185,9 @@ absl::Status GlobalStoreClient::initialize() {
   grpc::ClientContext context;
   context.set_deadline(
       std::chrono::system_clock::now() + std::chrono::seconds(absl::ToInt64Seconds(config_.connection_timeout)));
+  if (!config_.cluster_token.empty()) {
+    context.AddMetadata("x-tensorcast-cluster-token", config_.cluster_token);
+  }
 
   // OpenTelemetry: create a client span for HealthCheck and inject context.
   namespace otel = opentelemetry;
@@ -203,6 +206,20 @@ absl::Status GlobalStoreClient::initialize() {
     return absl::UnavailableError(
         absl::StrFormat(
             "Failed to connect to Global Store at %s: %s", config_.global_store_address, status.error_message()));
+  }
+
+  if (!config_.cluster_token.empty()) {
+    if (resp.cluster_token().empty()) {
+      return absl::FailedPreconditionError(
+          "Global Store health check did not return a cluster_token; refusing to continue with configured token.");
+    }
+    if (resp.cluster_token() != config_.cluster_token) {
+      return absl::FailedPreconditionError(
+          absl::StrFormat(
+              "Global Store cluster_token mismatch: expected '%s', got '%s'",
+              config_.cluster_token,
+              resp.cluster_token()));
+    }
   }
 
   LOG(INFO) << "Successfully connected to Global Store at " << config_.global_store_address;
@@ -1127,6 +1144,9 @@ absl::Status GlobalStoreClient::execute_rpc_with_retry(
     grpc::ClientContext context;
     context.set_deadline(
         std::chrono::system_clock::now() + std::chrono::seconds(absl::ToInt64Seconds(config_.rpc_timeout)));
+    if (!config_.cluster_token.empty()) {
+      context.AddMetadata("x-tensorcast-cluster-token", config_.cluster_token);
+    }
 
     // OpenTelemetry: create client span and inject W3C Trace Context.
     namespace otel = opentelemetry;

--- a/core/store/components/global_store_client.h
+++ b/core/store/components/global_store_client.h
@@ -32,6 +32,7 @@ struct GlobalStoreClientConfig {
   absl::Duration rpc_timeout = absl::Seconds(60);
   uint32_t max_retries = 3;
   absl::Duration retry_backoff = absl::Milliseconds(100);
+  std::string cluster_token;
 };
 
 // Information about a remote replica replica

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -89,7 +89,7 @@ Contract highlights:
 - TTL for every ephemeral map; all TTL updates and cleanup run under BackgroundScheduler.
 - Consistent deadlines: user timeouts are clamped to RPC deadlines.
 - Memory tiers: `engine.memory_tiers` drives stable/preemptible behavior; startup fails if configured `stable_bytes` exceed `(cgroup|MemTotal) - mem_pool_size_bytes`, and preemptible markings are skipped entirely when `enable_preemptible` is false. When HA is enabled, the daemon publishes `MemoryTierStatus` heartbeats via `MemoryTierService` using the UMA-backed `MemoryTierBudget` and replays `MemoryTierLease` state on startup/heartbeats (ListOutstandingLeases → UMA stable lease bind/release → ACK carrying artifact_id + chunk_ids + ledger_version for audit).
-- Observability is best-effort and never changes control flow; high-cardinality fields are gated.
+- Observability is best-effort and never changes control flow; high-cardinality fields are gated. Background HA counters (heartbeat/sync) tolerate missing meters so registration and sync continue even when telemetry providers are unavailable.
 - Idempotent unload and lock cleanup; expired tokens are unlocked automatically.
 - Lease-in-place commits rebuild the canonical tensor index from the fed `storage_entries` and `tensor_aliases`, emitting `tc_register_storage_count` / `tc_register_tensor_count` metrics so rollouts can confirm dedupe efficacy.
 

--- a/daemon/server_main.cc
+++ b/daemon/server_main.cc
@@ -267,6 +267,8 @@ int main(int argc, char** argv) {
       const auto& d = cfg.high_availability().periodic_sync_interval();
       lopts.chunk_sync_interval_ms = static_cast<int>(d.seconds() * 1000 + d.nanos() / 1000000);
     }
+    lopts.force_full_sync_on_empty_inventory = cfg.high_availability().force_full_sync_on_empty_inventory();
+    lopts.cluster_token = cfg.meta().cluster_token();
     lifecycle = std::make_unique<daemon::WorkerLifecycleManager>(
         gsl::not_null<std::shared_ptr<store::StoreEngine>>{engine},
         gsl::not_null<daemon::StoreDaemonServiceImpl*>{&service},

--- a/daemon/worker_lifecycle_manager.cc
+++ b/daemon/worker_lifecycle_manager.cc
@@ -33,28 +33,28 @@ using namespace std::chrono_literals;
 
 namespace {
 
-opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> hb_success_counter() {
+opentelemetry::metrics::Counter<uint64_t>* hb_success_counter() {
   static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
   static auto ctr = meter->CreateUInt64Counter("tc_daemon_ha_heartbeat_success_total");
-  return ctr;
+  return ctr.get();
 }
 
-opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> hb_failure_counter() {
+opentelemetry::metrics::Counter<uint64_t>* hb_failure_counter() {
   static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
   static auto ctr = meter->CreateUInt64Counter("tc_daemon_ha_heartbeat_failure_total");
-  return ctr;
+  return ctr.get();
 }
 
-opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> sync_success_counter() {
+opentelemetry::metrics::Counter<uint64_t>* sync_success_counter() {
   static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
   static auto ctr = meter->CreateUInt64Counter("tc_daemon_ha_sync_success_total");
-  return ctr;
+  return ctr.get();
 }
 
-opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> sync_failure_counter() {
+opentelemetry::metrics::Counter<uint64_t>* sync_failure_counter() {
   static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
   static auto ctr = meter->CreateUInt64Counter("tc_daemon_ha_sync_failure_total");
-  return ctr;
+  return ctr.get();
 }
 
 bool is_loopback_or_unspecified(absl::string_view addr) {
@@ -268,7 +268,9 @@ void WorkerLifecycleManager::heartbeat_loop() {
       if (!hb_or.ok()) {
         LOG(WARNING) << "Enhanced heartbeat failed: " << hb_or.status().message();
         hb_failure_.fetch_add(1);
-        hb_failure_counter()->Add(1);
+        if (auto* counter = hb_failure_counter()) {
+          counter->Add(1);
+        }
         // If connection is healthy but server rejected (e.g., NOT_FOUND after GS restart),
         // perform recovery-aware re-registration to preserve identity.
         if (global_store_->is_connected()) {
@@ -280,7 +282,9 @@ void WorkerLifecycleManager::heartbeat_loop() {
       } else {
         const auto& hb = *hb_or;
         hb_success_.fetch_add(1);
-        hb_success_counter()->Add(1);
+        if (auto* counter = hb_success_counter()) {
+          counter->Add(1);
+        }
         last_hb_ts_s_.store(
             static_cast<int64_t>(
                 std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
@@ -346,7 +350,9 @@ void WorkerLifecycleManager::heartbeat_loop() {
             state_version_ = sync_or->first;
             state_checksum_ = sync_or->second;
             sync_success_.fetch_add(1);
-            sync_success_counter()->Add(1);
+            if (auto* counter = sync_success_counter()) {
+              counter->Add(1);
+            }
             // Apply server-suggested removals
             std::vector<std::string> obsolete;
             obsolete.reserve(changes.size());
@@ -434,7 +440,9 @@ void WorkerLifecycleManager::heartbeat_loop() {
           } else {
             VLOG(1) << "SynchronizeWorkerState returned: " << sync_or.status();
             sync_failure_.fetch_add(1);
-            sync_failure_counter()->Add(1);
+            if (auto* counter = sync_failure_counter()) {
+              counter->Add(1);
+            }
             // Fallback to full-state sync if server indicates desync or errors persist
             std::vector<commonpb::ReplicaInfo> expected;
             auto full_or = global_store_->request_full_state_sync(worker_id_, state_version_, &expected);
@@ -764,6 +772,8 @@ void WorkerLifecycleManager::apply_full_state(const std::vector<commonpb::Replic
 std::string WorkerLifecycleManager::compute_state_checksum(
     std::string_view node_id,
     const std::vector<store::StoreEngine::ReplicaInfo>& infos) {
+  // Keep format aligned with Global Store's RecoveryService._compute_state_checksum:
+  // artifact_id:node_id:device_id:memory_type:available; sorted by (artifact_id, memory_type, device_id).
   struct Entry {
     std::string artifact_id;
     std::string memory_type;

--- a/daemon/worker_lifecycle_manager.cc
+++ b/daemon/worker_lifecycle_manager.cc
@@ -4,13 +4,15 @@
 
 #include <unistd.h>
 
+#include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <exception>
 #include <utility>
 
 #include "absl/container/flat_hash_set.h"
-#include "absl/hash/hash.h"
+#include "absl/crc/crc32c.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -30,6 +32,30 @@ namespace commonpb = common::v1;
 using namespace std::chrono_literals;
 
 namespace {
+
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> hb_success_counter() {
+  static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+  static auto ctr = meter->CreateUInt64Counter("tc_daemon_ha_heartbeat_success_total");
+  return ctr;
+}
+
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> hb_failure_counter() {
+  static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+  static auto ctr = meter->CreateUInt64Counter("tc_daemon_ha_heartbeat_failure_total");
+  return ctr;
+}
+
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> sync_success_counter() {
+  static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+  static auto ctr = meter->CreateUInt64Counter("tc_daemon_ha_sync_success_total");
+  return ctr;
+}
+
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> sync_failure_counter() {
+  static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+  static auto ctr = meter->CreateUInt64Counter("tc_daemon_ha_sync_failure_total");
+  return ctr;
+}
 
 bool is_loopback_or_unspecified(absl::string_view addr) {
   if (addr.empty())
@@ -63,6 +89,7 @@ gsl::not_null<std::shared_ptr<store::components::GlobalStoreClient>> WorkerLifec
 
   store::components::GlobalStoreClientConfig cfg;
   cfg.global_store_address = opts.global_store_addr;
+  cfg.cluster_token = opts.cluster_token;
   auto client = std::make_shared<store::components::GlobalStoreClient>(std::move(cfg));
   return gsl::not_null<std::shared_ptr<store::components::GlobalStoreClient>>{std::move(client)};
 }
@@ -228,7 +255,7 @@ void WorkerLifecycleManager::heartbeat_loop() {
         registered_ids.push_back(i.artifact_id);
       }
       // Compute simple checksum over current snapshot
-      state_checksum_ = compute_state_checksum(infos);
+      state_checksum_ = compute_state_checksum(node_id_, infos);
       auto hb_or = global_store_->send_heartbeat_enhanced(
           worker_id_,
           engine_->get_available_memory(),
@@ -241,6 +268,7 @@ void WorkerLifecycleManager::heartbeat_loop() {
       if (!hb_or.ok()) {
         LOG(WARNING) << "Enhanced heartbeat failed: " << hb_or.status().message();
         hb_failure_.fetch_add(1);
+        hb_failure_counter()->Add(1);
         // If connection is healthy but server rejected (e.g., NOT_FOUND after GS restart),
         // perform recovery-aware re-registration to preserve identity.
         if (global_store_->is_connected()) {
@@ -252,6 +280,7 @@ void WorkerLifecycleManager::heartbeat_loop() {
       } else {
         const auto& hb = *hb_or;
         hb_success_.fetch_add(1);
+        hb_success_counter()->Add(1);
         last_hb_ts_s_.store(
             static_cast<int64_t>(
                 std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
@@ -285,6 +314,7 @@ void WorkerLifecycleManager::heartbeat_loop() {
             rep->mutable_ref()->set_artifact_id(i.artifact_id);
             rep->mutable_ref()->set_replica_id("");
             auto* mi = rep->mutable_memory_info();
+            mi->set_node_id(node_id_);
             mi->set_memory_size(i.size_bytes);
             if (i.gpu_state != common::memory::MemoryLocation::NONE) {
               mi->set_memory_type(commonpb::MEMORY_TYPE_GPU);
@@ -305,16 +335,18 @@ void WorkerLifecycleManager::heartbeat_loop() {
                     : store::DeviceKey{.type = DeviceType::CPU, .ordinal = -1, .uuid = ""},
                 .replica = 0};
             rep->mutable_stats()->set_current_requests(static_cast<uint32_t>(service_->ref_count_for(rkey)));
-            rep->mutable_stats()->set_is_available(true);
+            rep->mutable_stats()->set_is_available(i.is_registered_for_comm);
             rep->mutable_stats()->mutable_registered_ts()->CopyFrom(local_state.last_update_ts());
           }
 
           std::vector<global_store::StateChange> changes;
-          auto sync_or = global_store_->synchronize_worker_state(local_state, /*force_full_sync=*/false, &changes);
+          const bool force_full_sync = opts_.force_full_sync_on_empty_inventory && infos.empty();
+          auto sync_or = global_store_->synchronize_worker_state(local_state, force_full_sync, &changes);
           if (sync_or.ok()) {
             state_version_ = sync_or->first;
             state_checksum_ = sync_or->second;
             sync_success_.fetch_add(1);
+            sync_success_counter()->Add(1);
             // Apply server-suggested removals
             std::vector<std::string> obsolete;
             obsolete.reserve(changes.size());
@@ -402,6 +434,7 @@ void WorkerLifecycleManager::heartbeat_loop() {
           } else {
             VLOG(1) << "SynchronizeWorkerState returned: " << sync_or.status();
             sync_failure_.fetch_add(1);
+            sync_failure_counter()->Add(1);
             // Fallback to full-state sync if server indicates desync or errors persist
             std::vector<commonpb::ReplicaInfo> expected;
             auto full_or = global_store_->request_full_state_sync(worker_id_, state_version_, &expected);
@@ -728,22 +761,61 @@ void WorkerLifecycleManager::apply_full_state(const std::vector<commonpb::Replic
   apply_obsolete_replicas(obsolete);
 }
 
-std::string WorkerLifecycleManager::compute_state_checksum(const std::vector<store::StoreEngine::ReplicaInfo>& infos) {
-  // Simple stable hash over (artifact_id, gpu_state, cpu_state, device_id)
-  size_t h = 0;
+std::string WorkerLifecycleManager::compute_state_checksum(
+    std::string_view node_id,
+    const std::vector<store::StoreEngine::ReplicaInfo>& infos) {
+  struct Entry {
+    std::string artifact_id;
+    std::string memory_type;
+    int device_id;
+    bool available;
+  };
+
+  std::vector<Entry> entries;
+  entries.reserve(infos.size());
+
   for (const auto& i : infos) {
-    h = absl::HashOf(h, i.artifact_id, static_cast<int>(i.gpu_state), static_cast<int>(i.cpu_state), i.gpu_device_id);
+    std::string mem_type = "DISK";
+    int device_id = 0;
+    if (i.gpu_state != common::memory::MemoryLocation::NONE) {
+      mem_type = "GPU";
+      device_id = i.gpu_device_id;
+    } else if (i.cpu_state != common::memory::MemoryLocation::NONE) {
+      mem_type = "RAM";
+      device_id = 0;
+    }
+    entries.push_back(
+        Entry{
+            .artifact_id = i.artifact_id,
+            .memory_type = std::move(mem_type),
+            .device_id = device_id,
+            .available = i.is_registered_for_comm,
+        });
   }
-  // Format as hex for readability
-  std::string out;
-  out.resize(sizeof(size_t) * 2);
-  static const char* hex = "0123456789abcdef";
-  for (size_t i = 0; i < sizeof(size_t); ++i) {
-    auto byte = static_cast<uint8_t>((h >> ((sizeof(size_t) - 1 - i) * 8)) & 0xFF);
-    out[i * 2] = hex[(byte >> 4) & 0xF];
-    out[i * 2 + 1] = hex[byte & 0xF];
+
+  std::sort(entries.begin(), entries.end(), [](const Entry& lhs, const Entry& rhs) {
+    if (lhs.artifact_id != rhs.artifact_id)
+      return lhs.artifact_id < rhs.artifact_id;
+    if (lhs.memory_type != rhs.memory_type)
+      return lhs.memory_type < rhs.memory_type;
+    return lhs.device_id < rhs.device_id;
+  });
+
+  std::string state_str;
+  for (const auto& e : entries) {
+    absl::StrAppendFormat(
+        &state_str, "%s:%s:%d:%s:%d;", e.artifact_id, node_id, e.device_id, e.memory_type, e.available ? 1 : 0);
   }
-  return out;
+
+  // FNV-1a 64-bit over the stable string; portable across languages.
+  uint64_t hash = 14695981039346656037ull; // FNV offset basis
+  constexpr uint64_t kFnvPrime = 1099511628211ull; // FNV prime
+  for (char c : state_str) {
+    hash ^= static_cast<uint8_t>(c);
+    hash *= kFnvPrime;
+  }
+
+  return absl::StrFormat("%016x", hash);
 }
 
 } // namespace tensorcast::daemon

--- a/daemon/worker_lifecycle_manager.h
+++ b/daemon/worker_lifecycle_manager.h
@@ -27,6 +27,12 @@ class WorkerLifecycleManager {
     uint16_t p2p_port{0};
     int heartbeat_interval_ms{5000};
     int chunk_sync_interval_ms{10000}; // 0 to disable
+    // When true, an empty local inventory is treated as authoritative and will
+    // drive removals via force_full_sync during synchronization.
+    bool force_full_sync_on_empty_inventory{false};
+    // Optional cluster identity guard; if set, daemon will refuse to register
+    // with a Global Store reporting a different token.
+    std::string cluster_token;
   };
 
   WorkerLifecycleManager(
@@ -65,7 +71,9 @@ class WorkerLifecycleManager {
   void monitor_loop();
   void apply_obsolete_replicas(const std::vector<std::string>& artifact_ids);
   void apply_full_state(const std::vector<commonpb::ReplicaInfo>& expected);
-  static std::string compute_state_checksum(const std::vector<store::StoreEngine::ReplicaInfo>& infos);
+  static std::string compute_state_checksum(
+      std::string_view node_id,
+      const std::vector<store::StoreEngine::ReplicaInfo>& infos);
   absl::Status reregister_worker(bool preserve_identity);
   void reconcile_memory_tier_leases_once();
 

--- a/daemon/worker_lifecycle_manager_sync_test.cc
+++ b/daemon/worker_lifecycle_manager_sync_test.cc
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -564,6 +565,35 @@ TEST_CASE("WorkerLifecycleManager heartbeat applies obsolete removals", "[daemon
   test_server.server->Shutdown();
   std::error_code ec;
   fs::remove_all(temp_root, ec);
+}
+
+TEST_CASE("state_checksum_is_stable_and_availability_sensitive") {
+  std::vector<StoreEngine::ReplicaInfo> infos;
+  StoreEngine::ReplicaInfo gpu;
+  gpu.artifact_id = "artifact-a";
+  gpu.gpu_state = tensorcast::common::memory::MemoryLocation::GPU;
+  gpu.cpu_state = tensorcast::common::memory::MemoryLocation::NONE;
+  gpu.gpu_device_id = 1;
+  gpu.is_registered_for_comm = true;
+  infos.push_back(gpu);
+
+  StoreEngine::ReplicaInfo cpu;
+  cpu.artifact_id = "artifact-b";
+  cpu.gpu_state = tensorcast::common::memory::MemoryLocation::NONE;
+  cpu.cpu_state = tensorcast::common::memory::MemoryLocation::CPU;
+  cpu.gpu_device_id = -1;
+  cpu.is_registered_for_comm = true;
+  infos.push_back(cpu);
+
+  const std::string node_id = "node-xyz";
+  const auto checksum1 = WorkerLifecycleManager::compute_state_checksum(node_id, infos);
+  std::reverse(infos.begin(), infos.end());
+  const auto checksum2 = WorkerLifecycleManager::compute_state_checksum(node_id, infos);
+  REQUIRE(checksum1 == checksum2);
+
+  infos.front().is_registered_for_comm = false;
+  const auto checksum3 = WorkerLifecycleManager::compute_state_checksum(node_id, infos);
+  REQUIRE(checksum3 != checksum1);
 }
 
 TEST_CASE("WorkerLifecycleManager applies REMOVE via SynchronizeWorkerState", "[daemon][ha][delta]") {

--- a/docs/architecture/high-availability-design.md
+++ b/docs/architecture/high-availability-design.md
@@ -13,162 +13,235 @@ This document explains High Availability (HA) as implemented in code: startup re
 ## Key Components (sources)
 
 - Global Store
-  - Recovery service: `tensorcast/global_store/services/recovery_service.py`
-  - gRPC service (registration, heartbeat, sync): `tensorcast/global_store/grpc_service.py`
+  - Recovery/state sync service: `tensorcast/global_store/services/recovery_service.py`
+  - gRPC surface (registration, heartbeat, sync, health): `tensorcast/global_store/grpc_service.py`
 - Store Daemon (C++)
-  - Lifecycle + heartbeat + sync: `daemon/worker_lifecycle_manager.cc`
+  - Lifecycle + heartbeat + sync + drift eviction: `daemon/worker_lifecycle_manager.cc`
   - Global Store client + retries/backoff: `core/store/components/global_store_client.{h,cc}`
+  - HA wiring + endpoint selection: `daemon/server_main.cc`
 - Protocol buffers
   - Enhanced heartbeat and sync: `proto/tensorcast/global_store/v1/global_store.proto`
 
 Materialization HA invariant: v2 descriptor streaming in the daemon uses UMA view plans when a view is requested and always routes disk fallbacks through `DiskFallbackHint` (including `verify_checksums`). SDKs never read disk directly for retrieval, so selective tensor loads and disk-sourced replicas share the same daemon-managed buffer layout.
 
+## Registration & Identity
+
+- The daemon must advertise a routable address (non-loopback, non-unspecified). `server.advertise.host` overrides `server.listen.host`; `RegisterWorker` rejects loopback/unspecified IPs.
+- HA requires `server.p2p_listen.port` to be non-zero; startup aborts otherwise.
+- Recovery registration preserves `worker_id` when possible and always requests a state sync; stale replicas owned by the previous worker id are reassigned or marked unavailable.
+
 ## Startup Recovery (Global Store)
 
-Global Store runs a recovery pass on startup; workers/replicas are marked stale until workers re-confirm via registration/heartbeat.
+On startup the Global Store runs a guarded recovery pass; state stays marked stale until workers re-confirm via registration or heartbeat.
 
-```42:71:tensorcast/global_store/services/recovery_service.py
-def initiate_recovery(self) -> bool:
-    if self.recovery_in_progress:
-        return False
-    self.recovery_in_progress = True
-    try:
-        self._validate_database_state()
-        self._mark_workers_as_stale()
-        self._mark_replicas_as_stale()
-        self.worker_state_versions.clear()
-        self.last_recovery_time = int(time.time())
-        return True
-    except Exception:
-        return False
-    finally:
-        self.recovery_in_progress = False
-```
+- `RecoveryService.initiate_recovery` short-circuits if already running so only one pass executes.
+- The pass validates the DuckDB backing store, marks every worker and replica as stale, clears cached state versions, and records the recovery timestamp.
+- Keeping the stale flag forces each daemon to re-register and re-sync before it can serve traffic, ensuring registry drift does not leak into routing.
 
 ## Enhanced Heartbeat
 
-The daemon sends an enhanced heartbeat including state metadata; the server validates and signals whether synchronization is required.
+Enhanced heartbeats (state_version > 0) include the daemon’s view of inventory and state so the Global Store can detect drift. Legacy heartbeats (state_version == 0) are still accepted for older daemons.
 
-```93:115:proto/tensorcast/global_store/v1/global_store.proto
-message WorkerHeartbeatRequest { string worker_id = 1; uint64 mem_pool_available_size = 2; bool accepting_new_requests = 3; uint64 state_version = 4; string state_checksum = 5; repeated string registered_artifact_ids = 6; int64 last_successful_sync = 7; ConnectionStatus global_store_status = 8; }
-message WorkerHeartbeatResponse { Status status = 1; bool state_sync_required = 2; uint64 expected_state_version = 3; repeated string obsolete_replicas = 4; google.protobuf.Timestamp server_timestamp_ts = 5; }
-```
-
-```721:780:tensorcast/global_store/grpc_service.py
-def _handle_enhanced_heartbeat(...):
-    success = self.worker_service.heartbeat(...)
-    current_version = self.recovery_service.get_worker_state_version(request.worker_id)
-    state_sync_required = request.state_version < current_version
-    if request.state_checksum:
-        server_checksum = self.recovery_service.get_worker_state_checksum(request.worker_id)
-        if request.state_checksum != server_checksum:
-            state_sync_required = True
-    obsolete_replicas = self.recovery_service.get_obsolete_artifacts(...)
-    if obsolete_replicas:
-        state_sync_required = True
-    return WorkerHeartbeatResponse(status=STATUS_OK, state_sync_required=state_sync_required, expected_state_version=current_version, obsolete_replicas=obsolete_replicas, server_timestamp_ts=ts)
-```
-
-```104:128:daemon/worker_lifecycle_manager.cc
-const auto infos = engine_->get_all_replicas_info();
-std::vector<std::string> registered_ids; for (const auto& i : infos) registered_ids.push_back(i.artifact_id);
-state_checksum_ = compute_state_checksum(infos);
-auto hb_or = global_store_->send_heartbeat_enhanced(*worker_id_, engine_->get_available_memory(), accepting, state_version_, state_checksum_, registered_ids, last_sync_success_ts_, global_store::CONNECTION_STATUS_CONNECTED);
-```
-
-The lifecycle manager now constructs its `GlobalStoreClient` (channel + stub) during instantiation; the handle is `gsl::not_null`, node identity is captured once at construction, and the worker id is populated during registration so `start()` only performs the health-check handshake and worker registration.
+- Request payload: worker id, available memory, acceptance flag, current `state_version`, computed `state_checksum`, the set of registered artifact ids, last successful sync timestamp, and the daemon→Global Store connection status.
+- Global Store handling (`grpc_service._handle_enhanced_heartbeat`):
+  - Compares the sent version with `RecoveryService`’s version and recomputes checksum when provided.
+  - Marks `state_sync_required` when versions or checksums diverge, or when obsolete replicas are detected.
+  - Returns the server timestamp, the expected version, and the list of obsolete replicas so the daemon can prune immediately.
+- Daemon behavior (`WorkerLifecycleManager` + `GlobalStoreClient`):
+  - Collects current replicas, computes a checksum, and calls `send_heartbeat_enhanced`.
+  - If the RPC returns `NOT_FOUND` while the channel is healthy, the daemon re-registers with the preserved identity and triggers a full-state sync before resuming heartbeats.
 
 ## State Synchronization
 
-When `state_sync_required` is true or version/checksum diverge, the daemon submits the authoritative inventory via `SynchronizeWorkerState`.
+When `state_sync_required` is returned (or the daemon detects its version/checksum diverged), the daemon submits its full inventory through `SynchronizeWorkerState`.
 
-Global Store computes changes with “addition over removal” semantics and applies them; removals are suppressed when the daemon does not supply inventory.
-
-```227:304:tensorcast/global_store/services/recovery_service.py
-# to_add = local \ global; to_remove = (global \ local) only if local inventory is non-empty
-```
-
-```699:727:core/store/components/global_store_client.cc
-absl::StatusOr<std::pair<uint64_t, std::string>> GlobalStoreClient::synchronize_worker_state(...)
-```
+- Global Store computes diffs with “addition over removal” semantics: additions are always applied, removals are only applied when the daemon provided a non-empty inventory to avoid deleting during partial reports.
+- Versions only advance when actual changes are applied; a no-op sync returns the existing version along with a recomputed checksum.
+- The daemon stores the returned version and checksum so subsequent heartbeats can short-circuit unnecessary syncs.
+- Checksum parity: both sides compute a stable FNV-1a hash over a sorted inventory of `(artifact_id, memory_type, device_id, node_id, availability)`. Order never changes the checksum, and availability flips (remote access enable/disable) intentionally mutate it to trigger reconciliation.
+- Authoritative empties: when `high_availability.force_full_sync_on_empty_inventory=true`, an empty inventory is treated as authoritative and removals are applied (for drains/retirements). Default keeps the conservative behavior (empty = “unknown”, no removals).
 
 ## Full-State Sync
 
-The daemon can request expected replicas for a full reconciliation after cold start or drift.
+The daemon requests the authoritative replica set after cold start, re-registration, or when drift is suspected. Full-state sync returns the current checksum and expected set without bumping versions.
 
-```729:756:core/store/components/global_store_client.cc
-absl::StatusOr<std::pair<uint64_t, std::string>> GlobalStoreClient::request_full_state_sync(...)
-```
+- `request_full_state_sync` provides a complete snapshot the daemon treats as source of truth.
+- During startup, `WorkerLifecycleManager::start` performs this call once, prunes any local replicas not present in the expected set, and only then starts serving traffic.
 
 ## Connection Management & Retries (Daemon)
 
-All RPCs are wrapped with bounded retries, exponential backoff and deadlines.
+All Global Store RPCs use bounded retries with exponential backoff and jitter (`max_retries=3`, initial backoff 100ms, doubled per attempt with ±50% jitter). Each call also sets deadlines so stalled channels fail fast.
 
-```579:626:core/store/components/global_store_client.cc
-template <typename Request, typename Response, typename RpcMethod>
-absl::Status GlobalStoreClient::execute_rpc_with_retry(...) { /* retry with jitter */ }
-```
+- The retry helper is centralized in `GlobalStoreClient::execute_rpc_with_retry`, so heartbeat, registration, sync, and health probes share the same policy.
+- Endpoint selection: the daemon currently uses the first entry in `high_availability.global_store_endpoints` as `global_store_address` (single Global Store only; additional endpoints are ignored for now).
+- Advertise constraints: `RegisterWorker` rejects loopback or unspecified addresses; `resolve_advertised_address` prefers `server.advertise.host` and otherwise uses the listen host, then validates routability.
+- Health check: `GlobalStoreClient::initialize` issues a `HealthCheck` before registration; failing the probe aborts HA startup early instead of hanging during registration. When a `meta.cluster_token` is configured, the daemon refuses to proceed unless the HealthCheck token matches, preventing accidental cross-cluster registration.
 
 ## Responsibilities
 
-- Global Store: persist registry; accept heartbeats and synchronize state; compute and apply changes; serve expected state for full sync.
-- Store Daemon: maintain authoritative local inventory; send enhanced heartbeats; perform incremental/full syncs; apply obsolete removals.
+- Global Store: persist registry; accept heartbeats and synchronize state; compute/apply changes; serve expected state for full sync; reject ambiguous loopback registrations; expose cluster token via HealthCheck.
+- Store Daemon: maintain authoritative local inventory; send enhanced heartbeats; perform incremental/full syncs; prune drift; re-register on desync; apply obsolete removals and prefetch adds returned by sync.
+
+## Failure Modes and Recovery Behavior
+
+- **Global Store outage/restart**
+  - Heartbeats log warnings and retry with backoff; `is_connected()` flips false when the gRPC channel is not READY, so P2P transports and registrations reject with `FailedPrecondition` unless a disk hint is provided.
+  - Store Daemons continue serving already-materialized replicas locally; inventory remains authoritative on the node, but new replicas are not registered while the outage lasts.
+  - In-flight transports keep streaming because the data plane is daemon-to-daemon; the follow-up `complete_replica_transport` call may fail and leak counters temporarily, but `cleanup_expired_transports()` on the Global Store cleans them up.
+  - When the Global Store comes back, the next enhanced heartbeat can return `NOT_FOUND`; the daemon automatically re-registers with preserved identity and performs a full-state sync to reconcile drift before resuming normal heartbeats.
+
+- **Store Daemon crash or shutdown**
+  - Heartbeats stop; Global Store marks the worker stale after `heartbeat_timeout` and removes it from transport selection. Existing replicas remain in the registry but are not assigned because `find_available_for_transport()` filters by heartbeat freshness.
+  - Stuck transports sourced from the crashed daemon are force-completed by the Global Store sweeper; P2P sessions targeting the crashed daemon fail at connection time and surface an error to callers.
+  - On restart, the daemon re-registers, runs full-state sync, and prunes obsolete replicas locally so it rejoins routing without manual cleanup.
+
+- **Network partition between daemon and Global Store**
+  - RPCs exhaust retry budgets (`execute_rpc_with_retry`), heartbeats record failures, and the daemon eventually considers the channel disconnected. Local reads still succeed; any operation requiring coordination (registration, transport request, chunk sync) fails fast to clients with the underlying gRPC status.
+  - When connectivity resumes, the daemon resumes heartbeats, re-registers if needed, and performs an incremental or full sync depending on version drift.
+
+- **P2P transport failure (network or source-side)**
+  - `MaterializeOrchestrator` always calls `complete_replica_transport()` even when `ingest_from_p2p()` fails, releasing source-side counters promptly.
+  - If a disk hint exists, the orchestrator retries via `ingest_from_disk()`; otherwise the error propagates to the client SDK. GPU memory pressure triggers an eviction + single retry before failing.
+  - Transport cleanup on the Global Store prevents long-lived counter leaks when either side dies mid-transfer.
+
+- **Client SDK visibility**
+  - Requests served from a healthy local replica succeed even during Global Store outages.
+  - Missing replicas with no disk hints return `FailedPrecondition` when the Global Store is unreachable; P2P failures surface the transport error unless disk fallback succeeds.
+  - After a daemon restart or reconnection, the first successful sync re-enables normal routing; clients see transient failures only during the gap.
+
+### HA Event Timeline (heartbeat, re-registration, sync)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SD as Store Daemon
+    participant GS as Global Store
+    participant CL as Client SDK
+
+    CL->>SD: Materialize request
+    SD->>GS: RegisterWorker + FullStateSync
+    SD->>GS: Heartbeat (enhanced)
+    GS-->>SD: HB OK (no sync)
+
+    Note over SD,GS: GS restart / outage
+    SD->>GS: Heartbeat retries w/ backoff
+    GS-->>SD: NOT_FOUND (after restart)
+    SD->>GS: Re-register (preserve identity)
+    SD->>GS: RequestFullStateSync
+    GS-->>SD: Expected replicas + checksum
+    SD->>SD: Prune drift, resume traffic
+
+    CL->>SD: New request during outage
+    SD-->>CL: Serve local replica OR error (needs GS / no disk hint)
+```
+
+### Transport Failure and Fallback Path
+
+```mermaid
+flowchart TD
+    RQ[Client materialize request] --> LCL{Local replica present?}
+    LCL -- Yes --> SERVE[Serve immediately]
+    LCL -- No --> GSOK{Global Store reachable?}
+    GSOK -- No --> DISKHINT{Disk hint provided?}
+    DISKHINT -- Yes --> DISK[ingest_from_disk()]
+    DISKHINT -- No --> ERR1[Fail: FailedPrecondition]
+    GSOK -- Yes --> P2P[RequestReplicaTransport()]
+    P2P -- Granted --> COPY[ingest_from_p2p()]
+    COPY -- Success --> COMPLETE[complete_replica_transport()]
+    COMPLETE --> REG[register_replica_with_global_store()]
+    COPY -- Failure --> CLOSE[complete_replica_transport()]
+    CLOSE --> DISKFALL{Disk hint available?}
+    DISKFALL -- Yes --> DISK
+    DISKFALL -- No --> ERR2[Fail with transport error]
+    DISK --> SERVE
+```
 
 ## Protocols (authoritative)
 
-```151:177:proto/tensorcast/global_store/v1/global_store.proto
-message WorkerLocalState { string worker_id = 1; uint64 state_version = 2; string state_checksum = 3; repeated tensorcast.common.v1.ReplicaInfo local_replicas = 4; google.protobuf.Timestamp last_update_ts = 5; }
-message SynchronizeWorkerStateRequest { string worker_id = 1; WorkerLocalState local_state = 2; bool force_full_sync = 3; }
-message SynchronizeWorkerStateResponse { Status status = 1; uint64 new_state_version = 2; repeated StateChange state_changes = 3; string new_state_checksum = 4; }
-message StateChange { enum ChangeType { CHANGE_TYPE_UNSPECIFIED = 0; CHANGE_TYPE_REMOVE_REPLICA = 1; CHANGE_TYPE_UPDATE_REPLICA = 2; CHANGE_TYPE_ADD_REPLICA = 3; } ChangeType type = 1; tensorcast.common.v1.ReplicaInfo replica_info = 2; string reason = 3; }
-```
+From `proto/tensorcast/global_store/v1/global_store.proto`:
+
+- `WorkerLocalState`: worker id, state version, checksum, full `ReplicaInfo` list, and last update timestamp.
+- `SynchronizeWorkerStateRequest`: worker id plus `WorkerLocalState`, with `force_full_sync` to bypass diffing if needed.
+- `SynchronizeWorkerStateResponse`: status, new state version, new checksum, and a list of `StateChange` entries describing applied add/update/remove operations (with reasons).
 
 ## End-to-End Flows
 
 - Startup recovery: validate DB, mark stale, reset versions → workers re-register/heartbeat → server may request sync.
 - Heartbeat loop: daemon sends enhanced heartbeat → server compares version/checksum and obsolete set → may request sync.
 - Incremental sync: daemon sends `WorkerLocalState.local_replicas` snapshot → server computes StateChange list and applies → returns new version/checksum.
-- Full-state sync: daemon requests expected replicas → applies locally, resumes incremental syncs.
+- Full-state sync: daemon requests expected replicas → prunes drift locally → resumes incremental syncs.
 
 ## Reconciliation Invariants
 
 - Authoritative inventory: daemon’s `local_replicas` is the source of truth for local presence.
-- Addition over removal: removals are suppressed if the daemon provides no inventory; only add/remove based on explicit differences.
-- Idempotency: repeated adds resolve to the same replica logically.
+- Addition over removal: removals are suppressed if the daemon provides no inventory; only add/remove based on explicit differences, and state versions bump only when changes are applied.
+- Idempotency: repeated adds resolve to the same replica logically; full-state sync is informational and does not mutate versions.
 
 ## Configuration
 
 ### Global Store (Unified Config)
 
-请在 Global Store 配置文件中设置 `server.listen.port`、`server.max_workers`、`database.db_file`、`worker_policy.{heartbeat_timeout,cleanup_interval,default_heartbeat_interval}` 等字段。
+Use `tensorcast.config.v1.GlobalStoreConfig` (YAML/JSON → proto with strict validation):
+
+```yaml
+database:
+  db_file: /var/lib/tensorcast/global_store.duckdb   # persistent for HA
+server:
+  listen:
+    host: 0.0.0.0
+    port: 50051
+  max_workers: 20
+worker_policy:
+  heartbeat_timeout: 30s
+  cleanup_interval: 60s
+  default_heartbeat_interval: 5s
+  memory_tiers:
+    snapshot_retention: 10m
+    snapshot_max_rows: 200
+    publish_interval: 5s
+meta:
+  cluster_token: <optional-cluster-id>               # propagated via HealthCheck
+```
 
 ### Store Daemon
 
 ```yaml
 high_availability:
   enabled: true
-  connection_retry:
-    max_attempts: -1
-    base_delay_ms: 1000
-    max_delay_ms: 60000
-    backoff_multiplier: 2.0
-  state_sync:
-    heartbeat_enhanced: true
-    state_checksum_enabled: true
-    periodic_sync_interval_ms: 600000
+  global_store_endpoints:
+    - host: 10.0.0.5          # first entry is used
+      port: 50051
+  heartbeat_interval: 5s      # defaults to 5s if omitted
+  periodic_sync_interval: 10s # drives chunk_sync_loop; 0 disables
+  force_full_sync_on_empty_inventory: false # set true to drain/retire nodes
+server:
+  listen:
+    host: 0.0.0.0
+    port: 50052
+  advertise:
+    host: 10.0.0.20           # must be routable (non-loopback)
+  p2p_listen:
+    host: 0.0.0.0
+    port: 65090               # required for HA registration
 ```
+
+Set `meta.cluster_token` in the daemon config to guard against cross-cluster connections: the daemon’s HealthCheck will fail fast when the Global Store advertises a different token.
 
 ## Observability
 
-- Connection: `global_store_connection_status`, `connection_retry_attempts_total`, `connection_downtime_seconds`
-- Sync: `state_sync_operations_total`, `state_sync_duration_seconds`, `state_inconsistencies_detected_total`
-- Recovery: `recovery_operations_total`, `recovery_success_rate`, `recovery_duration_seconds`
+- Global Store Prometheus metrics (see `tensorcast/global_store/metrics.py`):
+  - `tc_state_sync_total{result=success|error}`, `tc_state_sync_seconds`
+  - `tc_active_workers`, `tc_replicas_total`, `tc_replicas_per_memtype`
+  - gRPC interceptors export `tc_grpc_server_handled_total` and latency histograms
+- Daemon: OTEL spans around all RPCs plus HA counters exported through OTEL (`tc_daemon_ha_heartbeat_success_total`, `tc_daemon_ha_heartbeat_failure_total`, `tc_daemon_ha_sync_success_total`, `tc_daemon_ha_sync_failure_total`).
+- Health check: `tensorcast.global_store.v1.GlobalStoreService/HealthCheck` returns `cluster_token`, listen_host/port, metrics_port, and version.
 
 ## Troubleshooting
 
-- Heartbeat OK but frequent sync requests: verify checksum computation on daemon; check for rapidly changing inventories.
+- Registration rejected: ensure `server.advertise.host` (or listen host) is routable and `server.p2p_listen.port` is non-zero.
+- Heartbeat OK but frequent sync requests: verify checksum computation on daemon; check for rapidly changing inventories or missing replicas in `local_replicas`.
 - Unexpected removals: ensure daemon includes full `local_replicas`; server suppresses removals if inventory is empty.
-- RPC failures: tune `GlobalStoreClientConfig` timeouts/backoff; check network and server logs.
+- RPC failures: inspect OTEL traces and Global Store metrics; adjust network and retry settings if the first endpoint is unreachable.
 
 ## References
 

--- a/docs/deployment/high-availability-usage.md
+++ b/docs/deployment/high-availability-usage.md
@@ -8,263 +8,184 @@ sidebar_position: 3
 
 ## Overview
 
-The artifact storage system now includes comprehensive high availability features that ensure system resilience and eventual consistency in the face of failures. This guide explains how to configure and use these features.
+TensorCast HA keeps the single Global Store resilient and consistent with Store Daemon state by combining startup recovery, enhanced heartbeats, incremental/full state sync, and drift pruning. Configuration is file-based (proto-backed) and orchestrated via the `tensorcast` CLI.
 
 ## Features
 
-### Global Store High Availability
-- **Database Recovery**: Automatic recovery from persistent DuckDB storage
-- **Worker Rediscovery**: Automatic rediscovery of workers after restart
-- **State Synchronization**: Reconciles worker states with global state
-- **Enhanced Heartbeat**: State version tracking and consistency checking
+### Global Store
+- **Startup recovery**: marks workers and replicas stale, cleans orphaned replicas, and resets per-worker state versions.
+- **State sync pipeline**: enhanced heartbeats advertise version + checksum + registered artifacts; incremental sync applies additions/removals with “addition over removal” semantics; full-state sync returns the expected set without bumping versions.
+- **Identity guardrails**: rejects loopback/unspecified registration addresses; `HealthCheck` surfaces `cluster_token`, listen endpoints, metrics port, and version.
 
-### Store Daemon High Availability
-- **Connection Manager**: Intelligent reconnection with exponential backoff
-- **State Queueing**: Queues operations during disconnection
-- **Automatic Re-registration**: Re-registers with Global Store after failures
-- **State Synchronization**: Syncs local state with global state
+### Store Daemon
+- **Routable registration**: requires a non-loopback advertise host and non-zero `server.p2p_listen.port` before enabling HA.
+- **Initial drift pruning**: on startup (and recovery re-registration) runs `RequestFullStateSync` then unloads local replicas not expected by the Global Store.
+- **Enhanced heartbeat loop**: sends version/checksum/inventory; if the server returns `NOT_FOUND` but the channel is healthy, the daemon re-registers with the previous worker id and resyncs.
+- **Incremental sync handling**: applies obsolete removals immediately and prefetches server-requested `ADD_REPLICA` updates; toggles remote access for `UPDATE_REPLICA`.
+- **Bounded retries**: all RPCs use jittered exponential backoff (`max_retries=3`, base 100ms).
 
 ## Configuration
 
-### Global Store Configuration
+### Global Store (proto: `tensorcast.config.v1.GlobalStoreConfig`)
 
 ```yaml
-# global_store_config.yaml
-high_availability:
-  enabled: true
-  state_sync_interval_ms: 300000      # 5 minutes
-  worker_timeout_ms: 30000            # 30 seconds
-  recovery:
-    auto_recovery_enabled: true
-    max_recovery_attempts: 3
-    recovery_timeout_ms: 120000       # 2 minutes
+database:
+  db_file: /var/lib/tensorcast/global_store.duckdb   # persistent for HA
+server:
+  listen:
+    host: 0.0.0.0
+    port: 50051
+  max_workers: 20
+worker_policy:
+  heartbeat_timeout: 30s
+  cleanup_interval: 60s
+  default_heartbeat_interval: 5s
+  memory_tiers:
+    snapshot_retention: 10m
+    snapshot_max_rows: 200
+    publish_interval: 5s
+meta:
+  cluster_token: <optional-cluster-id>               # echoed by HealthCheck
 ```
 
-### Store Daemon Configuration
+### Store Daemon (proto: `tensorcast.config.v1.DaemonConfig`)
 
 ```yaml
-# daemon.yaml
+server:
+  listen:
+    host: 0.0.0.0
+    port: 50052
+  advertise:
+    host: 10.0.0.20           # must be routable (non-loopback/unspecified)
+  p2p_listen:
+    host: 0.0.0.0
+    port: 65090               # required for HA registration
 high_availability:
   enabled: true
-  connection_retry:
-    max_attempts: -1                  # Infinite retries
-    base_delay_ms: 1000
-    max_delay_ms: 60000
-    backoff_multiplier: 2.0
-  state_sync:
-    heartbeat_enhanced: true
-    state_checksum_enabled: true
-    periodic_sync_interval_ms: 600000 # 10 minutes
+  global_store_endpoints:
+    - host: 10.0.0.5          # first entry is used today
+      port: 50051
+  heartbeat_interval: 5s      # default when omitted
+  periodic_sync_interval: 10s # chunk sync loop; 0 disables
 ```
 
-## Usage Examples
+> The CLI (`tensorcast daemon start`) will inject `high_availability.global_store_endpoints` when you pass `--global-store-address`, and will auto-fill ports when set to 0. Keep `server.advertise.host` routable to avoid registration failures.
 
-### Starting Global Store with HA
+## Usage
 
-```python
-from tensorcast.global_store.grpc_service import GlobalStoreServicer
-
-# Start with persistent database for recovery
-global_store = GlobalStoreServicer(db_file="/path/to/persistent.db")
-
-# Recovery is automatically initiated on startup
-```
-
-### Starting Store Daemon with HA
+### Start Global Store (single instance)
 
 ```bash
-uv run -q python -m tensorcast.cli daemon start --config=/etc/tensorcast/daemon.yaml --global-store-mode connect
+uv run tensorcast global start --config=/etc/tensorcast/global_store.yaml --wait
 ```
 
-### Worker Recovery Registration
+- Use a persistent DuckDB path (`database.db_file`) for recovery.
+- The CLI persists `cluster_token` under `~/.tensorcast/runtime/cluster_token` to detect split-brain and returns the metrics port in the startup log.
 
-When a Store Daemon restarts, it can recover its previous state:
+### Start Store Daemon with HA
 
-```python
-# The connection manager automatically handles recovery registration
-# with the previous worker ID if available
-
-# Manual recovery registration
-request = global_store_pb2.RegisterWorkerRequest(
-    node_id="worker-node-1",
-    node_address="10.0.0.100",
-    grpc_port=50052,
-    p2p_port=9090,
-    mem_pool_total_size=10 * 1024**3,  # 10GB
-    mem_pool_available_size=8 * 1024**3,  # 8GB
-    is_recovery_registration=True,
-    previous_worker_id="worker_node-1_1640995200"
-)
-
-response = global_store_stub.RegisterWorker(request)
-if response.state_sync_required:
-    # Perform state synchronization
-    pass
+```bash
+uv run tensorcast daemon start \
+  --config=/etc/tensorcast/daemon.yaml \
+  --global-store-mode connect \
+  --global-store-address 10.0.0.5:50051 \
+  --wait
 ```
 
-### Enhanced Heartbeat
+- The orchestrator writes an effective config that enables HA, injects the Global Store endpoint, and fills missing listen/p2p ports.
+- Startup will fail fast if `server.p2p_listen.port` is zero or if `advertise.host` is loopback/unspecified.
 
-Store Daemons send enhanced heartbeats with state information:
+### Manual RPC examples (generated stubs)
+
+Enhanced heartbeat:
 
 ```python
-request = global_store_pb2.WorkerHeartbeatRequest(
-    worker_id="worker_node-1_1640995200",
+import time
+from tensorcast.proto.global_store.v1 import global_store_pb2
+
+req = global_store_pb2.WorkerHeartbeatRequest(
+    worker_id="worker-node-1",
     mem_pool_available_size=7 * 1024**3,
     accepting_new_requests=True,
-    # Enhanced HA fields
     state_version=15,
-    state_checksum="md5_hash_of_local_state",
-    registered_artifact_ids=["artifact1", "artifact2", "artifact3"],
-    last_successful_sync=1640995200,
-    global_store_status=global_store_pb2.ConnectionStatus.CONNECTION_STATUS_CONNECTED
+    state_checksum="local_state_md5",
+    registered_artifact_ids=["artifact1", "artifact2"],
+    last_successful_sync=int(time.time()),
+    global_store_status=global_store_pb2.CONNECTION_STATUS_CONNECTED,
 )
-
-response = global_store_stub.WorkerHeartbeat(request)
-if response.state_sync_required:
-    # Global Store detected inconsistency, perform sync
-    perform_state_sync(response.expected_state_version)
+resp = stub.WorkerHeartbeat(req)
+if resp.state_sync_required:
+    # initiate sync
+    ...
 ```
 
-### State Synchronization
-
-Manual state synchronization when needed:
+State sync:
 
 ```python
-# Prepare local state
+import time
+from google.protobuf import timestamp_pb2
+from tensorcast.proto.global_store.v1 import global_store_pb2
+from tensorcast.proto.common.v1 import common_pb2
+
+ts = timestamp_pb2.Timestamp()
+ts.FromSeconds(int(time.time()))
 local_state = global_store_pb2.WorkerLocalState(
-    worker_id="worker_node-1_1640995200",
+    worker_id="worker-node-1",
     state_version=15,
     state_checksum="local_state_checksum",
-    local_replicas=[...],  # List of local artifact replicas
-    last_update_timestamp=int(time.time())
+    last_update_ts=ts,
 )
-
-# Request synchronization
-sync_request = global_store_pb2.SynchronizeWorkerStateRequest(
-    worker_id="worker_node-1_1640995200",
-    local_state=local_state,
-    force_full_sync=False
+replica = local_state.local_replicas.add()
+replica.ref.artifact_id = "artifact1"
+replica.memory_info.memory_type = common_pb2.MEMORY_TYPE_GPU
+replica.memory_info.device_id = 0
+replica.memory_info.memory_size = 1 * 1024**3
+resp = stub.SynchronizeWorkerState(
+    global_store_pb2.SynchronizeWorkerStateRequest(
+        worker_id="worker-node-1",
+        local_state=local_state,
+        force_full_sync=False,
+    )
 )
-
-response = global_store_stub.SynchronizeWorkerState(sync_request)
-# Apply state changes
-for change in response.state_changes:
-    if change.type == global_store_pb2.StateChange.ADD_REPLICA:
-        # Add replica locally
-        pass
-    elif change.type == global_store_pb2.StateChange.REMOVE_REPLICA:
-        # Remove replica locally
-        pass
 ```
 
 ## Failure Scenarios
 
-### Global Store Crash/Restart
-
-1. **Automatic Recovery**: Global Store automatically recovers from persistent database
-2. **Worker Rediscovery**: Workers are marked as stale until they reconnect
-3. **State Reconciliation**: When workers reconnect, states are synchronized
-
-### Store Daemon Crash/Restart
-
-1. **Clean Registration**: Store Daemon registers as new worker (clears previous state)
-2. **Artifact Rediscovery**: Local storage is scanned for available artifacts
-3. **State Rebuild**: Artifact replicas are re-registered with Global Store
-
-### Network Partition
-
-1. **Connection Monitoring**: Store Daemon detects Global Store unavailability
-2. **Local Operation**: Continues serving cached artifacts locally
-3. **State Queueing**: Artifact registrations are queued for later sync
-4. **Automatic Reconnection**: Exponential backoff retry until reconnection
-5. **State Synchronization**: Queued changes are synced after reconnection
+- **Global Store crash/restart**: recovery marks workers/replicas stale; daemons continue heartbeating, re-register on `NOT_FOUND`, run full-state sync, and prune drift. Persistent `db_file` keeps registry state.
+- **Daemon crash/restart**: a fresh process registers a new worker id, runs full-state sync, and unloads replicas not expected by the Global Store.
+- **Network partition**: RPC retries are bounded; once connectivity returns the next heartbeat triggers sync. No offline queue is kept—state is rebuilt from the current engine snapshot.
+- **Registration rejected**: ensure `advertise.host` is routable and `p2p_listen.port` is set.
 
 ## Monitoring
 
-### Key Metrics
-
-Monitor these Prometheus metrics for HA health:
-
-```
-# Connection status
-global_store_connection_status{worker_id="..."}
-connection_retry_attempts_total{worker_id="..."}
-connection_downtime_seconds{worker_id="..."}
-
-# State synchronization
-state_sync_operations_total{worker_id="...", result="..."}
-state_sync_duration_seconds{worker_id="..."}
-state_inconsistencies_detected_total{worker_id="..."}
-
-# Recovery operations
-recovery_operations_total{type="...", result="..."}
-recovery_success_rate{type="..."}
-recovery_duration_seconds{type="..."}
-```
-
-### Health Checks
-
-```bash
-# Check Global Store via gRPC
-grpcurl -plaintext global-store:50051 \
-  global_store.GlobalStoreService/ListActiveWorkers
-```
+- **Metrics**: Global Store exports Prometheus metrics (e.g., `tc_state_sync_total`, `tc_state_sync_seconds`, `tc_active_workers`, `tc_replicas_total`, `tc_grpc_server_handled_total`). Scrape `http://<host>:<metrics_port>/metrics`.
+- **Health**:
+  - gRPC: `grpcurl -plaintext <host>:50051 tensorcast.global_store.v1.GlobalStoreService/HealthCheck`
+  - Inventory: `grpcurl -plaintext <host>:50051 tensorcast.global_store.v1.GlobalStoreService/ListActiveWorkers`
+- **Daemon visibility**: OTEL spans wrap all Global Store RPCs; counters (hb_success/failure, sync_success/failure) are exported via the configured OTEL sink when enabled.
 
 ## Best Practices
 
-### Deployment
-
-1. **Persistent Storage**: Always use persistent database files for Global Store
-2. **Health Monitoring**: Monitor connection and sync metrics
-3. **Gradual Rollout**: Update Global Store first, then Store Daemons
-4. **Testing**: Test failure scenarios in staging environment
-
-### Configuration
-
-1. **Timeout Values**: Adjust timeouts based on network latency
-2. **Retry Limits**: Use infinite retries for mission-critical deployments
-3. **Sync Intervals**: Balance consistency vs performance needs
-4. **Resource Allocation**: Ensure adequate memory for state queuing
-
-### Troubleshooting
-
-1. **Check Logs**: Both components log HA operations extensively
-2. **Verify Configuration**: Ensure HA is enabled in both components
-3. **Network Connectivity**: Verify gRPC connectivity between components
-4. **Database Access**: Ensure Global Store can read/write database file
-5. **Resource Limits**: Check memory and disk space for state operations
+- Use persistent storage for the Global Store database; back up `cluster_token` with it.
+- Set a routable `server.advertise.host` and non-zero `server.p2p_listen.port` before enabling HA.
+- Only enable `high_availability.force_full_sync_on_empty_inventory` when deliberately draining/retiring a node; otherwise keep the default conservative behavior.
+- Run with `--wait` to ensure both services reach healthy state before clients connect.
+- Keep configs proto-valid (strict parsing) and avoid relying on multiple endpoints—the first `global_store_endpoints` entry is used today.
 
 ## Migration from Legacy Setup
 
-### Phase 1: Enable HA in Global Store
-```bash
-# Update Global Store with persistent database
-global-store --db-file=/data/global-store.db
-```
-
-### Phase 2: Update Store Daemons
-```bash
-# Enable HA in Store Daemon configuration
-store-daemon --config=/etc/store-daemon-ha.yaml
-```
-
-### Phase 3: Verify Operation
-```bash
-# Check all workers are using enhanced heartbeat
-# Monitor connection status and state sync metrics
-# Test failure scenarios
-```
+1. Add a persistent `database.db_file` and optional `meta.cluster_token` to the Global Store config, then restart with `uv run tensorcast global start --config=... --wait`.
+2. Update daemon config to include `high_availability` and a routable `server.advertise.host`/`p2p_listen.port`, then restart with `uv run tensorcast daemon start --global-store-address <addr> --wait`.
+3. Verify via `HealthCheck`, metrics scrape, and a forced `RequestFullStateSync` (daemon restart) before rolling out broadly.
 
 ## Limitations
 
-1. **Single Global Store**: Current implementation supports single Global Store instance
-2. **Eventual Consistency**: System guarantees eventual, not immediate consistency
-3. **Memory Overhead**: State tracking and queueing requires additional memory
-4. **Network Dependency**: HA features require reliable network connectivity
+- Single Global Store instance; no automatic failover or multi-endpoint rotation (first endpoint only).
+- RPC retries are bounded; there is no durable queue of state changes while disconnected.
+- Eventual consistency: reconciles on heartbeat/sync, not instantly.
 
 ## Future Enhancements
 
-- Multi-master Global Store with consensus
-- Cross-region replication
-- Automated failover with standby instances
-- Advanced conflict resolution for concurrent updates
+- Endpoint rotation/failover across multiple Global Store addresses.
+- Multi-master Global Store with consensus and cross-region replication.
+- Automated standby promotion and richer conflict resolution for concurrent updates.

--- a/proto/tensorcast/config/v1/daemon_config.proto
+++ b/proto/tensorcast/config/v1/daemon_config.proto
@@ -61,6 +61,9 @@ message HighAvailability {
   google.protobuf.Duration periodic_sync_interval = 4;
   int32 max_retries = 5;
   google.protobuf.Duration registration_retry_delay = 6;
+  // When true, an empty local inventory is treated as authoritative and will
+  // remove replicas during sync (intended for drain/retire workflows).
+  bool force_full_sync_on_empty_inventory = 11;
 }
 
 message Engine {

--- a/tensorcast/global_store/README.md
+++ b/tensorcast/global_store/README.md
@@ -188,6 +188,7 @@ Workers (Store Daemons) register with the Global Store and send periodic heartbe
 - Handles worker re-registration by transferring replicas to new worker ID
 - Computes state diffs between worker's local inventory and global state
 - Validates consistency via a stable FNV-1a checksum over sorted replica state (aligned with the daemon)
+- HA checksum format is `artifact_id:node_id:device_id:memory_type:available;` (FNV-1a 64-bit).
 
 **Safe-removal semantics:** When a worker reports an empty inventory, the Global Store does NOT blindly delete all its replicas. An empty list might mean "I haven't enumerated yet" rather than "I have nothing." Removals only apply when the worker explicitly provides a non-empty inventory that excludes replicas the Global Store expects.
 

--- a/tensorcast/global_store/README.md
+++ b/tensorcast/global_store/README.md
@@ -187,7 +187,7 @@ Workers (Store Daemons) register with the Global Store and send periodic heartbe
 - On Global Store startup, marks all workers/replicas as stale until they re-confirm
 - Handles worker re-registration by transferring replicas to new worker ID
 - Computes state diffs between worker's local inventory and global state
-- Validates consistency via MD5 checksum over sorted replica state
+- Validates consistency via a stable FNV-1a checksum over sorted replica state (aligned with the daemon)
 
 **Safe-removal semantics:** When a worker reports an empty inventory, the Global Store does NOT blindly delete all its replicas. An empty list might mean "I haven't enumerated yet" rather than "I have nothing." Removals only apply when the worker explicitly provides a non-empty inventory that excludes replicas the Global Store expects.
 

--- a/tensorcast/global_store/grpc_service.py
+++ b/tensorcast/global_store/grpc_service.py
@@ -1641,7 +1641,7 @@ class GlobalStoreServicer(global_store_pb2_grpc.GlobalStoreServiceServicer):
         try:
             success, state_changes, new_version, new_checksum = (
                 self.recovery_service.synchronize_worker_state(
-                    request.worker_id, request.local_state
+                    request.worker_id, request.local_state, request.force_full_sync
                 )
             )
 

--- a/tensorcast/global_store/repositories/replica_repository.py
+++ b/tensorcast/global_store/repositories/replica_repository.py
@@ -371,6 +371,7 @@ class ReplicaRepository(BaseRepository):
             UPDATE artifact_replicas
             SET
                 updated_at = CURRENT_TIMESTAMP,
+                node_id = ?,
                 is_available = ?,
                 max_concurrency = ?,
                 remote_memory_keys = ?,
@@ -382,6 +383,7 @@ class ReplicaRepository(BaseRepository):
             RETURNING replica_id
             """,
             [
+                replica.node_id,
                 replica.is_available,
                 replica.max_concurrency,
                 list(replica.remote_memory_keys),

--- a/tensorcast/global_store/services/recovery_service.py
+++ b/tensorcast/global_store/services/recovery_service.py
@@ -6,7 +6,6 @@ Recovery service for Global Store high availability.
 Handles state recovery after failures, worker rediscovery, and state synchronization.
 """
 
-import hashlib
 import time
 from uuid import UUID, uuid4
 
@@ -175,7 +174,10 @@ class RecoveryService:
                 self.replica_repository.mark_unavailable(replica.replica_id)
 
     def synchronize_worker_state(
-        self, worker_id: str, local_state: global_store_pb2.WorkerLocalState
+        self,
+        worker_id: str,
+        local_state: global_store_pb2.WorkerLocalState,
+        force_full_sync: bool = False,
     ) -> tuple[bool, list[global_store_pb2.StateChange], int, str]:
         """
         Synchronize worker state with global state.
@@ -183,6 +185,8 @@ class RecoveryService:
         Args:
             worker_id: Worker ID
             local_state: Worker's local state
+            force_full_sync: When True, treat the provided inventory as
+                authoritative even if empty (allows drains/retirements).
 
         Returns:
             Tuple of (success, state_changes, new_version, new_checksum)
@@ -193,7 +197,9 @@ class RecoveryService:
             global_replicas = self.replica_repository.get_replicas_by_worker(worker_id)
 
             # Compare states and generate changes
-            state_changes = self._compute_state_changes(local_state, global_replicas)
+            state_changes = self._compute_state_changes(
+                local_state, global_replicas, force_full_sync
+            )
 
             current_version = self.worker_state_versions.get(worker_id, 0)
 
@@ -245,6 +251,7 @@ class RecoveryService:
         self,
         local_state: global_store_pb2.WorkerLocalState,
         global_replicas: list[Replica],
+        force_full_sync: bool,
     ) -> list[global_store_pb2.StateChange]:
         """Compute differences between local and global state."""
         state_changes = []
@@ -282,17 +289,15 @@ class RecoveryService:
             state_changes.append(change)
 
         # Safe-removal semantics --------------------------------------------------
-        # Only consider *removals* when the worker explicitly provides a non-empty
-        # inventory.  An empty ``local_replicas`` list is treated as *unknown* –
-        # we assume the worker could not (or chose not to) send its inventory
-        # and therefore suppress destructive REMOVE_REPLICA operations.
-
+        # Default: empty inventory suppresses removals (treat as unknown).
+        # When force_full_sync is True, empty inventory is authoritative and will
+        # drive removals (used for drains / explicit full reconciliation).
         to_remove: set[tuple[str, str, int]]
         if local_state.local_replicas:
-            # Worker supplied an inventory – compute genuine removals.
             to_remove = global_replica_keys - local_replica_keys
+        elif force_full_sync:
+            to_remove = global_replica_keys
         else:
-            # No inventory → do **not** remove anything.
             to_remove = set()
 
         for artifact_id, memory_type, device_id in to_remove:
@@ -441,18 +446,44 @@ class RecoveryService:
 
     def _compute_state_checksum(self, replicas: list[Replica]) -> str:
         """Compute checksum of replica state for consistency checking."""
+        entries: list[tuple[str, str, int, bool, str]] = []
+        for replica in replicas:
+            mem_type = "DISK"
+            device_id = 0
+            if replica.memory_type.value == "GPU":
+                mem_type = "GPU"
+                device_id = replica.device_id
+            elif replica.memory_type.value == "RAM":
+                mem_type = "RAM"
+                device_id = 0
+            entries.append(
+                (
+                    replica.artifact_id,
+                    mem_type,
+                    device_id,
+                    replica.is_available,
+                    replica.node_id or "",
+                )
+            )
+
         # Sort replicas by a stable key for consistent checksum
-        sorted_replicas = sorted(
-            replicas, key=lambda r: (r.artifact_id, r.node_id, r.device_id)
-        )
+        entries.sort(key=lambda e: (e[0], e[1], e[2]))
 
         # Create string representation of state
-        state_str = ""
-        for replica in sorted_replicas:
-            state_str += f"{replica.artifact_id}:{replica.node_id}:{replica.device_id}:{replica.is_available};"
+        state_parts = [
+            f"{artifact_id}:{node_id}:{device_id}:{mem_type}:{1 if available else 0};"
+            for artifact_id, mem_type, device_id, available, node_id in entries
+        ]
+        state_str = "".join(state_parts)
 
-        # Compute MD5 hash
-        return hashlib.md5(state_str.encode()).hexdigest()
+        # Compute FNV-1a 64-bit hash for portability with C++ daemon
+        hash_val = 0xCBF29CE484222325
+        fnv_prime = 0x100000001B3
+        for b in state_str.encode():
+            hash_val ^= b
+            hash_val = (hash_val * fnv_prime) & 0xFFFFFFFFFFFFFFFF
+
+        return f"{hash_val:016x}"
 
     def get_worker_state_version(self, worker_id: str) -> int:
         """Get current state version for a worker."""

--- a/tensorcast/global_store/services/recovery_service.py
+++ b/tensorcast/global_store/services/recovery_service.py
@@ -22,6 +22,8 @@ from tensorcast.proto.global_store.v1 import global_store_pb2
 
 logger = init_logger(__name__)
 
+ReplicaKey = tuple[str, str, str, int]
+
 
 class RecoveryService:
     """Service for handling Global Store recovery and state synchronization."""
@@ -256,30 +258,36 @@ class RecoveryService:
         """Compute differences between local and global state."""
         state_changes = []
 
-        # Convert to sets for comparison
-        local_replica_keys = {
-            (r.ref.artifact_id, str(r.memory_info.memory_type), r.memory_info.device_id)
+        def _memory_type_label(mem_type: common_pb2.MemoryType) -> str:
+            if mem_type == common_pb2.MemoryType.MEMORY_TYPE_GPU:
+                return "GPU"
+            if mem_type == common_pb2.MemoryType.MEMORY_TYPE_RAM:
+                return "RAM"
+            return "DISK"
+
+        # Convert to maps for comparison and fast lookup
+        local_replicas_by_key: dict[ReplicaKey, common_pb2.ReplicaInfo] = {
+            (
+                r.ref.artifact_id,
+                r.memory_info.node_id,
+                _memory_type_label(r.memory_info.memory_type),
+                r.memory_info.device_id,
+            ): r
             for r in local_state.local_replicas
         }
 
-        global_replica_keys = {
-            (r.artifact_id, str(r.memory_type.value), r.device_id)
+        global_replicas_by_key: dict[ReplicaKey, Replica] = {
+            (r.artifact_id, r.node_id, r.memory_type.value, r.device_id): r
             for r in global_replicas
         }
 
+        local_replica_keys: set[ReplicaKey] = set(local_replicas_by_key.keys())
+        global_replica_keys: set[ReplicaKey] = set(global_replicas_by_key.keys())
+
         # Find replicas to add (in local but not in global)
         to_add = local_replica_keys - global_replica_keys
-        for artifact_id, memory_type, device_id in to_add:
-            # Find the local replica info
-            local_replica = next(
-                r
-                for r in local_state.local_replicas
-                if (
-                    r.ref.artifact_id == artifact_id
-                    and str(r.memory_info.memory_type) == memory_type
-                    and r.memory_info.device_id == device_id
-                )
-            )
+        for key in to_add:
+            local_replica = local_replicas_by_key[key]
 
             change = global_store_pb2.StateChange(
                 type=global_store_pb2.StateChange.CHANGE_TYPE_ADD_REPLICA,
@@ -292,7 +300,7 @@ class RecoveryService:
         # Default: empty inventory suppresses removals (treat as unknown).
         # When force_full_sync is True, empty inventory is authoritative and will
         # drive removals (used for drains / explicit full reconciliation).
-        to_remove: set[tuple[str, str, int]]
+        to_remove: set[ReplicaKey]
         if local_state.local_replicas:
             to_remove = global_replica_keys - local_replica_keys
         elif force_full_sync:
@@ -300,17 +308,8 @@ class RecoveryService:
         else:
             to_remove = set()
 
-        for artifact_id, memory_type, device_id in to_remove:
-            # Find the global replica
-            global_replica = next(
-                r
-                for r in global_replicas
-                if (
-                    r.artifact_id == artifact_id
-                    and str(r.memory_type.value) == memory_type
-                    and r.device_id == device_id
-                )
-            )
+        for key in to_remove:
+            global_replica = global_replicas_by_key[key]
 
             # Convert to proto format
             replica_info = self._convert_replica_to_proto(global_replica)
@@ -319,6 +318,31 @@ class RecoveryService:
                 type=global_store_pb2.StateChange.CHANGE_TYPE_REMOVE_REPLICA,
                 replica_info=replica_info,
                 reason="Global replica not found in local state",
+            )
+            state_changes.append(change)
+
+        # Identify replicas that exist in both sets but have drifted metadata.
+        shared_keys = local_replica_keys & global_replica_keys
+        for key in shared_keys:
+            local_replica = local_replicas_by_key[key]
+            global_replica = global_replicas_by_key[key]
+
+            desired_available = local_replica.stats.is_available
+            current_available = global_replica.is_available
+
+            availability_changed = desired_available != current_available
+
+            if not availability_changed:
+                continue
+
+            updated_proto = self._convert_replica_to_proto(global_replica)
+            if availability_changed:
+                updated_proto.stats.is_available = desired_available
+
+            change = global_store_pb2.StateChange(
+                type=global_store_pb2.StateChange.CHANGE_TYPE_UPDATE_REPLICA,
+                replica_info=updated_proto,
+                reason="Replica metadata changed (availability)",
             )
             state_changes.append(change)
 
@@ -358,7 +382,7 @@ class RecoveryService:
                     replica = self._convert_proto_to_replica(
                         change.replica_info, worker_id
                     )
-                    self.replica_repository.create_or_update(replica)
+                    self.replica_repository.update(replica)
                     logger.debug(f"Updated replica: {replica.artifact_id}")
 
             except Exception as e:
@@ -446,7 +470,7 @@ class RecoveryService:
 
     def _compute_state_checksum(self, replicas: list[Replica]) -> str:
         """Compute checksum of replica state for consistency checking."""
-        entries: list[tuple[str, str, int, bool, str]] = []
+        entries: list[tuple[str, str, int, str, bool]] = []
         for replica in replicas:
             mem_type = "DISK"
             device_id = 0
@@ -459,20 +483,20 @@ class RecoveryService:
             entries.append(
                 (
                     replica.artifact_id,
-                    mem_type,
-                    device_id,
-                    replica.is_available,
                     replica.node_id or "",
+                    device_id,
+                    mem_type,
+                    replica.is_available,
                 )
             )
 
         # Sort replicas by a stable key for consistent checksum
-        entries.sort(key=lambda e: (e[0], e[1], e[2]))
+        entries.sort(key=lambda e: (e[0], e[3], e[2]))
 
         # Create string representation of state
         state_parts = [
-            f"{artifact_id}:{node_id}:{device_id}:{mem_type}:{1 if available else 0};"
-            for artifact_id, mem_type, device_id, available, node_id in entries
+            f"{artifact_id}:{node_id}:{device_id}:{memory_type}:{1 if available else 0};"
+            for artifact_id, node_id, device_id, memory_type, available in entries
         ]
         state_str = "".join(state_parts)
 

--- a/tests/python/global_store/test_recovery_service_checksum.py
+++ b/tests/python/global_store/test_recovery_service_checksum.py
@@ -1,0 +1,106 @@
+#  Copyright (c) 2025, TensorCast Team.
+
+# Copyright (c) 2025, TensorCast Team.
+
+from tensorcast.global_store.models import MemoryType, Replica, Worker
+from tensorcast.global_store.services.recovery_service import RecoveryService
+from tensorcast.proto.global_store.v1 import global_store_pb2
+
+
+def test_checksum_is_stable_and_availability_sensitive(repositories):
+    service = RecoveryService(repositories["worker"], repositories["replica"])
+
+    replicas = [
+        Replica(
+            artifact_id="artifact-a",
+            node_id="node-1",
+            node_address="10.0.0.1",
+            node_port=50051,
+            memory_size=1024,
+            memory_type=MemoryType.GPU,
+            device_id=0,
+            worker_id="worker-1",
+            is_available=True,
+        ),
+        Replica(
+            artifact_id="artifact-b",
+            node_id="node-1",
+            node_address="10.0.0.1",
+            node_port=50051,
+            memory_size=2048,
+            memory_type=MemoryType.RAM,
+            device_id=0,
+            worker_id="worker-1",
+            is_available=True,
+        ),
+    ]
+
+    checksum1 = service._compute_state_checksum(replicas)
+    # Order should not matter once sorted
+    checksum2 = service._compute_state_checksum(list(reversed(replicas)))
+    assert checksum1 == checksum2
+
+    replicas[0].is_available = False
+    checksum3 = service._compute_state_checksum(replicas)
+    assert checksum3 != checksum1
+
+
+def test_force_full_sync_allows_empty_inventory_removal(repositories):
+    recovery = RecoveryService(repositories["worker"], repositories["replica"])
+    worker_id = "worker-force"
+    repositories["worker"].create_or_update(
+        Worker(
+            worker_id=worker_id,
+            node_id="node-force",
+            node_address="10.0.0.2",
+            grpc_port=50051,
+            p2p_port=65090,
+            mem_pool_total_size=1024,
+            mem_pool_available_size=1024,
+        )
+    )
+
+    replicas = [
+        Replica(
+            artifact_id="artifact-x",
+            node_id="node-force",
+            node_address="10.0.0.2",
+            node_port=50051,
+            memory_size=512,
+            memory_type=MemoryType.GPU,
+            device_id=0,
+            worker_id=worker_id,
+        ),
+        Replica(
+            artifact_id="artifact-y",
+            node_id="node-force",
+            node_address="10.0.0.2",
+            node_port=50051,
+            memory_size=256,
+            memory_type=MemoryType.RAM,
+            device_id=0,
+            worker_id=worker_id,
+        ),
+    ]
+    for replica in replicas:
+        repositories["replica"].create_or_update(replica)
+
+    local_state = global_store_pb2.WorkerLocalState(
+        worker_id=worker_id,
+        state_version=0,
+        state_checksum="",
+    )
+
+    success, changes, new_version, checksum = recovery.synchronize_worker_state(
+        worker_id, local_state, True
+    )
+
+    assert success is True
+    assert any(
+        change.type == global_store_pb2.StateChange.CHANGE_TYPE_REMOVE_REPLICA
+        for change in changes
+    )
+    assert sum(
+        1 for change in changes if change.type == global_store_pb2.StateChange.CHANGE_TYPE_REMOVE_REPLICA
+    ) == len(replicas)
+    assert new_version >= 1

--- a/tests/python/global_store/test_recovery_service_checksum.py
+++ b/tests/python/global_store/test_recovery_service_checksum.py
@@ -4,7 +4,41 @@
 
 from tensorcast.global_store.models import MemoryType, Replica, Worker
 from tensorcast.global_store.services.recovery_service import RecoveryService
+from tensorcast.proto.common.v1 import common_pb2
 from tensorcast.proto.global_store.v1 import global_store_pb2
+
+
+def _fnv1a_64(value: str) -> str:
+    hash_val = 0xCBF29CE484222325
+    fnv_prime = 0x100000001B3
+    for b in value.encode():
+        hash_val ^= b
+        hash_val = (hash_val * fnv_prime) & 0xFFFFFFFFFFFFFFFF
+    return f"{hash_val:016x}"
+
+
+def test_checksum_format_matches_daemon(repositories):
+    service = RecoveryService(repositories["worker"], repositories["replica"])
+
+    replicas = [
+        Replica(
+            artifact_id="artifact-format",
+            node_id="node-format",
+            node_address="10.0.0.1",
+            node_port=50051,
+            memory_size=256,
+            memory_type=MemoryType.RAM,
+            device_id=0,
+            worker_id="worker-format",
+            is_available=True,
+        )
+    ]
+
+    expected_state = "artifact-format:node-format:0:RAM:1;"
+    wrong_state = "artifact-format:RAM:0:1:node-format;"
+
+    assert service._compute_state_checksum(replicas) == _fnv1a_64(expected_state)
+    assert service._compute_state_checksum(replicas) != _fnv1a_64(wrong_state)
 
 
 def test_checksum_is_stable_and_availability_sensitive(repositories):
@@ -104,3 +138,79 @@ def test_force_full_sync_allows_empty_inventory_removal(repositories):
         1 for change in changes if change.type == global_store_pb2.StateChange.CHANGE_TYPE_REMOVE_REPLICA
     ) == len(replicas)
     assert new_version >= 1
+
+
+def test_availability_drift_triggers_update(repositories):
+    recovery = RecoveryService(repositories["worker"], repositories["replica"])
+    worker_id = "worker-availability"
+
+    repositories["worker"].create_or_update(
+        Worker(
+            worker_id=worker_id,
+            node_id="node-availability",
+            node_address="10.0.0.10",
+            grpc_port=50051,
+            p2p_port=65090,
+            mem_pool_total_size=4096,
+            mem_pool_available_size=4096,
+        )
+    )
+
+    replica = Replica(
+        artifact_id="artifact-availability",
+        node_id="node-availability",
+        node_address="10.0.0.10",
+        node_port=50051,
+        memory_size=512,
+        memory_type=MemoryType.GPU,
+        device_id=1,
+        worker_id=worker_id,
+        is_available=True,
+    )
+    repositories["replica"].create(replica)
+
+    local_state = global_store_pb2.WorkerLocalState(
+        worker_id=worker_id,
+        state_version=0,
+        state_checksum="",
+    )
+    local_replica = local_state.local_replicas.add()
+    local_replica.ref.artifact_id = replica.artifact_id
+    local_replica.memory_info.node_id = replica.node_id
+    local_replica.memory_info.memory_type = common_pb2.MEMORY_TYPE_GPU
+    local_replica.memory_info.device_id = replica.device_id
+    local_replica.stats.is_available = False
+
+    original_checksum = recovery._compute_state_checksum([replica])
+
+    success, changes, new_version, new_checksum = recovery.synchronize_worker_state(
+        worker_id, local_state, False
+    )
+
+    assert success is True
+    assert new_version == 1
+    assert any(
+        change.type == global_store_pb2.StateChange.CHANGE_TYPE_UPDATE_REPLICA
+        for change in changes
+    )
+
+    updated_replicas = repositories["replica"].get_replicas_by_worker(worker_id)
+    assert updated_replicas[0].is_available is False
+
+    expected_checksum = recovery._compute_state_checksum(
+        [
+            Replica(
+                artifact_id=replica.artifact_id,
+                node_id=replica.node_id,
+                node_address=replica.node_address,
+                node_port=replica.node_port,
+                memory_size=replica.memory_size,
+                memory_type=replica.memory_type,
+                device_id=replica.device_id,
+                worker_id=worker_id,
+                is_available=False,
+            )
+        ]
+    )
+    assert new_checksum == expected_checksum
+    assert new_checksum != original_checksum


### PR DESCRIPTION
…ate synchronization improvements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cluster token validation and a configurable force-full-sync path, switches HA state checksum to stable FNV-1a across daemon and Global Store, and updates wiring, metrics, docs, and tests.
> 
> - **High Availability (daemon)**:
>   - `GlobalStoreClient`: injects `x-tensorcast-cluster-token` on all RPCs; `initialize()` validates `cluster_token` via `HealthCheck` and fails on mismatch.
>   - `WorkerLifecycleManager`:
>     - New opts: `force_full_sync_on_empty_inventory`, `cluster_token`; checksum now FNV-1a over `(artifact_id,node_id,device_id,memory_type,availability)`; heartbeat includes availability and sets `node_id` in `MemoryInfo`.
>     - Sync: passes `force_full_sync` when inventory empty; applies obsolete removals, prefetches `ADD_REPLICA`, toggles availability on `UPDATE_REPLICA`; initial and recovery re-registration trigger full-state sync.
>     - Observability: adds OTEL counters `tc_daemon_ha_*` for heartbeat/sync success/failure.
>   - `server_main`: wires `high_availability.force_full_sync_on_empty_inventory` and `meta.cluster_token` into lifecycle; selects first GS endpoint.
> - **Global Store (server)**:
>   - `grpc_service.SynchronizeWorkerState`: forwards `force_full_sync` to recovery.
>   - `RecoveryService`: adds `force_full_sync` semantics (empty inventory can remove), keeps no-op sync version, and replaces MD5 with FNV-1a checksum aligned with daemon.
> - **Config/Proto**:
>   - `proto/tensorcast/config/v1/daemon_config.proto`: adds `high_availability.force_full_sync_on_empty_inventory`.
> - **Docs**:
>   - Updates HA design/usage to document cluster token, FNV-1a checksum parity, force-full-sync behavior, and metrics.
> - **Tests**:
>   - New tests for checksum stability/availability sensitivity and forced removal on empty inventory (C++ and Python).
> - **Build**:
>   - `MODULE.bazel`: bump `rules_cc` to `0.2.2`; add `rules_python@1.7.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d0dd6a76b30f64b2d7e622da8c6ac5c39bc3ee8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->