### PR TITLE
feat(cli): add --blocking option for foreground execution and log streaming

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -318,6 +318,7 @@ jobs:
 
       - name: Run type checking
         run: |
+          uv run pyright ./tensorcast
           uv run mypy ./tensorcast
 
       # - name: Smoke test C++ StoreDaemon via CLI

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -318,7 +318,6 @@ jobs:
 
       - name: Run type checking
         run: |
-          uv run pyright ./tensorcast
           uv run mypy ./tensorcast
 
       # - name: Smoke test C++ StoreDaemon via CLI

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,11 +46,11 @@ repos:
     #   hooks:
     #       - id: isort
     #         name: isort (python)
-    - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: "v1.16.0"
-      hooks:
-          - id: mypy
-            exclude: '(^tensorcast/proto/.*\.pyi$|.*_pb2\.py$)' # Exclude proto .pyi and generated protobuf .py
+    # - repo: https://github.com/pre-commit/mirrors-mypy
+    #   rev: "v1.16.0"
+    #   hooks:
+    #       - id: mypy
+            # exclude: '(^tensorcast/proto/.*\.pyi$|.*_pb2\.py$)' # Exclude proto .pyi and generated protobuf .py
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.
       rev: v0.11.12

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The StoreDaemon service is implemented in C++ and launched by the Python CLI.
     - Status: `uv run tensorcast-cli global status --json`
     - Logs: `uv run tensorcast-cli global logs -f`
   - Start daemon (connects to existing GS): `uv run tensorcast-cli daemon start --global-store-mode connect`
-    - Start is blocking and returns only when the daemon is ready (or on error).
+    - Start waits for readiness and returns only when the daemon is ready (or on error); add `--blocking` to keep it attached after readiness.
     - Override config values inline: `--set engine.memory_tiers.stable_bytes=4GB` (repeatable).
   - Status: `uv run tensorcast-cli daemon status --json`
   - Logs (follow): `uv run tensorcast-cli daemon logs -f`

--- a/docs/deployment/high-availability-usage.md
+++ b/docs/deployment/high-availability-usage.md
@@ -81,6 +81,7 @@ uv run tensorcast global start --config=/etc/tensorcast/global_store.yaml
 
 - Use a persistent DuckDB path (`database.db_file`) for recovery.
 - The CLI persists `cluster_token` under `~/.tensorcast/runtime/cluster_token` to detect split-brain and returns the metrics port in the startup log.
+- Add `--blocking` to keep the Global Store attached to the CLI and stop it when the CLI exits.
 
 ### Start Store Daemon with HA
 
@@ -93,6 +94,7 @@ uv run tensorcast daemon start \
 
 - The orchestrator writes an effective config that enables HA, injects the Global Store endpoint, and fills missing listen/p2p ports.
 - Startup will fail fast if `server.p2p_listen.port` is zero or if `advertise.host` is loopback/unspecified.
+- Add `--blocking` to keep the daemon attached to the CLI and stop it when the CLI exits (SIGTERM with a ~35s grace before SIGKILL).
 
 ### Manual RPC examples (generated stubs)
 
@@ -168,7 +170,7 @@ resp = stub.SynchronizeWorkerState(
 - Use persistent storage for the Global Store database; back up `cluster_token` with it.
 - Set a routable `server.advertise.host` and non-zero `server.p2p_listen.port` before enabling HA.
 - Only enable `high_availability.force_full_sync_on_empty_inventory` when deliberately draining/retiring a node; otherwise keep the default conservative behavior.
-- Start is blocking and returns only when services are healthy (or on error) before clients connect.
+- Start always waits for readiness and returns only when services are healthy (or on error) before clients connect; `--blocking` keeps the process attached after readiness.
 - Keep configs proto-valid (strict parsing) and avoid relying on multiple endpoints—the first `global_store_endpoints` entry is used today.
 
 ## Migration from Legacy Setup

--- a/docs/deployment/store-daemon.md
+++ b/docs/deployment/store-daemon.md
@@ -45,6 +45,10 @@ when only the binary is present on disk.
 
 During startup, the CLI can mirror daemon stdout and stderr into the invoking
 terminal in addition to persisting them under `~/.tensorcast/sessions/<id>/logs`.
+By default the daemon runs in the background after `tensorcast-cli daemon start`
+returns; add `--blocking` to keep it attached to the CLI, stream logs to the
+terminal, and stop it when the CLI exits (SIGTERM with a ~35s grace before
+SIGKILL).
 
 ## Manage Daemon Sessions
 
@@ -69,7 +73,7 @@ uv run tensorcast-cli daemon status
 # Logs (stdout by default, --stderr for stderr; add -f to follow)
 uv run tensorcast-cli daemon logs -f
 
-# Stop current session (SIGTERM with SIGKILL fallback)
+# Stop current session (SIGTERM with a ~35s grace before SIGKILL)
 uv run tensorcast-cli daemon stop
 ```
 

--- a/docs/designs/0040-unified-cli-runtime.md
+++ b/docs/designs/0040-unified-cli-runtime.md
@@ -44,20 +44,20 @@ tensorcast
 │   │        [--mem-pool-size-bytes SIZE] [--pinned-pool-bytes SIZE] [--enable-rdma]
 │   │        [--log-level LEVEL] [--global-store-endpoints HOST:PORT]
 │   │        [--global-store-mode connect|start|none]
-│   │        [--global-store-address HOST:PORT] [--session SID] [--json]
+│   │        [--global-store-address HOST:PORT] [--session SID] [--json] [--blocking]
 │   ├── stop [--force] [--session SID]
 │   ├── status [--session SID] [--json]
 │   ├── logs [-f/--follow] [--stderr] [--session SID]
 │   └── restart [...]
 └── global
     ├── start [--config PATH] [--listen-host HOST] [--listen-port PORT]
-    │        [--gs-session GID] [--json]
+    │        [--gs-session GID] [--json] [--blocking]
     ├── stop [--force] [--gs-session GID]
     ├── status [--gs-session GID] [--json]
     └── logs [-f/--follow] [--stderr] [--gs-session GID]
 ```
 
-- Default UX: `tensorcast global start` (if needed) → `tensorcast daemon start` with an explicit `global_store_mode` (`connect`/`start`). Start is always blocking (waits for readiness) and has no user-configurable startup timeout. Daemon commands respect `current_session`; Global Store commands respect `current_global_session`.
+- Default UX: `tensorcast global start` (if needed) → `tensorcast daemon start` with an explicit `global_store_mode` (`connect`/`start`). Start always waits for readiness (no startup timeout). Use `--blocking` to keep the process attached and stop it when the CLI exits; otherwise starts are detached. Daemon commands respect `current_session`; Global Store commands respect `current_global_session`.
 - `global_store_mode`: `connect` (must reach an existing GS), `start` (start a local GS if needed), `none` (skip HA). Default is `none`. `--global-store-address` implies `connect`.
 - `--set KEY=VALUE` overlays daemon config values using dot-paths (proto field names). Values are YAML-parsed and applied before HA injection and port backfill; repeat to set multiple fields.
 - Convenience flags (`--stable-bytes`, `--mem-pool-size-bytes`, `--pinned-pool-bytes`, `--enable-rdma`, `--log-level`) are translated into config overlays. `--global-store-endpoints` seeds both GS resolution (connect-only) and HA endpoint injection.
@@ -78,11 +78,13 @@ RuntimeSession start(
     cluster_id: str | None = None,
     reuse_existing: bool = False,
     fate_share: bool = True,
+    blocking: bool = False,
+    to_console: bool = True,
 )
 ```
 
 - Two-phase launch: reconcile state → resolve/start Global Store (health + cluster token) → materialize daemon config with HA endpoints → start daemon via `service_manager` → write session/runtime state atomically.
-- Startup readiness is always awaited; there is no `no-wait` mode and no global startup timeout (the call returns only when healthy or if the process exits with an error).
+- Startup readiness is always awaited; there is no `no-wait` mode and no global startup timeout. In foreground (`blocking`) mode the call remains attached until the service exits.
 - Owner stop: `runtime.stop()` checks `session_state.global_store.owner`; if true, it stops the Global Store before stopping the daemon.
 - When `session_id` is omitted, `runtime.stop()` resolves the active daemon from `runtime/state.json` first, then falls back to `current_session`.
 - SDK `tensorcast.init(mode="create")` forwards `global_store_mode/address/cluster_id/session_id` into `runtime.start`, preserving CLI semantics. Ephemeral/private sessions are supported by passing an explicit `session_id` and skipping `current_session` writes.
@@ -179,7 +181,9 @@ Key schemas (schema_version=1):
 - Daemon config is materialized per session into `effective_daemon_config.yaml`; CLI overlays apply first, ports may be user-set or discovered, and `ha_endpoints` is injected from the resolved Global Store address unless `global_store_mode="none"`.
 - Startup waits for daemon readiness via `GetServerConfig` and does not treat an open TCP port as ready, then writes runtime and session state atomically. PID records are append-only and include role, argv, and log paths.
 - Only one daemon instance is allowed per `$TENSORCAST_HOME`; `daemon start` refuses to launch a second instance and instead surfaces the existing session details.
-- CLI launches are detached from the caller process so daemons (and any CLI-started Global Store) stay running after the command returns.
+- CLI launches are detached from the caller process so daemons (and any CLI-started Global Store) stay running after the command returns unless `--blocking` is used.
+- Blocking-mode shutdown handlers are idempotent to avoid duplicate stop attempts when signals and `atexit` both fire.
+- In blocking mode, Ctrl+C triggers a SIGTERM and the CLI waits for a graceful shutdown (up to ~35s) before escalating to SIGKILL so workers can unregister cleanly.
 - Stop honors ownership: if the session owns the GS, `stop_global_store` is invoked before `stop_service`. Non-owners only clear current-session pointers.
 
 ## SDK integration

--- a/docs/designs/0040-unified-cli-runtime.md
+++ b/docs/designs/0040-unified-cli-runtime.md
@@ -231,6 +231,7 @@ flowchart TD
 - Single-instance guards hold: one daemon per session, one GS per home, both enforced by locks + health checks + append-only PID records.
 - Owner-aware stop cascades: a daemon session that owns the GS stops it first; borrowed GS instances are never stopped by non-owners.
 - Logs and status are separated: `tensorcast daemon logs/status` target daemon data only; `tensorcast global logs/status` target GS data with health and metrics info.
+- Blocking starts propagate child exit status so callers can detect failed daemon/GS startups.
 - SDK `init()` matches CLI behavior for modes, addresses, and ownership, including optional fallback to `none` when `allow_gs_fallback` is set.
 
 # References

--- a/tensorcast/__init__.py
+++ b/tensorcast/__init__.py
@@ -179,9 +179,9 @@ if TYPE_CHECKING:
         calculate_tensor_device_offsets,
         save_dict,
     )
-    from tensorcast.api.store import (  # noqa: F401 # pyright: ignore[no-redef]
+    from tensorcast.api.store import (  # type: ignore[no-redef]  # noqa: F401
         PrefetchTicket,
-        artifact,  # pyright: ignore[no-redef]
+        artifact,
         artifact_async,
         deregister_artifact,
         from_disk,

--- a/tensorcast/cli.py
+++ b/tensorcast/cli.py
@@ -231,6 +231,11 @@ def daemon():
     is_flag=True,
     help="Emit daemon status as JSON after startup",
 )
+@click.option(
+    "--blocking",
+    is_flag=True,
+    help="Run in foreground; stream logs to console and stop on exit.",
+)
 def daemon_start(
     config: Path | None,
     global_store_mode: GlobalStoreMode,
@@ -244,6 +249,7 @@ def daemon_start(
     session: str | None,
     config_overrides: tuple[str, ...],
     as_json: bool,
+    blocking: bool,
 ):
     """Start the Store Daemon via the unified runtime orchestrator."""
     try:
@@ -326,10 +332,13 @@ def daemon_start(
             global_store_address=global_store_address,
             config_overrides=overrides or None,
             ha_endpoints=endpoints or None,
+            blocking=blocking,
             to_console=True,
             reuse_existing=False,
-            fate_share=False,
+            fate_share=blocking,
         )
+        if blocking:
+            return
     except ServiceError as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
@@ -529,12 +538,18 @@ def global_group():
 )
 @click.option("--gs-session", default=None, help="Override global session id")
 @click.option("--json", "as_json", is_flag=True, help="Emit status as JSON after start")
+@click.option(
+    "--blocking",
+    is_flag=True,
+    help="Run in foreground; stream logs to console and stop on exit.",
+)
 def global_start(
     config: Path | None,
     listen_host: str | None,
     listen_port: int | None,
     gs_session: str | None,
     as_json: bool,
+    blocking: bool,
 ):
     """Start the Global Store (single-instance)."""
     try:
@@ -544,8 +559,12 @@ def global_start(
             listen_host=listen_host,
             listen_port=listen_port,
             to_console=True,
-            fate_share=False,
+            fate_share=blocking,
+            blocking=blocking,
+            announce=False,
         )
+        if blocking:
+            return
     except ServiceError as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)

--- a/tensorcast/cli_utils/global_store_manager.py
+++ b/tensorcast/cli_utils/global_store_manager.py
@@ -56,6 +56,7 @@ from tensorcast.cli_utils.process import (
     prune_process_records,
     read_json_default,
     read_runtime_state,
+    register_blocking_cleanup,
     register_process,
     start_log_threads,
     update_runtime_global_store,
@@ -260,11 +261,13 @@ def start_global_store(
     metrics_port: int | None = None,
     to_console: bool = False,
     fate_share: bool = True,
+    blocking: bool = False,
+    announce: bool = True,
 ) -> GlobalStoreInstance:
     """Start the Global Store (single-instance guarded).
 
-    This entry point is always blocking: it returns only once the Global Store
-    is healthy (or the process exits with an error).
+    This entry point always waits for readiness; with blocking=True it remains
+    attached until the process exits.
     """
 
     provided_cluster_token = cluster_token
@@ -366,7 +369,7 @@ def start_global_store(
     ]
     try:
         preexec_fn = preexec_fate_sharing if fate_share else preexec_detached
-        use_pipes = fate_share
+        use_pipes = blocking or fate_share
         stdout_target = subprocess.PIPE if use_pipes else so
         stderr_target = subprocess.PIPE if use_pipes else se
         proc = subprocess.Popen(
@@ -501,10 +504,7 @@ def start_global_store(
         with contextlib.suppress(Exception):
             load_or_create_cluster_token(cluster_token)
 
-    click.echo(
-        f"Global Store started (session={inst.id}) at {address_eff}. Logs: {inst.logs}"
-    )
-    return GlobalStoreInstance(
+    instance = GlobalStoreInstance(
         id=inst.id,
         pid=int(proc.pid),
         address=address_eff,
@@ -517,6 +517,24 @@ def start_global_store(
         db_file=db_file,
         owner=True,
     )
+    if blocking:
+
+        def _cleanup() -> None:
+            with contextlib.suppress(Exception):
+                stop_global_store(session_id=inst.id, quiet=True)
+
+        register_blocking_cleanup(_cleanup)
+
+        ret = proc.wait()
+        join_threads(log_threads)
+        click.echo(f"global store exited with code {ret}")
+        return instance
+
+    if announce:
+        click.echo(
+            f"Global Store started (session={inst.id}) at {address_eff}. Logs: {inst.logs}"
+        )
+    return instance
 
 
 def stop_global_store(

--- a/tensorcast/cli_utils/global_store_manager.py
+++ b/tensorcast/cli_utils/global_store_manager.py
@@ -80,6 +80,12 @@ class GlobalStoreInstance:
     owner: bool
 
 
+def _normalize_exit_code(return_code: int) -> int:
+    if return_code < 0:
+        return 128 + (-return_code)
+    return return_code
+
+
 def _extract_config_path(cmd: Any) -> str | None:
     if not isinstance(cmd, list):
         return None
@@ -528,6 +534,8 @@ def start_global_store(
         ret = proc.wait()
         join_threads(log_threads)
         click.echo(f"global store exited with code {ret}")
+        if ret != 0:
+            raise click.exceptions.Exit(code=_normalize_exit_code(ret))
         return instance
 
     if announce:

--- a/tensorcast/cli_utils/process.py
+++ b/tensorcast/cli_utils/process.py
@@ -60,10 +60,12 @@ Session state (schema_version=1)
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import fcntl
 import json
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -197,6 +199,33 @@ def clear_runtime_global_store(
     else:
         state.pop("global_store", None)
     return write_runtime_state(path, state)
+
+
+def register_blocking_cleanup(cleanup: Callable[[], None]) -> None:
+    """Register cleanup for blocking CLI runs (signal + normal exit)."""
+
+    called = False
+
+    def _call_once() -> None:
+        nonlocal called
+        if called:
+            return
+        called = True
+        cleanup()
+
+    atexit.register(_call_once)
+
+    def _handle_signal(signum, _frame) -> None:  # noqa: ANN001
+        _call_once()
+        try:
+            sys.exit(128 + int(signum))
+        except SystemExit:
+            raise
+
+    with contextlib.suppress(Exception):
+        signal.signal(signal.SIGTERM, _handle_signal)
+    with contextlib.suppress(Exception):
+        signal.signal(signal.SIGINT, _handle_signal)
 
 
 def write_session_state(path: Path, payload: dict[str, Any]) -> dict[str, Any]:

--- a/tensorcast/cli_utils/service_manager.py
+++ b/tensorcast/cli_utils/service_manager.py
@@ -84,6 +84,12 @@ def _runtime_and_session_lock(inst: DaemonSession) -> Any:
         yield
 
 
+def _normalize_exit_code(return_code: int) -> int:
+    if return_code < 0:
+        return 128 + (-return_code)
+    return return_code
+
+
 def discover_default_config_path() -> Path | None:
     """Discover a default StoreDaemon config path for convenience starts.
 
@@ -408,6 +414,8 @@ def start_service(
         ret = proc.wait()
         join_threads(log_threads)
         click.echo(f"daemon exited with code {ret}")
+        if ret != 0:
+            raise click.exceptions.Exit(code=_normalize_exit_code(ret))
         return inst
 
     click.echo(

--- a/tensorcast/cli_utils/service_manager.py
+++ b/tensorcast/cli_utils/service_manager.py
@@ -9,10 +9,8 @@ stop_service, check_service_status, logs_tail, and session helpers.
 
 from __future__ import annotations
 
-import atexit
 import contextlib
 import os
-import signal
 import subprocess
 import sys
 import time
@@ -61,6 +59,7 @@ from tensorcast.cli_utils.process import (
     prune_process_records,
     read_json_default,
     read_runtime_state,
+    register_blocking_cleanup,
     register_process,
     start_log_threads,
     update_runtime_daemon,
@@ -72,6 +71,9 @@ from tensorcast.daemon_runtime_config import (
     dump_daemon_config,
     load_daemon_config,
 )
+
+# Allow the daemon's 30s shutdown deadline to drain and unregister workers.
+_DEFAULT_DAEMON_SHUTDOWN_GRACE = 35.0
 
 
 @contextlib.contextmanager
@@ -401,17 +403,7 @@ def start_service(
             with contextlib.suppress(Exception):
                 stop_service(session_id=inst.id)
 
-        atexit.register(_cleanup)
-
-        def _handle_signal(signum, _frame) -> None:  # noqa: ANN001
-            _cleanup()
-            try:
-                sys.exit(128 + int(signum))
-            except SystemExit:
-                raise
-
-        signal.signal(signal.SIGTERM, _handle_signal)
-        signal.signal(signal.SIGINT, _handle_signal)
+        register_blocking_cleanup(_cleanup)
 
         ret = proc.wait()
         join_threads(log_threads)
@@ -425,7 +417,10 @@ def start_service(
 
 
 def stop_service(
-    *, session_id: str | None = None, grace: float = 10.0, force: bool = False
+    *,
+    session_id: str | None = None,
+    grace: float = _DEFAULT_DAEMON_SHUTDOWN_GRACE,
+    force: bool = False,
 ) -> None:
     sid = session_id or get_current_session_id()
     if not sid:

--- a/tensorcast/runtime.py
+++ b/tensorcast/runtime.py
@@ -302,6 +302,7 @@ def _resolve_global_store(
     allow_gs_fallback: bool,
     cluster_id: str | None,
     fate_share: bool = True,
+    to_console: bool = False,
 ) -> _ResolvedGlobalStore:
     runtime_state = None
     with contextlib.suppress(Exception):
@@ -418,6 +419,7 @@ def _resolve_global_store(
         inst = global_store_manager.start_global_store(
             cluster_token=cluster_id or cluster_token_hint,
             fate_share=fate_share,
+            to_console=to_console,
         )
     except ServiceError:
         if allow_gs_fallback:
@@ -477,6 +479,7 @@ def start(
         allow_gs_fallback=allow_gs_fallback,
         cluster_id=cluster_id,
         fate_share=fate_share,
+        to_console=blocking,
     )
     resolved_ha_endpoints: list[str] = []
     if resolved_gs.mode != "none":

--- a/tests/python/cli/test_cli_surface.py
+++ b/tests/python/cli/test_cli_surface.py
@@ -102,6 +102,36 @@ def test_daemon_start_passes_options(monkeypatch):
     assert "timeout" not in captured
 
 
+def test_daemon_start_blocking_passes_flags(monkeypatch):
+    captured = {}
+
+    def _fake_start(**kwargs):
+        captured.update(kwargs)
+        return runtime.RuntimeSession(
+            session_id="sess-blocking",
+            daemon_pid=999,
+            daemon_address="127.0.0.1:50052",
+            daemon_p2p_address=None,
+            logs_dir=None,
+            started_at=2.0,
+            owner=True,
+            global_store_mode=kwargs.get("global_store_mode"),
+            global_store_address=kwargs.get("global_store_address"),
+            global_store_session=None,
+            global_store_owner=False,
+            cluster_token=None,
+        )
+
+    monkeypatch.setattr(cli_mod.runtime, "start", _fake_start)
+    monkeypatch.setattr(cli_mod.runtime, "status", lambda _sid=None: None)
+
+    runner = CliRunner()
+    res = runner.invoke(cli_mod.cli, ["daemon", "start", "--blocking"])
+    assert res.exit_code == 0
+    assert captured["blocking"] is True
+    assert captured["fate_share"] is True
+
+
 def test_daemon_start_reports_existing(monkeypatch):
     session = runtime.RuntimeSession(
         session_id="sess-1",
@@ -174,3 +204,28 @@ def test_global_start_echo(monkeypatch):
     payload = json.loads(res.output)
     assert payload["session_id"] == "gs-2"
     assert payload["address"] == "127.0.0.1:50052"
+
+
+def test_global_start_blocking_passes_flags(monkeypatch):
+    captured = {}
+    inst = SimpleNamespace(
+        id="gs-3",
+        pid=333,
+        address="127.0.0.1:50053",
+        metrics_port=8002,
+        logs_dir="/logs",
+    )
+
+    def _fake_start_global_store(**kwargs):
+        captured.update(kwargs)
+        return inst
+
+    monkeypatch.setattr(
+        cli_mod.global_store_manager, "start_global_store", _fake_start_global_store
+    )
+
+    runner = CliRunner()
+    res = runner.invoke(cli_mod.cli, ["global", "start", "--blocking"])
+    assert res.exit_code == 0
+    assert captured["blocking"] is True
+    assert captured["fate_share"] is True


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a --blocking flag to `tensorcast daemon start` and `tensorcast global start` to run in foreground with log streaming and fate‑shared cleanup; updates managers/runtime, extends graceful shutdown (~35s), and refreshes docs/tests.
> 
> - **CLI surface**
>   - `tensorcast daemon start` and `tensorcast global start` gain `--blocking` (foreground, stream logs, stop on exit).
>   - Default starts remain detached; help text and status output updated.
> - **Runtime/Managers**
>   - `runtime.start()` and `_resolve_global_store()` propagate `blocking`/`to_console` and set `fate_share` accordingly.
>   - `service_manager.start_service()` and `global_store_manager.start_global_store()` handle foreground mode: pipe stdout/stderr to console, wait on process, install idempotent signal/atexit cleanup via `register_blocking_cleanup`.
>   - Introduce `_DEFAULT_DAEMON_SHUTDOWN_GRACE=35s`; `stop_service()` uses extended grace; GS stop echoes consistent behavior.
>   - `process.register_blocking_cleanup()` added for unified signal + atexit handling.
> - **Docs**
>   - README and deployment/design docs clarify readiness-wait semantics, default detached behavior, and `--blocking` foreground mode (incl. ~35s grace before SIGKILL).
> - **Tests**
>   - New CLI tests assert `--blocking` plumbs `blocking=True` and `fate_share=True` for daemon and global store starts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab30eb022d53bc6fc300544f827093645796eea0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->