### PR TITLE
feat(daemon): add MaterializeIntoTarget RPC for region-backed tensor_dict_into

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,8 +14,8 @@ llvm.toolchain(
     urls = {
         "linux-x86_64": [
             "file://./downloads/LLVM-21.1.0-Linux-X64.tar.xz",
-            # "https://githubfast.com/llvm/llvm-project/releases/download/llvmorg-21.1.0/LLVM-21.1.0-Linux-X64.tar.xz",
-            # "https://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.0/LLVM-21.1.0-Linux-X64.tar.xz",
+            "https://githubfast.com/llvm/llvm-project/releases/download/llvmorg-21.1.0/LLVM-21.1.0-Linux-X64.tar.xz",
+            "https://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.0/LLVM-21.1.0-Linux-X64.tar.xz",
         ],
     },
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,6 +35,7 @@ bazel_dep(name = "rules_proto_grpc_cpp", version = "5.7.1")
 bazel_dep(name = "toolchains_protoc", version = "0.5.0")
 bazel_dep(name = "protobuf", version = "31.1")
 bazel_dep(name = "gsl", version = "4.0.0")
+bazel_dep(name = "glog", version = "0.7.1")
 bazel_dep(name = "boringssl", version = "0.20250818.0")
 bazel_dep(name = "opentelemetry-cpp", version = "1.22.0")
 bazel_dep(name = "grpc", version = "1.74.1")
@@ -42,6 +43,13 @@ bazel_dep(name = "rules_buf", version = "0.5.2")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "folly", version = "2025.01.13.00.bcr.3")
 bazel_dep(name = "double-conversion", version = "3.3.1")
+
+single_version_override(
+    module_name = "glog",
+    patch_strip = 1,
+    patches = ["//third_party/glog/patches:0001-export-macros.patch"],
+    version = "0.7.1",
+)
 
 protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
 protoc.toolchain(

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -18,6 +18,7 @@
 -Ibazel-bin/external/catch2+
 -Ibazel-bin/external/folly+
 -Ibazel-out/k8-fastbuild/bin/external/catch2+/_virtual_includes/catch2_generated
+-Ibazel-out/k8-fastbuild/bin/external/folly+
 -Ibazel-bin/external/glog+/_virtual_includes/glog
 -Iexternal/abseil-cpp+
 -Iexternal/nlohmann_json+/include

--- a/core/common/BUILD
+++ b/core/common/BUILD
@@ -256,6 +256,7 @@ sc_cc_library(
         "@folly//folly/executors:serial_executor",
         "@folly//folly/futures:core",
         "@folly//folly/io/async:request_context",
+        "@glog",
         "@opentelemetry-cpp//api:api",
     ],
 )

--- a/core/store/materialization/benchmarks/safetensors_load_strategy_benchmark_main.cc
+++ b/core/store/materialization/benchmarks/safetensors_load_strategy_benchmark_main.cc
@@ -33,6 +33,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "core/common/async_runtime.h"
 #include "core/common/cuda_api.h"
 #include "core/common/logging_init.h"
 #include "core/common/memory/cuda_memory.h"
@@ -71,6 +72,14 @@ namespace {
     }                                  \
     (lhs) = std::move(_or).value();    \
   } while (0)
+
+common::AsyncRuntime& pump_benchmark_runtime() {
+  static common::AsyncRuntime runtime(
+      common::AsyncRuntime::Options{
+          .thread_name_prefix = "tensorcast-pump-bench",
+      });
+  return runtime;
+}
 
 enum class BenchMode : uint8_t {
   kLoader = 0,
@@ -1599,7 +1608,8 @@ absl::StatusOr<RunResult> run_strategy_a_baseline(
   r.bytes.h2d_bytes = total_payload_bytes;
   r.res.gpu_alloc_bytes = total_payload_bytes;
 
-  TC_RETURN_IF_ERROR(loader::pump_ranges(src, sink, *pool_ptr, ranges, io_threads));
+  TC_RETURN_IF_ERROR(
+      loader::pump_ranges(src, sink, *pool_ptr, ranges, io_threads, pump_benchmark_runtime().blocking_executor()));
   TC_RETURN_IF_ERROR(sink.close());
   r.t.open_copy = seconds_since(t_copy);
   const auto sched_after = loader::get_gpu_scheduler_stats(cfg.device_id);
@@ -1700,7 +1710,8 @@ absl::StatusOr<std::pair<RunResult, StrategyAState>> run_strategy_a_baseline_wit
   r.bytes.h2d_bytes = s.total_payload_bytes;
   r.res.gpu_alloc_bytes = s.total_payload_bytes;
 
-  TC_RETURN_IF_ERROR(loader::pump_ranges(src, sink, *pool_ptr, ranges, io_threads));
+  TC_RETURN_IF_ERROR(
+      loader::pump_ranges(src, sink, *pool_ptr, ranges, io_threads, pump_benchmark_runtime().blocking_executor()));
   TC_RETURN_IF_ERROR(sink.close());
   r.t.open_copy = seconds_since(t_copy);
   const auto sched_after = loader::get_gpu_scheduler_stats(cfg.device_id);
@@ -1867,7 +1878,9 @@ absl::StatusOr<MultiRankStrategyACollectivesResult> run_strategy_a_collectives_s
       r.bytes.disk_read_bytes = ctx.owned_total_bytes;
       r.bytes.h2d_bytes = ctx.owned_total_bytes;
 
-      TC_RETURN_IF_ERROR(loader::pump_ranges(src, sink, *pool_ptr, ranges_out, io_threads));
+      TC_RETURN_IF_ERROR(
+          loader::pump_ranges(
+              src, sink, *pool_ptr, ranges_out, io_threads, pump_benchmark_runtime().blocking_executor()));
       TC_RETURN_IF_ERROR(sink.close());
     } else {
       r.planned_ranges = 0;
@@ -2227,7 +2240,8 @@ absl::StatusOr<std::pair<RunResult, StrategyBState>> run_strategy_b_with_state(
   r.bytes.h2d_bytes = total_requested_bytes;
   (void)total_payload_bytes;
 
-  TC_RETURN_IF_ERROR(loader::pump_ranges(src, sink, *pool_ptr, ranges, io_threads));
+  TC_RETURN_IF_ERROR(
+      loader::pump_ranges(src, sink, *pool_ptr, ranges, io_threads, pump_benchmark_runtime().blocking_executor()));
   TC_RETURN_IF_ERROR(sink.close());
   r.t.commit = seconds_since(t_commit);
   const auto sched_after = loader::get_gpu_scheduler_stats(cfg.device_id);
@@ -2392,7 +2406,8 @@ absl::Status run_safetensors_disk_baseline(const LoaderConfig& cfg, const std::v
   const auto sched_before = loader::get_gpu_scheduler_stats(cfg.device_id);
   const auto t0 = absl::Now();
   auto ranges = split_even_ranges(/*base=*/0, total_payload_bytes, io_threads);
-  TC_RETURN_IF_ERROR(loader::pump_ranges(src, sink, *pool_ptr, ranges, io_threads));
+  TC_RETURN_IF_ERROR(
+      loader::pump_ranges(src, sink, *pool_ptr, ranges, io_threads, pump_benchmark_runtime().blocking_executor()));
   TC_RETURN_IF_ERROR(sink.close());
   const auto sched_after = loader::get_gpu_scheduler_stats(cfg.device_id);
   const auto sched_waits = ((sched_after.waits >= sched_before.waits) ? (sched_after.waits - sched_before.waits) : 0);
@@ -2693,7 +2708,8 @@ absl::Status run_disk_baseline(const LoaderConfig& cfg) {
           .end_offset = cfg.disk_bench_bytes,
       }});
   auto ranges = split_even_ranges(/*base=*/0, cfg.disk_bench_bytes, io_threads);
-  TC_RETURN_IF_ERROR(loader::pump_ranges(remapped, sink, *pool_ptr, ranges, io_threads));
+  TC_RETURN_IF_ERROR(
+      loader::pump_ranges(remapped, sink, *pool_ptr, ranges, io_threads, pump_benchmark_runtime().blocking_executor()));
   TC_RETURN_IF_ERROR(sink.close());
   const auto sched_after = loader::get_gpu_scheduler_stats(cfg.device_id);
   const uint64_t sched_waits =
@@ -2794,7 +2810,8 @@ absl::Status run_disk_fragmentation(const LoaderConfig& cfg) {
 
   const auto t0 = absl::Now();
   const auto sched_before = loader::get_gpu_scheduler_stats(cfg.device_id);
-  TC_RETURN_IF_ERROR(loader::pump_ranges(remapped, sink, *pool_ptr, ranges, io_threads));
+  TC_RETURN_IF_ERROR(
+      loader::pump_ranges(remapped, sink, *pool_ptr, ranges, io_threads, pump_benchmark_runtime().blocking_executor()));
   TC_RETURN_IF_ERROR(sink.close());
   const auto sched_after = loader::get_gpu_scheduler_stats(cfg.device_id);
   const uint64_t sched_waits =

--- a/core/store/materialization/contracts/BUILD
+++ b/core/store/materialization/contracts/BUILD
@@ -40,6 +40,7 @@ sc_header_only_library(
         "//core/store/replica:memory_state",
         "@abseil-cpp//absl/hash",
         "@folly//folly/futures:core",
+        "@glog",
     ],
 )
 

--- a/core/store/materialization/contracts/loading_spec.h
+++ b/core/store/materialization/contracts/loading_spec.h
@@ -34,6 +34,10 @@ enum class SourcePreference : uint8_t { kUnspecified, kAuto, kPreferP2P, kPrefer
 
 enum class MaterializationSource : uint8_t { kUnspecified, kDisk, kP2P, kLocalReplica };
 
+struct MaterializeIntoTargetResult {
+  MaterializationSource source{MaterializationSource::kUnspecified};
+};
+
 struct DiskSource {
   std::filesystem::path path;
   std::optional<uint64_t> expected_size;

--- a/core/store/runtime/ingestion/ingestion_runtime.cc
+++ b/core/store/runtime/ingestion/ingestion_runtime.cc
@@ -37,6 +37,17 @@ absl::StatusOr<loading::ReplicaHandle> IngestionRuntime::materialize_replica(
   return materialization_facade_->materialize_replica(target_device, mode, hints);
 }
 
+absl::StatusOr<loading::MaterializeIntoTargetResult> IngestionRuntime::materialize_into_target(
+    const DeviceKey& target_device,
+    gsl::not_null<void*> target_ptr,
+    uint64_t total_size,
+    std::string_view canonical_index_json,
+    uint64_t generation,
+    const loading::MaterializeHints& hints) {
+  return materialization_facade_->materialize_into_target(
+      target_device, target_ptr, total_size, canonical_index_json, generation, hints);
+}
+
 absl::StatusOr<loading::ReplicaHandle> IngestionRuntime::ingest_from_disk(
     const std::string& artifact_identifier,
     const loading::DiskSource& source,

--- a/core/store/runtime/ingestion/ingestion_runtime.h
+++ b/core/store/runtime/ingestion/ingestion_runtime.h
@@ -47,6 +47,14 @@ class IngestionRuntime {
       loading::MaterializeMode mode,
       const loading::MaterializeHints& hints);
 
+  absl::StatusOr<loading::MaterializeIntoTargetResult> materialize_into_target(
+      const DeviceKey& target_device,
+      gsl::not_null<void*> target_ptr,
+      uint64_t total_size,
+      std::string_view canonical_index_json,
+      uint64_t generation,
+      const loading::MaterializeHints& hints);
+
   absl::StatusOr<loading::ReplicaHandle> ingest_from_disk(
       const std::string& artifact_identifier,
       const loading::DiskSource& source,

--- a/core/store/runtime/ingestion/materialization_facade.cc
+++ b/core/store/runtime/ingestion/materialization_facade.cc
@@ -2,20 +2,101 @@
 
 #include "core/store/runtime/ingestion/materialization_facade.h"
 
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <filesystem>
+#include <functional>
 #include <utility>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "core/common/artifact_hash.h"
+#include "core/common/artifact_identity.h"
 #include "core/store/materialization/control/materialize_orchestrator.h"
+#include "core/store/materialization/dataplane/loaders/disk_loader.h"
+#include "core/store/materialization/dataplane/loaders/p2p_loader.h"
+#include "core/store/materialization/dataplane/runtime/pump.h"
+#include "core/store/materialization/dataplane/runtime/streaming_buffer_adapter.h"
+#include "core/store/materialization/dataplane/sinks/gpu_memory_sink.h"
 
 namespace tensorcast::store::runtime::ingestion {
 
 namespace pipeline = tensorcast::store::materialization::runtime::pipeline;
 using materialization::control::MaterializeOrchestrator;
+
+class PlanBackedSeekableSource final : public loader::SeekableSource {
+ public:
+  PlanBackedSeekableSource(
+      std::unique_ptr<loader::SeekableSource> source,
+      std::shared_ptr<const std::vector<loader::SegmentPiece>> plan,
+      uint64_t total_size)
+      : source_(std::move(source)), plan_(std::move(plan)), total_size_(total_size) {}
+
+  absl::StatusOr<size_t> read(void* dst, size_t max_bytes) override {
+    auto st = read_at(current_offset_, dst, max_bytes);
+    if (!st.ok()) {
+      return st;
+    }
+    current_offset_ += *st;
+    return st;
+  }
+
+  absl::StatusOr<size_t> read_at(uint64_t offset, void* dst, size_t bytes) override {
+    if (offset >= total_size_) {
+      return static_cast<size_t>(0);
+    }
+    size_t remaining = static_cast<size_t>(std::min<uint64_t>(bytes, total_size_ - offset));
+    auto* out = static_cast<uint8_t*>(dst);
+
+    size_t idx = 0;
+    for (; idx < plan_->size(); ++idx) {
+      const auto& p = (*plan_)[idx];
+      if (offset < p.dst_offset + p.length) {
+        break;
+      }
+    }
+    if (idx == plan_->size()) {
+      return static_cast<size_t>(0);
+    }
+
+    while (remaining > 0 && idx < plan_->size()) {
+      const auto& p = (*plan_)[idx];
+      const uint64_t local = offset - p.dst_offset;
+      const size_t avail = static_cast<size_t>(p.length - local);
+      const size_t take = std::min(remaining, avail);
+      if (p.kind == loader::SegmentPiece::PAD) {
+        std::memset(out, 0, take);
+      } else {
+        auto read_or = source_->read_at(p.src_offset + local, out, take);
+        if (!read_or.ok()) {
+          return read_or.status();
+        }
+        if (*read_or != take) {
+          return absl::DataLossError("Short read while materializing into target");
+        }
+      }
+      out += take;
+      offset += take;
+      remaining -= take;
+      if (take == avail) {
+        ++idx;
+      }
+    }
+    return static_cast<size_t>(out - static_cast<uint8_t*>(dst));
+  }
+
+ private:
+  std::unique_ptr<loader::SeekableSource> source_;
+  std::shared_ptr<const std::vector<loader::SegmentPiece>> plan_;
+  uint64_t total_size_{0};
+  uint64_t current_offset_{0};
+};
 
 MaterializationFacade::MaterializationFacade(Config config)
     : config_(std::move(config)),
@@ -91,6 +172,179 @@ absl::StatusOr<loading::ReplicaHandle> MaterializationFacade::materialize_replic
     return request_or.status();
   }
   return materialization_service_->execute(request_or.value());
+}
+
+absl::StatusOr<loading::MaterializeIntoTargetResult> MaterializationFacade::materialize_into_target(
+    const DeviceKey& target_device,
+    gsl::not_null<void*> target_ptr,
+    uint64_t total_size,
+    std::string_view canonical_index_json,
+    uint64_t generation,
+    const loading::MaterializeHints& hints) {
+  if (target_device.type != DeviceType::GPU) {
+    return absl::InvalidArgumentError("materialize_into_target requires GPU target device");
+  }
+  if (total_size == 0) {
+    return absl::InvalidArgumentError("materialize_into_target requires total_size > 0");
+  }
+  if (canonical_index_json.empty()) {
+    return absl::InvalidArgumentError("materialize_into_target requires canonical index bytes");
+  }
+  if (hints.artifact_id.empty()) {
+    return absl::InvalidArgumentError("materialize_into_target requires hints.artifact_id");
+  }
+
+  auto plan_key = [&]() -> std::string {
+    auto mh_or = common::compute_index_multihash(std::optional<std::string>(canonical_index_json), "");
+    if (mh_or.ok()) {
+      return absl::StrCat(generation, ":", *mh_or);
+    }
+    const size_t fallback_hash = std::hash<std::string_view>{}(canonical_index_json);
+    return absl::StrCat(generation, ":raw:", fallback_hash);
+  }();
+
+  std::shared_ptr<std::vector<loader::SegmentPiece>> plan_ptr;
+  {
+    absl::MutexLock lock(&segment_plan_mu_);
+    auto it = segment_plan_cache_.find(plan_key);
+    if (it != segment_plan_cache_.end()) {
+      plan_ptr = it->second;
+    }
+  }
+  if (!plan_ptr) {
+    auto plan_or = loader::build_segment_plan_from_canonical_index_json(canonical_index_json, total_size);
+    if (!plan_or.ok()) {
+      return plan_or.status();
+    }
+    plan_ptr = std::make_shared<std::vector<loader::SegmentPiece>>(std::move(*plan_or));
+    absl::MutexLock lock(&segment_plan_mu_);
+    segment_plan_cache_.emplace(plan_key, plan_ptr);
+  }
+
+  auto run_source =
+      [&](std::unique_ptr<IArtifactLoader> loader,
+          loading::MaterializationSource source_kind) -> absl::StatusOr<loading::MaterializeIntoTargetResult> {
+    auto init_status = loader->initialize();
+    if (!init_status.ok()) {
+      return init_status;
+    }
+    auto source_or = loader->open_source();
+    if (!source_or.ok()) {
+      return source_or.status();
+    }
+
+    auto plan_source = std::make_unique<PlanBackedSeekableSource>(std::move(*source_or), plan_ptr, total_size);
+
+    const size_t slice_bytes = config_.runtime_context->tx_slice_bytes();
+    if (slice_bytes == 0 || config_.artifact_chunk_bytes == 0) {
+      return absl::FailedPreconditionError("tx_slice_bytes or artifact_chunk_bytes is zero");
+    }
+    auto session_spb = std::make_shared<common::memory::StreamingPinnedBuffer>(
+        /*num_chunks=*/16, slice_bytes, config_.runtime_context->pinned_buffer_pool());
+    const std::chrono::milliseconds timeout =
+        hints.pinned_timeout.count() > 0 ? hints.pinned_timeout : config_.pinned_memory_timeout;
+    auto init_spb_status = session_spb->initialize(timeout);
+    if (!init_spb_status.ok()) {
+      return init_spb_status;
+    }
+    loader::StreamingBufferAdapter adapter(session_spb);
+
+    loader::GpuMemorySink::Options sink_opts{
+        .gpu_base_ptr = target_ptr,
+        .total_size = total_size,
+        .chunk_size = config_.artifact_chunk_bytes,
+        .device_id = target_device.ordinal,
+    };
+    loader::GpuMemorySink sink(std::move(sink_opts));
+
+    const int concurrency = hints.pipeline_concurrency > 0 ? static_cast<int>(hints.pipeline_concurrency)
+                                                           : std::max(1, config_.num_threads);
+    std::array<loader::Range, 1> ranges{loader::Range{0, static_cast<size_t>(total_size)}};
+    auto pump_status = loader::pump_ranges(
+        *plan_source,
+        sink,
+        adapter,
+        absl::MakeSpan(ranges),
+        concurrency,
+        config_.runtime_context->async_runtime()->blocking_executor());
+    if (!pump_status.ok()) {
+      return absl::DataLossError(absl::StrCat("materialize_into_target pump failed: ", pump_status.message()));
+    }
+    auto close_status = sink.close();
+    if (!close_status.ok()) {
+      return absl::DataLossError(absl::StrCat("materialize_into_target sink close failed: ", close_status.message()));
+    }
+    return loading::MaterializeIntoTargetResult{.source = source_kind};
+  };
+
+  auto gs_client = config_.runtime_context->global_store_client();
+  const bool gs_connected = gs_client && gs_client->is_connected();
+  const bool prefer_disk = hints.source_preference == loading::SourcePreference::kPreferDisk;
+  const bool prefer_p2p = hints.source_preference == loading::SourcePreference::kPreferP2P;
+  const bool has_disk_path = !hints.disk_path.empty();
+
+  if (prefer_disk && has_disk_path) {
+    loading::DiskSource disk_src;
+    disk_src.path = std::filesystem::path(hints.disk_path);
+    disk_src.require_descriptor = tensorcast::common::is_mi2_artifact_id(hints.artifact_id);
+    auto disk_or = run_source(std::make_unique<DiskLoader>(disk_src), loading::MaterializationSource::kDisk);
+    if (disk_or.ok()) {
+      return disk_or;
+    }
+    if (!gs_connected) {
+      return disk_or.status();
+    }
+  }
+
+  if (!gs_connected && !has_disk_path) {
+    return absl::FailedPreconditionError("GlobalStoreClient not connected");
+  }
+
+  if (gs_connected && !hints.artifact_id.empty()) {
+    auto transport_or = gs_client->request_replica_transport(
+        hints.artifact_id,
+        /*source_node_id=*/"",
+        /*source_address=*/"",
+        /*source_port=*/0,
+        target_device,
+        /*wait_timeout_ms=*/30000);
+    if (transport_or.ok()) {
+      const auto& session = *transport_or;
+      const auto& remote = session.remote_replica;
+      P2PSource p2p_src;
+      p2p_src.size_bytes = remote.memory_size;
+      p2p_src.ip = remote.node_address;
+      p2p_src.port = static_cast<uint16_t>(remote.node_port);
+      p2p_src.memory_keys = remote.remote_memory_keys;
+      p2p_src.buf_sizes = remote.buffer_sizes;
+      p2p_src.verification_json = remote.verification_json;
+      p2p_src.enable_checksum = false;
+      p2p_src.location.type = remote.memory_type;
+      p2p_src.location.device_id = remote.device_id;
+      auto p2p_or = run_source(std::make_unique<P2PLoader>(p2p_src), loading::MaterializationSource::kP2P);
+      auto complete_status = gs_client->complete_replica_transport(session.transport_id);
+      if (!complete_status.ok()) {
+        LOG(WARNING) << "complete_replica_transport returned error: " << complete_status;
+      }
+      if (p2p_or.ok()) {
+        return p2p_or;
+      }
+      if (!has_disk_path || prefer_p2p) {
+        return p2p_or.status();
+      }
+    } else if (!has_disk_path) {
+      return transport_or.status();
+    }
+  }
+
+  if (has_disk_path) {
+    loading::DiskSource disk_src;
+    disk_src.path = std::filesystem::path(hints.disk_path);
+    disk_src.require_descriptor = tensorcast::common::is_mi2_artifact_id(hints.artifact_id);
+    return run_source(std::make_unique<DiskLoader>(disk_src), loading::MaterializationSource::kDisk);
+  }
+
+  return absl::FailedPreconditionError("materialize_into_target requires disk_path or Global Store connectivity");
 }
 
 absl::StatusOr<loading::ReplicaHandle> MaterializationFacade::ingest_from_disk(

--- a/core/store/runtime/ingestion/materialization_facade.h
+++ b/core/store/runtime/ingestion/materialization_facade.h
@@ -18,6 +18,7 @@
 #include "absl/synchronization/mutex.h"
 #include "core/store/device_types.h"
 #include "core/store/materialization/control/materialization_backend.h"
+#include "core/store/materialization/dataplane/sources/segment_plan_source.h"
 #include "core/store/materialization/runtime/pipeline/ingestion_pipeline.h"
 #include "core/store/runtime/context/runtime_context.h"
 #include "core/store/runtime/ingestion/ingestion_event_hub.h"
@@ -88,6 +89,14 @@ class MaterializationFacade : public materialization::control::MaterializationBa
   absl::StatusOr<loading::ReplicaHandle> materialize_replica(
       const DeviceKey& target_device,
       loading::MaterializeMode mode,
+      const loading::MaterializeHints& hints);
+
+  absl::StatusOr<loading::MaterializeIntoTargetResult> materialize_into_target(
+      const DeviceKey& target_device,
+      gsl::not_null<void*> target_ptr,
+      uint64_t total_size,
+      std::string_view canonical_index_json,
+      uint64_t generation,
       const loading::MaterializeHints& hints);
 
   absl::StatusOr<loading::ReplicaHandle> ingest_from_disk(
@@ -180,6 +189,9 @@ class MaterializationFacade : public materialization::control::MaterializationBa
   std::unique_ptr<MaterializationService> materialization_service_;
   ingestion::IngestionEventHub* ingestion_event_hub_;
   std::atomic<uint64_t> request_counter_{1};
+  mutable absl::Mutex segment_plan_mu_;
+  absl::flat_hash_map<std::string, std::shared_ptr<std::vector<loader::SegmentPiece>>> segment_plan_cache_
+      ABSL_GUARDED_BY(segment_plan_mu_);
   mutable absl::Mutex publish_context_mu_;
   absl::flat_hash_map<loading::ReplicaKey, std::string, loading::ReplicaKeyHash> publish_context_by_replica_
       ABSL_GUARDED_BY(publish_context_mu_);

--- a/core/store/store_engine.cc
+++ b/core/store/store_engine.cc
@@ -464,6 +464,17 @@ absl::StatusOr<loading::ReplicaHandle> StoreEngine::materialize_replica(
   return ingestion_runtime_->materialize_replica(target_device, mode, hints);
 }
 
+absl::StatusOr<loading::MaterializeIntoTargetResult> StoreEngine::materialize_into_target(
+    const DeviceKey& target_device,
+    gsl::not_null<void*> target_ptr,
+    uint64_t total_size,
+    std::string_view canonical_index_json,
+    uint64_t generation,
+    const loading::MaterializeHints& hints) {
+  return ingestion_runtime_->materialize_into_target(
+      target_device, target_ptr, total_size, canonical_index_json, generation, hints);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Global Store registration helper for already-loaded replicas
 // ═══════════════════════════════════════════════════════════════════════════

--- a/core/store/store_engine.h
+++ b/core/store/store_engine.h
@@ -72,6 +72,14 @@ class StoreEngine {
       MaterializeMode mode = MaterializeMode::AUTO,
       const loading::MaterializeHints& hints = {});
 
+  absl::StatusOr<loading::MaterializeIntoTargetResult> materialize_into_target(
+      const DeviceKey& target_device,
+      gsl::not_null<void*> target_ptr,
+      uint64_t total_size,
+      std::string_view canonical_index_json,
+      uint64_t generation,
+      const loading::MaterializeHints& hints = {});
+
   absl::StatusOr<loading::ReplicaHandle> ingest_from_p2p(
       const std::string& artifact_identifier,
       const P2PSource& source,

--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -110,6 +110,7 @@ sc_header_only_library(
         "@abseil-cpp//absl/time:time",
         "@folly//folly:executor",
         "@folly//folly/futures:core",
+        "@glog",
     ],
 )
 
@@ -736,6 +737,20 @@ cc_test(
         "@abseil-cpp//absl/types:span",
         "@catch2//:catch2_main",
         "@nlohmann_json//:json",
+    ],
+)
+
+cc_test(
+    name = "materialize_into_target_validation_test",
+    srcs = ["materialize_into_target_validation_test.cc"],
+    deps = [
+        ":ipc_region_registry_lib",
+        ":lip_manager_lib",
+        ":materialization_controller_lib",
+        "//core/store:store_engine",
+        "//proto/tensorcast/daemon/v2:daemon_grpc_cc",
+        "@abseil-cpp//absl/time:time",
+        "@catch2//:catch2_main",
     ],
 )
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -62,6 +62,7 @@ flowchart TB
 
 - Loading: `MaterializeByKey` (preferred), `MaterializeReplica`, `ConfirmReplica`, `UnloadReplica`, `WaitReplicaVerification`.
 - Loading v2 (gated): `MaterializeByKey`/`MaterializeReplica` with descriptor payloads plus `GetMaterializeCapabilities` (SDK probe) under `StoreDaemonServiceV2`. Descriptors are derived from UMA view plans (offset/stride/byte-length) when a view is requested so the exported buffer layout matches the planner, and disk fallbacks stay daemon-owned via `DiskFallbackHint` (respecting `verify_checksums`).
+- Loading v2 (region-backed): `MaterializeIntoTarget` streams bytes directly into a client-registered CUDA region when the SDK supplies a full coalesced `TargetLayout` (`layout_kind=LAYOUT_KIND_COALESCED_UNSPECIFIED`, `index_kind=INDEX_KIND_CANONICAL_UNSPECIFIED`, `tensor_spec_kind=TENSOR_SPEC_KIND_OFFSETS`) and `artifact_id`. The daemon validates layout/device constraints, maps the IPC handle, and never allocates a daemon-owned replica.
 - Disk fallbacks honor `verify_checksums` on `DiskFallbackHint`/`MaterializeReplicaRequest` and propagate the flag into engine `MaterializeHints` so checksum/descriptor validation is enforced by default but can be disabled for local development.
 - Key mapping: `PublishReplicaKey`, `ResolveKeyMapping`, `GetArtifactIndexById`.
 - Status: `GetServerConfig`, `GetWorkerStatus`, `GetDetailedStatus`, `GetLoadedReplicasV2` (paginated).
@@ -74,6 +75,7 @@ Contract highlights:
 - `Materialize*` returns after allocation with a CUDA IPC handle; clients must `ConfirmReplica` and may `WaitReplicaVerification`.
 - `MaterializeByKey` performs key resolution and P2P-first loading with disk fallback inside the daemon; clients do not implement fallback.
 - `MaterializeReplica` shares the same LIP fast-path semantics; same-device denial from LIP is treated as a cache miss and falls back to the engine path rather than surfacing an RPC failure.
+- `MaterializeIntoTarget` requires canonical layouts and `artifact_id` in Phase 1, skips verification, and returns `DATA_LOSS` on post-start failures after poisoning the region to prevent reuse.
 - Transport locks infer a unique device when `device_id` is absent; ambiguity returns `INVALID_ARGUMENT`.
 
 ### Variant Views (v1)
@@ -104,6 +106,7 @@ Contract highlights:
 - `verification_tracker.h`: completion-driven verification tracking (ReadySignal subscriptions) with capacity/expiry pruning.
 - `lip_manager.{h,cc}`, `lip_bridge.{h,cc}`: LIP fast path and cross-device helpers.
 - `background_scheduler.h`, `session_lifecycle.h`, `sweep_tasks.h`: event-driven runtime scheduler and lifecycle/task definitions.
+- `ipc_region_registry.{h,cc}`: tracks client-registered CUDA IPC regions with TTL, refcounts, and poison state.
 - `rpc_context.h`, `grpc_span.h`, `grpc_metrics.h`, `deadline_utils.h`, `device_resolver.h`, `status_utils.h`.
 - `worker_lifecycle_manager.{h,cc}`: integration with Global Store (register/heartbeat/reconcile) using a constructor-built `gsl::not_null` `GlobalStoreClient`, fixed node identity captured at construction, and a mutable worker id that is populated during registration; `start()` just performs the handshake and initial registration, and shutdown signals interruptible waits so stop exits promptly.
 - `server_main.cc`: flags/bootstrap and service registration.

--- a/daemon/grpc_service_impl.cc
+++ b/daemon/grpc_service_impl.cc
@@ -275,6 +275,14 @@ Status StoreDaemonServiceV2Impl::MaterializeReplica(
   return materialization_controller_.materialize_replica_v2(rctx, *req, *resp);
 }
 
+Status StoreDaemonServiceV2Impl::MaterializeIntoTarget(
+    grpc::ServerContext* ctx,
+    const v2::MaterializeIntoTargetRequest* req,
+    v2::MaterializeIntoTargetResponse* resp) {
+  RpcContext rctx{"MaterializeIntoTarget", *ctx, allow_high_card_attrs_};
+  return materialization_controller_.materialize_into_target(rctx, *req, *resp);
+}
+
 Status StoreDaemonServiceV2Impl::MaterializeByKey(
     grpc::ServerContext* ctx,
     const v2::MaterializeByKeyRequest* req,
@@ -297,6 +305,7 @@ Status StoreDaemonServiceV2Impl::GetMaterializeCapabilities(
     v2::GetMaterializeCapabilitiesResponse* resp) {
   RpcContext rctx{"GetMaterializeCapabilities", *ctx, allow_high_card_attrs_};
   resp->set_supports_view_subset_hash(true);
+  resp->set_supports_region_backed_get_into(true);
   rctx.mark_success();
   return Status::OK;
 }

--- a/daemon/grpc_service_impl.h
+++ b/daemon/grpc_service_impl.h
@@ -116,6 +116,7 @@ class StoreDaemonServiceImpl final : public v1::StoreDaemonService::Service {
         .sessions = *sessions_svc_,
         .lip = *lip_bridge_,
         .devices = devices_,
+        .regions = *region_registry_,
         .is_shutting_down = is_shutting_down_,
         .lifecycle = lifecycle_mgr_.get(),
         .disk_path_whitelist = opts_.disk_path_whitelist};
@@ -420,6 +421,11 @@ class StoreDaemonServiceV2Impl final : public v2::StoreDaemonService::Service {
       grpc::ServerContext* ctx,
       const v2::MaterializeReplicaRequest* req,
       v2::MaterializeReplicaResponse* resp) override;
+
+  grpc::Status MaterializeIntoTarget(
+      grpc::ServerContext* ctx,
+      const v2::MaterializeIntoTargetRequest* req,
+      v2::MaterializeIntoTargetResponse* resp) override;
 
   grpc::Status MaterializeByKey(
       grpc::ServerContext* ctx,

--- a/daemon/ipc_region_registry.cc
+++ b/daemon/ipc_region_registry.cc
@@ -66,9 +66,11 @@ absl::StatusOr<IpcRegionRegistry::RegionDescriptor> IpcRegionRegistry::register_
   rec.desc.session_id = params.session_id;
   rec.desc.region_name = params.region_name;
   rec.desc.expires_at = absl::Now() + absl::Milliseconds(ttl_ms);
+  rec.desc.poisoned = false;
   rec.handle_bytes = params.handle_bytes;
   rec.refcount = 0;
   rec.inserted_at = absl::Now();
+  rec.poisoned = false;
 
   auto [it, inserted] = regions_.emplace(rec.desc.region_id, std::move(rec));
   if (!inserted) {
@@ -99,7 +101,9 @@ absl::StatusOr<IpcRegionRegistry::RegionDescriptor> IpcRegionRegistry::describe(
   if (it == regions_.end()) {
     return absl::NotFoundError("region_id not found");
   }
-  return it->second.desc;
+  RegionDescriptor desc = it->second.desc;
+  desc.poisoned = it->second.poisoned;
+  return desc;
 }
 
 bool IpcRegionRegistry::refresh_ttl(const std::string& region_id, uint32_t ttl_ms) {
@@ -158,11 +162,15 @@ absl::StatusOr<IpcRegionRegistry::RegionDescriptor> IpcRegionRegistry::acquire(
   if (it == regions_.end()) {
     return absl::NotFoundError("region_id not found");
   }
+  if (it->second.poisoned) {
+    return absl::FailedPreconditionError("region is poisoned");
+  }
   if (owner_pid != 0 && owner_pid != it->second.desc.owner_pid) {
     return absl::PermissionDeniedError("owner_pid mismatch");
   }
   ++it->second.refcount;
   it->second.desc.expires_at = absl::Now() + absl::Milliseconds(it->second.desc.ttl_ms);
+  it->second.desc.poisoned = it->second.poisoned;
   return it->second.desc;
 }
 
@@ -180,6 +188,26 @@ absl::Status IpcRegionRegistry::release(const std::string& region_id) {
     it->second.desc.expires_at = absl::Now() + absl::Milliseconds(it->second.desc.ttl_ms);
   }
   return absl::OkStatus();
+}
+
+absl::Status IpcRegionRegistry::mark_poisoned(const std::string& region_id) {
+  absl::MutexLock lock(&mu_);
+  auto it = regions_.find(region_id);
+  if (it == regions_.end()) {
+    return absl::NotFoundError("region_id not found");
+  }
+  it->second.poisoned = true;
+  it->second.desc.poisoned = true;
+  return absl::OkStatus();
+}
+
+bool IpcRegionRegistry::is_poisoned(const std::string& region_id) const {
+  absl::MutexLock lock(&mu_);
+  auto it = regions_.find(region_id);
+  if (it == regions_.end()) {
+    return false;
+  }
+  return it->second.poisoned;
 }
 
 std::string IpcRegionRegistry::mint_region_id_locked() {

--- a/daemon/ipc_region_registry.h
+++ b/daemon/ipc_region_registry.h
@@ -47,6 +47,7 @@ class IpcRegionRegistry {
     std::string session_id;
     std::string region_name;
     absl::Time expires_at = absl::InfiniteFuture();
+    bool poisoned = false;
   };
 
   explicit IpcRegionRegistry(Options opts);
@@ -75,12 +76,19 @@ class IpcRegionRegistry {
   // Release a previously acquired region.
   absl::Status release(const std::string& region_id);
 
+  // Mark a region as poisoned to prevent further writes.
+  absl::Status mark_poisoned(const std::string& region_id);
+
+  // Check if a region is poisoned.
+  bool is_poisoned(const std::string& region_id) const;
+
  private:
   struct RegionRecord {
     RegionDescriptor desc;
     std::string handle_bytes;
     uint64_t refcount = 0;
     absl::Time inserted_at = absl::Now();
+    bool poisoned = false;
   };
 
   std::string mint_region_id_locked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);

--- a/daemon/ipc_region_registry_test.cc
+++ b/daemon/ipc_region_registry_test.cc
@@ -96,3 +96,22 @@ TEST_CASE("IpcRegionRegistry TTL refresh and sweep", "[daemon][region]") {
   REQUIRE(expired.size() == 1);
   REQUIRE(expired[0].region_id == region_id);
 }
+
+TEST_CASE("IpcRegionRegistry poison blocks acquire", "[daemon][region]") {
+  IpcRegionRegistry reg(IpcRegionRegistry::Options{});
+  IpcRegionRegistry::RegisterParams params;
+  params.device_id = 0;
+  params.owner_pid = 7;
+  params.size_bytes = 4096;
+  params.ttl_ms = 1000;
+  params.handle_bytes = "h";
+
+  auto desc_or = reg.register_region(params);
+  REQUIRE(desc_or.ok());
+  const std::string region_id = desc_or->region_id;
+
+  REQUIRE(reg.mark_poisoned(region_id).ok());
+  REQUIRE(reg.is_poisoned(region_id));
+  auto acq_or = reg.acquire(region_id, params.owner_pid);
+  REQUIRE_FALSE(acq_or.ok());
+}

--- a/daemon/materialize_into_target_validation_test.cc
+++ b/daemon/materialize_into_target_validation_test.cc
@@ -1,0 +1,157 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "daemon/service/controllers/materialization_controller.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "core/store/store_engine.h"
+#include "daemon/background_scheduler.h"
+#include "daemon/device_resolver.h"
+#include "daemon/ipc_region_registry.h"
+#include "daemon/lip_bridge.h"
+#include "daemon/lip_manager.h"
+#include "daemon/ref_tracker.h"
+#include "daemon/replica_session_manager.h"
+#include "daemon/rpc_context.h"
+#include "daemon/sessions_service.h"
+#include "daemon/verification_tracker.h"
+#include "grpcpp/server_context.h"
+#include "tensorcast/daemon/v2/store_daemon.pb.h"
+
+namespace {
+
+using tensorcast::daemon::MaterializationController;
+using tensorcast::daemon::v2::MaterializeIntoTargetRequest;
+using tensorcast::daemon::v2::MaterializeIntoTargetResponse;
+
+std::filesystem::path test_tmpdir() {
+  const char* env = std::getenv("TEST_TMPDIR");
+  if (env && *env) {
+    return std::filesystem::path(env);
+  }
+  return std::filesystem::temp_directory_path() / "tensorcast_daemon_materialize_into_target_test";
+}
+
+tensorcast::store::StoreEngineOptions make_opts() {
+  tensorcast::store::StoreEngineOptions opts;
+  opts.storage_path = (test_tmpdir() / "engine").string();
+  std::filesystem::create_directories(opts.storage_path);
+  opts.p2p_port = 47016;
+  opts.memory_pool_size = 32ULL << 20;
+  opts.tx_slice_bytes = 1ULL << 20;
+  opts.num_thread = 2;
+  opts.global_store_address.clear();
+  return opts;
+}
+
+struct ValidationFixture {
+  std::shared_ptr<tensorcast::store::StoreEngine> engine;
+  tensorcast::daemon::RefTracker refs;
+  tensorcast::daemon::IpcRegionRegistry regions;
+  tensorcast::daemon::LipManager lip_mgr;
+  tensorcast::daemon::LipBridge lip_bridge;
+  tensorcast::daemon::ReplicaSessionManager session_mgr;
+  tensorcast::daemon::VerificationTracker verif_tracker;
+  tensorcast::daemon::BackgroundScheduler scheduler;
+  tensorcast::daemon::SessionsService sessions_svc;
+  tensorcast::daemon::DeviceResolver devices;
+  std::atomic<bool> shutting_down{false};
+  MaterializationController controller;
+
+  ValidationFixture()
+      : engine(std::make_shared<tensorcast::store::StoreEngine>(make_opts())),
+        regions(tensorcast::daemon::IpcRegionRegistry::Options{}),
+        lip_mgr(engine, &regions),
+        lip_bridge(lip_mgr),
+        session_mgr(std::chrono::seconds(60)),
+        verif_tracker(),
+        scheduler(),
+        sessions_svc(session_mgr, verif_tracker, &scheduler, /*lifecycle=*/nullptr, absl::Seconds(60)),
+        devices(tensorcast::store::DeviceRegistry::instance()),
+        controller(MaterializationController(
+            MaterializationController::Dep{
+                .engine = *engine,
+                .refs = refs,
+                .sessions = sessions_svc,
+                .lip = lip_bridge,
+                .devices = devices,
+                .regions = regions,
+                .is_shutting_down = shutting_down,
+                .lifecycle = nullptr,
+            })) {}
+};
+
+grpc::Status run_request(
+    MaterializationController& controller,
+    const MaterializeIntoTargetRequest& req,
+    MaterializeIntoTargetResponse& resp) {
+  grpc::ServerContext ctx;
+  tensorcast::daemon::RpcContext rctx{"MaterializeIntoTargetTest", ctx, /*allow_high_card_attrs=*/true};
+  return controller.materialize_into_target(rctx, req, resp);
+}
+
+} // namespace
+
+TEST_CASE("MaterializeIntoTarget rejects missing artifact_id", "[daemon][materialize][into_target]") {
+  ValidationFixture fix;
+  MaterializeIntoTargetRequest req;
+  MaterializeIntoTargetResponse resp;
+  auto status = run_request(fix.controller, req, resp);
+
+  REQUIRE_FALSE(status.ok());
+  REQUIRE(status.error_code() == grpc::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_CASE("MaterializeIntoTarget rejects empty disk_fallback path", "[daemon][materialize][into_target]") {
+  ValidationFixture fix;
+  MaterializeIntoTargetRequest req;
+  req.set_artifact_id("mi2:dummy:dummy");
+  req.mutable_disk_fallback();
+  MaterializeIntoTargetResponse resp;
+  auto status = run_request(fix.controller, req, resp);
+
+  REQUIRE_FALSE(status.ok());
+  REQUIRE(status.error_code() == grpc::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_CASE("MaterializeIntoTarget rejects subset requests", "[daemon][materialize][into_target]") {
+  ValidationFixture fix;
+  MaterializeIntoTargetRequest req;
+  req.set_artifact_id("mi2:dummy:dummy");
+  req.mutable_target_layout();
+  req.add_tensor_names("foo");
+  MaterializeIntoTargetResponse resp;
+  auto status = run_request(fix.controller, req, resp);
+
+  REQUIRE_FALSE(status.ok());
+  REQUIRE(status.error_code() == grpc::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_CASE("MaterializeIntoTarget rejects view/view_id", "[daemon][materialize][into_target]") {
+  ValidationFixture fix;
+  MaterializeIntoTargetRequest req;
+  req.set_artifact_id("mi2:dummy:dummy");
+  req.mutable_target_layout();
+  req.set_view_id("view:dummy");
+  MaterializeIntoTargetResponse resp;
+  auto status = run_request(fix.controller, req, resp);
+
+  REQUIRE_FALSE(status.ok());
+  REQUIRE(status.error_code() == grpc::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_CASE("MaterializeIntoTarget requires device_uuid", "[daemon][materialize][into_target]") {
+  ValidationFixture fix;
+  MaterializeIntoTargetRequest req;
+  req.set_artifact_id("mi2:dummy:dummy");
+  req.mutable_target_layout();
+  MaterializeIntoTargetResponse resp;
+  auto status = run_request(fix.controller, req, resp);
+
+  REQUIRE_FALSE(status.ok());
+  REQUIRE(status.error_code() == grpc::StatusCode::INVALID_ARGUMENT);
+}

--- a/daemon/service/controllers/materialization_controller.cc
+++ b/daemon/service/controllers/materialization_controller.cc
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -21,12 +22,14 @@
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
 #include "google/protobuf/util/time_util.h"
+#include "gsl/pointers"
 #include "opentelemetry/metrics/provider.h"
 
 #include "core/common/artifact_hash.h"
 #include "core/store/device_registry.h"
 #include "core/store/materialization/dataplane/metadata/index_reader.h"
 #include "core/store/materialization/dataplane/view/view_planner.h"
+#include "daemon/cuda_ipc_raii.h"
 #include "daemon/deadline_utils.h"
 #include "daemon/status_utils.h"
 #include "nlohmann/json.hpp"
@@ -115,6 +118,20 @@ struct DescriptorMetadata {
   std::optional<std::string> data_multihash;
 };
 
+struct CanonicalIndexEntry {
+  uint64_t logical_offset{0};
+  uint64_t logical_length{0};
+  uint64_t storage_offset{0};
+  std::vector<int64_t> shape;
+  std::vector<int64_t> stride;
+  std::string dtype;
+};
+
+struct CanonicalIndexTable {
+  absl::flat_hash_map<std::string, CanonicalIndexEntry> entries;
+  uint64_t logical_total_size{0};
+};
+
 absl::StatusOr<DescriptorMetadata> load_descriptor_metadata(const std::filesystem::path& artifact_dir) {
   DescriptorMetadata metadata;
   const auto descriptor_path = artifact_dir / "artifact_descriptor.json";
@@ -157,6 +174,104 @@ absl::StatusOr<DescriptorMetadata> load_descriptor_metadata(const std::filesyste
         absl::StrCat("Failed to parse artifact_descriptor.json at ", descriptor_path.string(), ": ", ex.what()));
   }
   return metadata;
+}
+
+absl::StatusOr<CanonicalIndexTable> parse_canonical_index(std::string_view index_json) {
+  if (index_json.empty()) {
+    return absl::InvalidArgumentError("canonical index JSON is empty");
+  }
+  nlohmann::json j;
+  try {
+    j = nlohmann::json::parse(index_json, nullptr, true);
+  } catch (const std::exception& e) {
+    return absl::InvalidArgumentError(absl::StrCat("Failed to parse canonical index JSON: ", e.what()));
+  }
+  CanonicalIndexTable table;
+  for (auto it = j.begin(); it != j.end(); ++it) {
+    const auto& arr = it.value();
+    if (!arr.is_array() || arr.size() != 6) {
+      return absl::InvalidArgumentError("Invalid canonical index entry");
+    }
+    CanonicalIndexEntry entry;
+    entry.logical_offset = arr[0].get<uint64_t>();
+    entry.logical_length = arr[1].get<uint64_t>();
+    entry.shape.reserve(arr[2].size());
+    for (const auto& dim : arr[2]) {
+      entry.shape.push_back(dim.get<int64_t>());
+    }
+    entry.stride.reserve(arr[3].size());
+    for (const auto& dim : arr[3]) {
+      entry.stride.push_back(dim.get<int64_t>());
+    }
+    entry.dtype = arr[4].get<std::string>();
+    entry.storage_offset = arr[5].get<uint64_t>();
+    table.logical_total_size =
+        std::max<uint64_t>(table.logical_total_size, entry.logical_offset + entry.logical_length);
+    table.entries.emplace(it.key(), std::move(entry));
+  }
+  return table;
+}
+
+struct TargetOffsetEntry {
+  std::string name;
+  std::string storage_id;
+  uint64_t storage_offset{0};
+  uint64_t logical_length{0};
+};
+
+absl::StatusOr<std::vector<TargetOffsetEntry>> resolve_target_offsets(const v2::TargetLayout& layout) {
+  std::vector<TargetOffsetEntry> offsets;
+  offsets.reserve(layout.offsets_size() + layout.aliases_size());
+  if (layout.tensor_spec_kind() == v2::TargetLayout::TENSOR_SPEC_KIND_OFFSETS) {
+    for (const auto& entry : layout.offsets()) {
+      TargetOffsetEntry resolved;
+      resolved.name = entry.name();
+      resolved.storage_id = entry.storage_id();
+      resolved.storage_offset = entry.storage_offset();
+      resolved.logical_length = entry.logical_length();
+      offsets.push_back(std::move(resolved));
+    }
+    return offsets;
+  }
+  if (layout.tensor_spec_kind() == v2::TargetLayout::TENSOR_SPEC_KIND_ALIAS_UNSPECIFIED) {
+    for (const auto& entry : layout.aliases()) {
+      TargetOffsetEntry resolved;
+      resolved.name = entry.name();
+      resolved.storage_id = entry.storage_id();
+      resolved.storage_offset = entry.storage_offset();
+      resolved.logical_length = entry.logical_length();
+      offsets.push_back(std::move(resolved));
+    }
+    return offsets;
+  }
+  return absl::InvalidArgumentError("Unsupported tensor_spec_kind for target layout");
+}
+
+void record_materialize_into_target(
+    std::string_view result,
+    std::string_view reason,
+    v1::MaterializationSource source) {
+  try {
+    static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+    static auto counter = meter->CreateUInt64Counter("tc_store_materialize_into_target_total");
+    if (counter) {
+      counter->Add(
+          1,
+          {{"result", std::string(result)}, {"reason", std::string(reason)}, {"source", static_cast<int64_t>(source)}});
+    }
+  } catch (...) {
+  }
+}
+
+void record_materialize_into_target_verification_skipped() {
+  try {
+    static auto meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+    static auto counter = meter->CreateUInt64Counter("tc_store_materialize_into_target_verification_skipped_total");
+    if (counter) {
+      counter->Add(1);
+    }
+  } catch (...) {
+  }
 }
 
 absl::Status validate_descriptor_against_index(
@@ -1085,6 +1200,253 @@ grpc::Status MaterializationController::materialize_replica_v2(
     *ticket->mutable_created_at() = google::protobuf::util::TimeUtil::GetCurrentTime();
   }
   return status;
+}
+
+grpc::Status MaterializationController::materialize_into_target(
+    RpcContext& rctx,
+    const v2::MaterializeIntoTargetRequest& req,
+    v2::MaterializeIntoTargetResponse& resp) {
+  auto& span = rctx.span();
+  if (d_.is_shutting_down.load()) {
+    record_materialize_into_target(
+        "error", "unavailable", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::UNAVAILABLE, "daemon is shutting down"};
+  }
+
+  const bool has_artifact_id = req.has_artifact_id() && !req.artifact_id().empty();
+  const bool has_key = req.has_key() && !req.key().empty();
+  if (has_key) {
+    record_materialize_into_target(
+        "error", "key_not_supported", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "key-based requests not supported for MaterializeIntoTarget"};
+  }
+  if (!has_artifact_id) {
+    record_materialize_into_target(
+        "error", "missing_artifact_id", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "artifact_id is required for MaterializeIntoTarget"};
+  }
+  if (req.has_disk_fallback() && req.disk_fallback().disk_path().empty()) {
+    record_materialize_into_target(
+        "error", "disk_fallback_empty", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "disk_fallback.disk_path must not be empty"};
+  }
+  if (!req.has_target_layout()) {
+    record_materialize_into_target(
+        "error", "layout_missing", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "target_layout is required"};
+  }
+  if (req.tensor_names_size() > 0 || !req.view_subset_hash().empty()) {
+    record_materialize_into_target(
+        "error", "subset_not_supported", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "tensor_names/view_subset_hash not supported for MaterializeIntoTarget"};
+  }
+  if (req.view_identity_case() != v2::MaterializeIntoTargetRequest::VIEW_IDENTITY_NOT_SET) {
+    record_materialize_into_target(
+        "error", "view_not_supported", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "view/view_id not supported for MaterializeIntoTarget"};
+  }
+  if (req.device_uuid().empty()) {
+    record_materialize_into_target(
+        "error", "device_uuid_missing", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "device_uuid is required"};
+  }
+  if (req.pid() <= 0) {
+    record_materialize_into_target(
+        "error", "owner_pid_missing", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "pid is required for MaterializeIntoTarget"};
+  }
+
+  const auto& layout = req.target_layout();
+  if (layout.layout_kind() != v2::TargetLayout::LAYOUT_KIND_COALESCED_UNSPECIFIED) {
+    record_materialize_into_target(
+        "error", "layout_kind_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "Only LAYOUT_KIND_COALESCED_UNSPECIFIED is supported"};
+  }
+  if (layout.index_kind() != v2::TargetLayout::INDEX_KIND_CANONICAL_UNSPECIFIED) {
+    record_materialize_into_target(
+        "error", "index_kind_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "Only INDEX_KIND_CANONICAL_UNSPECIFIED is supported"};
+  }
+  if (layout.storages_size() != 1) {
+    record_materialize_into_target(
+        "error", "multi_storage", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "COALESCED layouts must include exactly one storage entry"};
+  }
+  if (layout.tensor_spec_kind() != v2::TargetLayout::TENSOR_SPEC_KIND_OFFSETS &&
+      layout.tensor_spec_kind() != v2::TargetLayout::TENSOR_SPEC_KIND_ALIAS_UNSPECIFIED) {
+    record_materialize_into_target(
+        "error", "tensor_spec_kind_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "Unsupported tensor_spec_kind for MaterializeIntoTarget"};
+  }
+
+  const auto& storage = layout.storages(0);
+  if (storage.storage_source_case() != v1::StorageEntry::kVramRegionId) {
+    record_materialize_into_target(
+        "error", "storage_not_region", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "Target storage must reference a vram_region_id"};
+  }
+  if (!storage.has_region_base_offset()) {
+    record_materialize_into_target(
+        "error", "region_base_offset_missing", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "region_base_offset is required for region-backed targets"};
+  }
+
+  const auto device = d_.devices.From(v1::DeviceType::DEVICE_TYPE_GPU, req.device_uuid(), std::nullopt);
+  if (storage.device_id() != device.ordinal) {
+    record_materialize_into_target(
+        "error", "device_uuid_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "storage.device_id does not match device_uuid"};
+  }
+
+  auto canonical_json_or = d_.engine.get_canonical_index_by_id(req.artifact_id());
+  if (!canonical_json_or.ok()) {
+    record_materialize_into_target(
+        "error", "index_missing", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return to_grpc_status(canonical_json_or.status());
+  }
+  auto index_table_or = parse_canonical_index(*canonical_json_or);
+  if (!index_table_or.ok()) {
+    record_materialize_into_target(
+        "error", "index_parse_failed", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return to_grpc_status(index_table_or.status());
+  }
+  const CanonicalIndexTable& index_table = *index_table_or;
+  const uint64_t logical_total_size = index_table.logical_total_size;
+
+  auto offsets_or = resolve_target_offsets(layout);
+  if (!offsets_or.ok()) {
+    record_materialize_into_target(
+        "error", "offsets_missing", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return to_grpc_status(offsets_or.status());
+  }
+  const auto& offsets = *offsets_or;
+  if (offsets.empty()) {
+    record_materialize_into_target(
+        "error", "offsets_missing", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "target_layout offsets are required"};
+  }
+  if (offsets.size() != index_table.entries.size()) {
+    record_materialize_into_target(
+        "error", "tensor_name_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "target_layout must include every canonical tensor"};
+  }
+  for (const auto& entry : offsets) {
+    auto it = index_table.entries.find(entry.name);
+    if (it == index_table.entries.end()) {
+      record_materialize_into_target(
+          "error", "tensor_name_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+      return {StatusCode::INVALID_ARGUMENT, "target_layout includes unknown tensor name"};
+    }
+    if (entry.logical_length != it->second.logical_length) {
+      record_materialize_into_target(
+          "error", "layout_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+      return {StatusCode::INVALID_ARGUMENT, "target_layout logical_length mismatch"};
+    }
+    if (entry.storage_offset != it->second.logical_offset) {
+      record_materialize_into_target(
+          "error", "offset_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+      return {StatusCode::INVALID_ARGUMENT, "target_layout storage_offset must match logical offset"};
+    }
+    if (entry.storage_id != storage.storage_id()) {
+      record_materialize_into_target(
+          "error", "storage_id_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+      return {StatusCode::INVALID_ARGUMENT, "target_layout storage_id mismatch"};
+    }
+  }
+  if (storage.storage_length() != logical_total_size) {
+    record_materialize_into_target(
+        "error", "storage_length_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::INVALID_ARGUMENT, "storage_length must cover full logical space"};
+  }
+
+  if (rctx.server_context().IsCancelled()) {
+    record_materialize_into_target("error", "cancelled", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return {StatusCode::CANCELLED, "request cancelled before transfer"};
+  }
+
+  auto region_desc_or = d_.regions.acquire(storage.vram_region_id(), req.pid());
+  if (!region_desc_or.ok()) {
+    const absl::Status& st = region_desc_or.status();
+    const bool poisoned = absl::IsFailedPrecondition(st) && st.message() == "region is poisoned";
+    record_materialize_into_target(
+        "error",
+        poisoned ? "region_poisoned" : "region_missing",
+        v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return to_grpc_status(st);
+  }
+  auto region_desc = *region_desc_or;
+  if (region_desc.device_id != storage.device_id()) {
+    record_materialize_into_target(
+        "error", "device_uuid_mismatch", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    d_.regions.release(storage.vram_region_id()).IgnoreError();
+    return {StatusCode::FAILED_PRECONDITION, "region device does not match storage device"};
+  }
+  const uint64_t region_end = storage.region_base_offset() + storage.storage_length();
+  if (region_end > region_desc.size_bytes) {
+    record_materialize_into_target("error", "bounds", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    d_.regions.release(storage.vram_region_id()).IgnoreError();
+    return {StatusCode::FAILED_PRECONDITION, "region-backed storage exceeds region bounds"};
+  }
+
+  struct RegionReleaseGuard {
+    IpcRegionRegistry& registry;
+    std::string region_id;
+    bool active{true};
+
+    ~RegionReleaseGuard() {
+      if (active) {
+        (void)registry.release(region_id);
+      }
+    }
+  } guard{d_.regions, storage.vram_region_id(), true};
+
+  auto handle_or = d_.regions.get_handle_bytes(storage.vram_region_id());
+  if (!handle_or.ok()) {
+    record_materialize_into_target(
+        "error", "region_missing", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return to_grpc_status(handle_or.status());
+  }
+  auto map_or = CudaIpcMapping::open(*handle_or, cudaIpcMemLazyEnablePeerAccess);
+  if (!map_or.ok()) {
+    record_materialize_into_target(
+        "error", "map_failed", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    return to_grpc_status(map_or.status());
+  }
+
+  store::loading::MaterializeHints hints;
+  hints.artifact_id = req.artifact_id();
+  if (req.has_disk_fallback() && !req.disk_fallback().disk_path().empty()) {
+    hints.disk_path = req.disk_fallback().disk_path();
+  }
+  hints.source_preference = to_hint_preference(req.preference());
+  hints.verify = store::loading::MaterializeHints::Verify::NONE;
+
+  record_materialize_into_target_verification_skipped();
+
+  void* region_base_ptr = static_cast<uint8_t*>(map_or->get()) + static_cast<uint64_t>(storage.region_base_offset());
+  const uint64_t generation = compute_generation_from_index(*canonical_json_or);
+  auto result_or = d_.engine.materialize_into_target(
+      device, gsl::not_null<void*>{region_base_ptr}, logical_total_size, *canonical_json_or, generation, hints);
+  if (!result_or.ok()) {
+    if (absl::IsDataLoss(result_or.status())) {
+      d_.regions.mark_poisoned(storage.vram_region_id()).IgnoreError();
+      record_materialize_into_target(
+          "error", "transfer_failed", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    } else {
+      record_materialize_into_target(
+          "error", "transfer_error", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+    }
+    return to_grpc_status(result_or.status());
+  }
+
+  resp.set_artifact_id(req.artifact_id());
+  resp.set_status(v1::MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_ALLOCATED);
+  resp.set_source(to_proto_source(result_or->source));
+  resp.set_canonical_index_bytes(*canonical_json_or);
+  resp.set_generation(generation);
+  record_materialize_into_target("ok", "ok", resp.source());
+  rctx.mark_success();
+  return Status::OK;
 }
 
 grpc::Status MaterializationController::materialize_by_key_v2(

--- a/daemon/service/controllers/materialization_controller.h
+++ b/daemon/service/controllers/materialization_controller.h
@@ -10,6 +10,7 @@
 
 #include "core/store/store_engine.h"
 #include "daemon/device_resolver.h"
+#include "daemon/ipc_region_registry.h"
 #include "daemon/lip_bridge.h"
 #include "daemon/ref_tracker.h"
 #include "daemon/rpc_context.h"
@@ -27,6 +28,7 @@ class MaterializationController {
     SessionsService& sessions;
     LipBridge& lip;
     DeviceResolver& devices;
+    IpcRegionRegistry& regions;
     std::atomic<bool>& is_shutting_down;
     SessionLifecycleManager* lifecycle{nullptr};
     std::vector<std::filesystem::path> disk_path_whitelist;
@@ -48,6 +50,11 @@ class MaterializationController {
       RpcContext& rctx,
       const v2::MaterializeReplicaRequest& req,
       v2::MaterializeReplicaResponse& resp);
+
+  grpc::Status materialize_into_target(
+      RpcContext& rctx,
+      const v2::MaterializeIntoTargetRequest& req,
+      v2::MaterializeIntoTargetResponse& resp);
 
   grpc::Status materialize_by_key_v2(
       RpcContext& rctx,

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Guides for developing specific components:
 - **[Global Store Development](../tensorcast/global_store/README.md)** - Developing the Global Store service
 - **[Store Daemon Development](../daemon/README.md)** - Store Daemon internals and development
 - **[Adding New Metrics](internals/adding-metrics.md)** - How to create and expose metrics
+- **[tensor_dict_into Dataflow](internals/tensor_dict_into_dataflow.md)** - Legacy vs region-backed into paths
 - **[Preemptible Memory Internals](internals/preemptible-memory.md)** - UMA/VS preemption workflow and tuning
 
 ## ⚙️ Core Modules (C++)

--- a/docs/designs/0042-region-backed-tensor-dict-into.md
+++ b/docs/designs/0042-region-backed-tensor-dict-into.md
@@ -1,0 +1,589 @@
+---
+slug: 0042-region-backed-tensor-dict-into
+title: Region-Backed tensor_dict_into (Design)
+links:
+  plan: ../plans/0042-region-backed-tensor-dict-into.md
+areas: ["core", "daemon", "sdk", "proto"]
+related_code:
+  - docs/internals/tensor_dict_into_dataflow.md
+  - docs/designs/0021-region‑backed-registration.md
+  - docs/designs/0004-unified-runtime-config.md
+  - proto/tensorcast/daemon/v2/store_daemon.proto
+  - proto/tensorcast/config/v1/client_config.proto
+  - tensorcast/api/store/materialization.py
+  - tensorcast/api/_materialize.py
+  - tensorcast/daemon_ctl.py
+  - daemon/service/controllers/materialization_controller.cc
+  - daemon/ipc_region_registry.h
+  - core/store/materialization/**
+created: 2025-12-21
+last_updated: 2025-12-21
+status: proposed
+---
+
+# Summary
+
+Introduce a dedicated region-backed `tensor_dict_into` RPC (`MaterializeIntoTarget`) that streams artifact bytes directly into a client-registered CUDA region, bypassing daemon replica allocation and `mem_handle` export. Phase 1 requires `artifact_id`, COALESCED single-storage, and a full logical layout (no subset); `disk_fallback` is a source hint only. External-target verification is deferred. The daemon reuses the existing materialization dataplane (sources, sinks, pump) but writes into an external GPU region and releases region refs after completion. Region-backed mode applies only to `tensor_dict_into` / `tensor_into` / `get_into`; `get` / `get_view` always use the existing daemon-owned replica path.
+
+# Goals / Non-Goals
+
+## Goals
+1. Provide a dedicated, long-lived RPC for region-backed get-into that does not rely on `mem_handle`.
+2. Zero extra VRAM on the daemon for region-backed targets.
+3. Keep IPC handle count minimal (typically one region handle plus a compact offset table).
+4. Reuse the existing daemon data-path abstractions (sources, sinks, buffer pools, pump).
+5. Reject any region-backed layout whose logical space does not match the target layout.
+
+## Non-Goals
+- Replace `tensor_dict()` or `get()` flows (they continue to materialize a daemon-owned replica).
+- Apply `region_backed_mode` to `get` / `get_view` or change their semantics; those calls always use the daemon-owned replica path.
+- Enable cross-node GPU direct write (RDMA into client GPU) beyond current infrastructure.
+- Support arbitrary strided targets in the first release; non-contiguous tensors fall back.
+- Support subset materialization for region-backed targets (`tensor_names` / `view_subset_hash` are deferred).
+- Introduce Global Store schema changes or replica tracking for `tensor_dict_into` targets.
+- Support multi-storage COALESCED layouts or any TENSOR_TABLE layout in this phase.
+- Perform verification for external targets in Phase 1.
+
+## Phase 1 Scope
+- Artifact identity must be `artifact_id` (key-based requests are reserved for a later phase).
+- `disk_fallback` may be provided as a source hint but never as the sole identity.
+- `index_kind=CANONICAL` only; `INDEX_KIND_VIEW` is deferred to Phase 2.
+- View-based requests (`view` / `view_id`) are not supported for region-backed targets.
+- Subset selection is not supported: `tensor_names` / `view_subset_hash` must be empty, and the layout must cover the full canonical byte space.
+- `device_uuid` is required and authoritative; `device_id` is treated as a local ordinal only.
+- `region_backed_mode` is consulted only by `tensor_dict_into` / `tensor_into` / `get_into`; `get` / `get_view` ignore it.
+
+# Current State
+
+`tensor_dict_into` currently materializes a daemon-owned replica, exports a single IPC handle, and lets the client copy into target tensors before calling `UnloadReplica`. The v2 materialization path expects `mem_handle` on completion, so there is no RPC that writes directly into client regions. Region-backed registration exists for LIP and transport locks but is not used by `tensor_dict_into`.
+
+# Architecture & Interfaces
+
+## Target Layout and Data Organization
+
+Region-backed `tensor_dict_into` needs a compact description of where each tensor should land inside one or more registered regions. The layout is defined in a **logical byte space** anchored to the canonical or view index; the daemon maps that logical space onto region-backed storages.
+
+### Logical Byte Space
+- The logical destination offsets are canonical (or view) offsets, not raw region offsets.
+- Each tensor defines a contiguous logical range; the layout maps that range to a storage
+  and then to a region base pointer.
+- This keeps the pump interface stable: it only sees logical offsets, and a sink maps
+  logical offsets to the underlying region and device pointer.
+- The logical total size is defined as `max(offset + logical_length)` across the canonical
+  (or view) index entries, not the sum of lengths; COALESCED storages must span this size.
+
+**TargetLayout** (new v2 wrapper message)
+- `repeated tensorcast.daemon.v1.StorageEntry storages`
+- `repeated tensorcast.daemon.v1.TensorAlias aliases`
+- `repeated TargetTensorOffset offsets`
+- `enum LayoutKind { LAYOUT_KIND_COALESCED_UNSPECIFIED = 0; LAYOUT_KIND_TENSOR_TABLE = 1; }`
+- `LayoutKind layout_kind`
+- `enum IndexKind { INDEX_KIND_CANONICAL_UNSPECIFIED = 0; INDEX_KIND_VIEW = 1; }`
+- `IndexKind index_kind`
+- `string view_id` (required when index_kind is VIEW)
+- `enum TensorSpecKind { TENSOR_SPEC_KIND_ALIAS_UNSPECIFIED = 0; TENSOR_SPEC_KIND_OFFSETS = 1; }`
+- `TensorSpecKind tensor_spec_kind`
+- `bytes logical_layout_hash` (optional, for diagnostics; Phase 1 does not require it)
+
+**TargetTensorOffset** (new v2 message)
+- `name`, `storage_id`, `storage_offset`, `logical_length`
+
+**StorageEntry** (existing, v1)
+- `storage_id`, `device_id`, `storage_length`
+- `vram_region_id` (required for region-backed target)
+- `region_base_offset` (required)
+
+**TensorAlias** (existing, v1)
+- `name`, `storage_id`, `storage_offset`, `logical_length`
+- `shape`, `stride`, `dtype`
+
+The **offset table** maps each tensor's logical offset to a region offset:
+`logical_offset (canonical or view) -> region_id + region_base_offset + storage_offset`.
+
+### Layout Compaction
+- `TENSOR_SPEC_KIND_OFFSETS` sends only `TargetTensorOffset` entries; dtype/shape/stride come
+  from the canonical or view index to avoid duplication.
+- `TENSOR_SPEC_KIND_ALIAS_UNSPECIFIED` is a verbose mode (debug or compatibility) that duplicates the
+  index metadata in `TensorAlias`.
+
+### Logical Layout Hash (Phase 1 optional)
+`logical_layout_hash` is a SHA-256 digest over the logical byte space only:
+- Derive it from canonical (or view) index bytes plus `index_kind`; prefer `index_multihash`
+  when present to avoid re-hashing large indices.
+- Exclude physical binding fields (`storage_id`, `vram_region_id`, `region_base_offset`,
+  `storage_offset`) so the hash stays stable across region bindings.
+- In Phase 1 the on-wire field is optional and diagnostic; SegmentPlan caching should
+  key on `index_multihash` (or a locally computed `logical_layout_hash`) plus
+  `generation`, not on physical layout.
+- If a physical-binding hash is ever needed, define it separately (e.g., `binding_hash`)
+  so it does not affect plan caching.
+
+### Future: Selection Hash (Phase 2+)
+When view/subset support is added, plan identity becomes:
+`logical_layout_hash + selection_hash`. `selection_hash` encodes view identity and
+subset selection (`view_id` or canonicalized `view` spec, plus `tensor_names` /
+`view_subset_hash`) using a stable serialization. Phase 1 keeps selection empty and
+does not implement this logic.
+
+### Index Anchoring
+- `index_kind=CANONICAL` means logical offsets are canonical offsets.
+- `index_kind=VIEW` means logical offsets are view offsets; `view_id` or `view` must be
+  present in the request to resolve the view plan.
+- Phase 1 only supports `INDEX_KIND_CANONICAL_UNSPECIFIED`; `INDEX_KIND_VIEW` is reserved for Phase 2.
+
+### Device Identity
+- `device_uuid` is the authoritative device identity across processes.
+- `device_id` is a local ordinal that may vary across processes; it is validated against
+  the daemon-resolved UUID but is never used to establish identity on its own.
+- SDKs must always populate `device_uuid` and treat any UUID mismatch as a hard error
+  when `region_backed_mode=require`.
+
+### Layout Modes
+1. **COALESCED**: the target region is arranged in logical order (canonical or view).
+   The daemon verifies `storage_offset == logical_offset` for each tensor, and a single
+   storage entry spans the logical space (`storage_length == logical_total_size`). The `region_base_offset` acts as the base of
+   the coalesced buffer slice in the region. This lets the pipeline stream ranges
+   without extra scatter logic and reuse `pump_ranges`.
+   COALESCED implies the storage covers the full logical space and includes every tensor
+   in the canonical index; packed subset layouts are not supported in Phase 1.
+
+`TENSOR_TABLE` is reserved for a future extension. For now, any non-COALESCED layout
+or multi-storage layout is rejected with `INVALID_ARGUMENT`.
+
+## SDK: Client-Side Shape and Validation
+
+The SDK preserves `tensor_dict_into` semantics by validating targets before any
+daemon-side write. It builds a `TargetLayout` only when all of the following are true:
+- The request uses `artifact_id` (Phase 1 does not support key-based targets).
+- Every target tensor is CUDA and on the selected device.
+- Every target storage is fully covered by a registered region in the client cache.
+- Every target tensor is contiguous (or matches a supported contiguous stride pattern).
+- The canonical index is available to compute offsets (view index support is deferred).
+- Subset selection is disabled: `tensor_names` / `view_subset_hash` must be empty (or
+  `tensor_names` must include all canonical names) and the layout must cover the full
+  logical byte space.
+- Phase 1 rejects view requests (`view` / `view_id`) for region-backed targets.
+- `device_uuid` is required and treated as authoritative for device identity; `device_id`
+  is carried only as a local ordinal and must match the daemon-resolved UUID.
+- The daemon advertises `supports_region_backed_get_into`; otherwise the SDK falls back
+  or errors based on `region_backed_mode`.
+
+**Construction steps**
+1. Resolve artifact identity and fetch canonical index bytes (already cached).
+2. Parse the canonical index and compute `logical_total_size = max(offset + logical_length)`;
+   `logical_length` reflects storage segments (max alias length), not a sum of tensor sizes.
+3. Validate target dtype/shape/stride against the canonical index without relying on
+   daemon-provided tensors, and ensure the target covers every canonical entry.
+4. Enforce subset rules: `tensor_names` must be empty (or include all canonical names)
+   and `view_subset_hash` must be empty for Phase 1.
+5. Group target tensors by storage; assign deterministic `storage_id` (e.g., hash of base
+   pointer + size).
+6. For each storage, find the covering region and compute `region_base_offset`.
+7. Emit `StorageEntry` records with `vram_region_id`, `region_base_offset`, and
+   `storage_length == logical_total_size`.
+8. Emit `TargetTensorOffset` records for each tensor with `storage_offset` and
+   `logical_length` (use `TensorAlias` only when `tensor_spec_kind=ALIAS`).
+9. Set `index_kind` to CANONICAL (VIEW is deferred to Phase 2).
+10. Enforce COALESCED constraints:
+   - `len(storages) == 1`
+   - `storage_offset == logical_offset` for all tensors
+   - `storage_length == logical_total_size`
+   If any check fails, either fall back (when `region_backed_mode=auto`) or raise
+   `INVALID_ARGUMENT` (when `region_backed_mode=require`).
+11. Set `layout_kind = COALESCED` and optionally compute `logical_layout_hash` from
+   canonical index bytes + `index_kind` (exclude any region binding). Selection hashing
+   is reserved for Phase 2+.
+12. Send `MaterializeIntoTarget` only if all constraints hold; otherwise fall back to
+   normal `materialize + client copy`.
+
+Phase 1 COALESCED layouts require a full canonical layout: the storage spans the full
+logical byte space and every canonical tensor is present. Subset requests are rejected
+by the region-backed path and fall back (or error) based on `region_backed_mode`.
+
+Phase 1 does not support view-indexed layouts. If a view is requested and the client
+cannot build a canonical layout, the SDK falls back or errors based on
+`region_backed_mode`.
+
+### Client API Surface
+- `tensor_dict_into(...)`, `tensor_into(...)`, and `get_into(...)` use `MaterializeIntoTarget`
+  when `region_backed_mode` allows and `artifact_id` is available (Phase 1). `get` /
+  `get_view` always use the existing daemon-owned replica path and ignore
+  `region_backed_mode`.
+- Region-backed paths require full materialization. If callers pass `tensor_names` that
+  do not include all canonical tensors, the SDK must not invoke `MaterializeIntoTarget`
+  (fallback in `auto`, error in `require`).
+- Region-backed results use a dedicated SDK return type (no `mem_handle`, no
+  `UnloadReplica`) to avoid mixing into-target semantics with legacy payloads.
+- `get_into_async.cancel()` returns `False` once a region-backed transfer has started;
+  before start, the SDK may fall back to the legacy path if `region_backed_mode=auto`.
+- `region_backed_mode` is defined via the unified runtime config system. In Phase 1 it
+  is read only by into paths; a future API split introduces `GetIntoOptions` /
+  `TargetSpec` so into-specific options do not affect `get`.
+- When `region_backed_mode=require`, the SDK errors instead of falling back.
+
+### Capabilities and Config Integration
+- Extend `ClientConfig.defaults` with `region_backed_mode` so the default path is
+  driven by the unified runtime config system.
+- Extend `StoreCapabilities` with `supports_region_backed_get_into` and populate it
+  by calling `GetMaterializeCapabilities` during session initialization (in addition
+  to `GetServerConfig`).
+- `region_backed_mode` defaults to the configured value and can be overridden per call,
+  but into paths are the only consumers until `GetIntoOptions` is introduced.
+
+## RPC Changes (v2)
+
+Add a dedicated RPC to `proto/tensorcast/daemon/v2/store_daemon.proto`:
+
+```proto
+service StoreDaemonService {
+  ...
+  rpc MaterializeIntoTarget(MaterializeIntoTargetRequest) returns (MaterializeIntoTargetResponse) {}
+}
+
+message MaterializeIntoTargetRequest {
+  oneof artifact_ref {
+    string artifact_id = 1;
+    string key = 2; // reserved for Phase 2
+  }
+  DiskFallbackHint disk_fallback = 3; // optional source hint, not identity
+
+  TargetLayout target_layout = 4;
+  int32 pid = 5;
+  string device_uuid = 6;
+
+  tensorcast.daemon.v1.SourcePreference preference = 7;
+
+  // Selective materialization (reserved for Phase 2)
+  repeated string tensor_names = 8;
+  bytes view_subset_hash = 9;
+
+  oneof view_identity {
+    tensorcast.daemon.v1.ViewSpec view = 1001;
+    string view_id = 1002;
+  }
+
+  tensorcast.daemon.v1.TransformPlacement placement = 1003;
+}
+
+message MaterializeIntoTargetResponse {
+  string artifact_id = 1;
+  tensorcast.daemon.v1.MaterializeReplicaStatus status = 2;
+  tensorcast.daemon.v1.MaterializationSource source = 3;
+  bytes canonical_index_bytes = 4;
+  ViewSubset view_subset = 5;
+  bytes view_index_bytes = 6;
+  uint64 generation = 7;
+}
+
+message GetMaterializeCapabilitiesResponse {
+  bool supports_view_subset_hash = 1;
+  bool supports_region_backed_get_into = 2;
+}
+```
+
+When `MaterializeIntoTarget` is used:
+- The daemon writes directly into the provided regions.
+- `mem_handle` is not returned.
+- `canonical_index_bytes` (and `view_index_bytes` when available) are returned for validation.
+- Phase 1 requires `artifact_id` and treats `disk_fallback` as a source hint only.
+- Phase 1 rejects key-based requests, `tensor_names` / `view_subset_hash`, `index_kind != CANONICAL`,
+  `layout_kind != COALESCED`, `len(storages) != 1`, or `storage_length != logical_total_size`
+  with `INVALID_ARGUMENT`.
+- `device_uuid` must be present and resolves the target device; `device_id` is validated
+  against the resolved UUID but is not authoritative across processes.
+- Phase 1 is synchronous; there is no transfer ticket or async completion.
+
+## Examples
+
+### Example A: COALESCED canonical, single region (supported)
+
+Canonical index (JSON, simplified):
+
+```json
+{
+  "w1": [0, 1024, [256], [1], "float16", 0],
+  "w2": [1024, 2048, [1024], [1], "float16", 0]
+}
+```
+
+Target layout (compact offsets):
+
+```text
+target_layout {
+  storages: {
+    storage_id: "s0"
+    device_id: 0
+    vram_region_id: "region:0001"
+    region_base_offset: 0
+    storage_length: 3072
+  }
+  offsets: [
+    { name: "w1", storage_id: "s0", storage_offset: 0,    logical_length: 1024 },
+    { name: "w2", storage_id: "s0", storage_offset: 1024, logical_length: 2048 }
+  ]
+  layout_kind: COALESCED
+  index_kind: INDEX_KIND_CANONICAL_UNSPECIFIED
+  tensor_spec_kind: TENSOR_SPEC_KIND_OFFSETS
+}
+```
+
+`storage_offset == logical_offset` and a single storage spans the logical space, so
+the daemon uses `pump_ranges` with a SegmentPlan derived from the canonical index.
+
+### Example B: COALESCED view, single region (planned, Phase 2)
+
+Phase 1 rejects `INDEX_KIND_VIEW`.
+
+Canonical index (JSON, simplified):
+
+```json
+{
+  "k": [0, 4096, [1024], [1], "float16", 0],
+  "q": [4096, 4096, [1024], [1], "float16", 0]
+}
+```
+
+View index for `view:swap` (JSON, simplified) reorders `q` then `k`:
+
+```json
+{
+  "q": [0, 4096, [1024], [1], "float16", 0],
+  "k": [4096, 4096, [1024], [1], "float16", 0]
+}
+```
+
+Target layout (view-indexed, still COALESCED):
+
+```text
+target_layout {
+  storages: {
+    storage_id: "s0"
+    device_id: 0
+    vram_region_id: "region:0002"
+    region_base_offset: 0
+    storage_length: 8192
+  }
+  offsets: [
+    { name: "q", storage_id: "s0", storage_offset: 0,    logical_length: 4096 },
+    { name: "k", storage_id: "s0", storage_offset: 4096, logical_length: 4096 }
+  ]
+  layout_kind: COALESCED
+  index_kind: INDEX_KIND_VIEW
+  view_id: "view:swap"
+  tensor_spec_kind: TENSOR_SPEC_KIND_OFFSETS
+}
+```
+
+Logical offsets follow the view index, so `storage_offset == logical_offset` still holds.
+
+### Example C: Unsupported layouts (error)
+
+Case 1: offsets do not match logical space:
+
+```text
+offsets: [
+  { name: "q", storage_id: "s0", storage_offset: 8192, logical_length: 4096 }
+]
+```
+
+Case 2: multiple storages:
+
+```text
+storages: [ { storage_id: "s0", ... }, { storage_id: "s1", ... } ]
+```
+
+Both cases are rejected with `INVALID_ARGUMENT` because only COALESCED single-storage
+layouts are supported.
+
+## Daemon Pipeline Integration
+
+The daemon controller should remain thin: it validates inputs and delegates to a
+new `StoreEngine::materialize_into_target` entrypoint (via `MaterializationFacade`)
+so the data-path stays in core and shares scheduling, buffer pools, and loaders.
+
+### Validation
+`MaterializationController` validates:
+- `artifact_id` is present (Phase 1 rejects key-based requests and disk-only requests).
+- `target_layout` is present and non-empty.
+- `target_layout.storages` are region-backed (no inline handles).
+- `device_uuid` is present and resolves to a device; each storage entry `device_id`
+  matches the resolved UUID (device_id is not authoritative across processes).
+- `layout_kind == COALESCED` and `len(storages) == 1`.
+- `region_base_offset + storage_length <= region.size_bytes`.
+- `owner_pid` matches the session (via `IpcRegionRegistry::acquire`).
+- Region is not poisoned (fail fast if the registry marks the region as invalid).
+- `TensorAlias` or `TargetTensorOffset` matches canonical entry (length, name).
+- `tensor_names` and `view_subset_hash` are empty in Phase 1.
+- `view` / `view_id` are not set (Phase 1 rejects view materialization).
+- `index_kind == INDEX_KIND_CANONICAL_UNSPECIFIED` (Phase 1 rejects view layouts).
+- For COALESCED, `storage_offset == logical_offset` for all entries.
+- For COALESCED, the storage table spans the logical space (`storage_length == logical_total_size`).
+
+### Coalesced Data Path
+For COALESCED layouts, the logical offsets match the destination offsets. The daemon:
+
+- Builds a SegmentPlan from the canonical (Phase 1) or view (Phase 2) index that spans
+  the full logical byte space.
+- Uses `pump_ranges` to stream the logical ranges directly into the region-backed sink.
+- Avoids any scatter plan or additional copy-plan machinery.
+
+### External GPU Target
+Introduce an external GPU target in the materialization pipeline:
+- Bypass `AllocationStage` and `HandleStage`; no daemon-owned replica or IPC export.
+- Open the single region IPC handle and pass `gpu_base_ptr = region_base + region_base_offset`
+  into `GpuMemorySink`, with `total_size = logical_total_size` to enforce a full copy.
+- Acquire the region via `IpcRegionRegistry::acquire` to extend TTL and enforce ownership,
+  then release on completion to decrement the refcount.
+- Phase 1 skips verification for external targets (TODO: add plan-based verification
+  via `compute_data_multihash_from_gpu_plan`).
+- Region-backed ignores `enable_verification`; do not start `_monitor_verification`, and
+  emit `verification_skipped` metrics.
+- If transfer starts and later fails, mark the region as poisoned so further writes are
+  rejected until the client unregisters and re-registers the region.
+
+Region refs are released immediately after the copy completes.
+
+Implementation note: extend `IpcRegionRegistry` to track region state
+(active/poisoned) alongside refcounts; `UnregisterVramRegion` clears poison.
+
+### Fast Paths and Caching
+- **Local replica copy (deferred)**: copy from an existing local replica into the target
+  region once a range-based GPU→external target copy helper exists. Phase 1 always streams
+  via loaders/pump, even when a local replica is present.
+- **SegmentPlan cache**: cache `logical_layout_hash` (or `index_multihash`) + `generation`
+  to reuse computed plans across calls; exclude physical binding fields.
+- **IPC mapping cache**: reuse `CudaIpcMapping` per region for the duration of a request
+  batch to avoid repeated open/close overhead.
+
+## Control Flow
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Daemon
+  participant Engine
+  Client->>Daemon: MaterializeIntoTargetRequest<br>target_layout
+  Daemon->>Daemon: Validate region and layout
+  Daemon->>Engine: materialize_into_target
+  Engine->>Engine: Build SegmentPlan and pump_ranges
+  Engine-->>Daemon: status + index bytes
+  Daemon-->>Client: response without mem_handle
+```
+
+```mermaid
+flowchart LR
+  A["Source<br>disk or p2p"] --> B["SegmentPlan<br>logical ranges"]
+  B --> C["pump_ranges"]
+  C --> D["GpuMemorySink<br>mapped region"]
+```
+
+# Invariants & Error Model
+
+## Invariants
+- Only region-backed storages are accepted (no inline IPC handles).
+- Every tensor in the request maps to a canonical or view entry by name.
+- Writes are bounded to the declared storage length and region size.
+- When `layout_kind=COALESCED`, `storage_offset == logical_offset` and the storage spans the logical space.
+- Phase 1 requires full canonical coverage; subset requests are rejected.
+- Phase 1 requires `index_kind=CANONICAL` and skips verification for external targets.
+- Phase 1 requires `artifact_id`; `disk_fallback` is a source hint only.
+- `device_uuid` is authoritative for device identity; `device_id` is validated but not trusted across processes.
+- Region references are held for the duration of the transfer only.
+- Region-backed transfers are non-cancelable once the pump starts; daemon-side cancellation
+  checks only occur before transfer to avoid partial writes.
+- `tensor_spec_kind` determines which tensor table is authoritative.
+
+## Idempotency & Retry Semantics
+- `MaterializeIntoTarget` is not idempotent; failures can leave partial writes in the
+  target region.
+- Callers must treat target bytes as undefined on any error; region-backed failures mark
+  the target region as poisoned and are non-retryable for that region until it is
+  re-registered.
+- SDKs must mark region-backed failures as non-retryable (`retryable=false`).
+- `region_backed_mode=require` must surface failures to the caller (fatal to the request);
+  optional fatal-exit behavior, if desired, must be wired through the unified config.
+
+## Error Mapping
+- `INVALID_ARGUMENT`: missing layout entries, dtype/shape mismatch, both region and
+  handle fields set, tensor_spec_kind mismatch, non-COALESCED layout, multiple storages,
+  key-based requests, missing `artifact_id`, `disk_fallback` without `artifact_id`,
+  missing/invalid `device_uuid` or device mismatch, `tensor_names` / `view_subset_hash` set,
+  `index_kind != CANONICAL`, view identity set, non-full layouts, or `tensor_names`
+  mismatch (Phase 1).
+- `FAILED_PRECONDITION`: region not found, region poisoned, TTL expired, owner_pid mismatch,
+  bounds violation, or non-contiguous targets when required.
+- `DATA_LOSS`: transfer started but failed (partial writes possible); retryable=false.
+- `CANCELLED`: client cancellation before transfer start (no bytes written).
+- `RESOURCE_EXHAUSTED`: pinned buffer pool exhausted.
+
+## Observability
+- Daemon counter: `tc_store_materialize_into_target_total{result,reason,source}` where
+  `reason` is low-cardinality (layout_mismatch, region_missing, ttl_expired,
+  owner_pid_mismatch, bounds, non_contiguous, capability_missing, subset_not_supported,
+  device_uuid_mismatch, region_poisoned, transfer_failed).
+- SDK counters:
+  - `tc_store_region_backed_fallback_total{reason}`
+  - `tc_store_region_backed_verification_skipped_total`
+- SDK reuses `tc_store_operation_latency_seconds` with `selection=region_backed|fallback`
+  to keep latency trends visible alongside legacy paths.
+
+# Schema Changes
+
+Proto API changes only (new v2 RPC and messages); `schema.sql` is unchanged. Breaking
+updates are acceptable in this pre-launch phase.
+
+# Trade-offs & Risks
+
+- **COALESCED single-storage only**: simplifies implementation but rejects multi-storage
+  or packed layouts. Mitigate by retaining fallback and reserving TENSOR_TABLE for a
+  later design.
+- **Non-contiguous tensors**: strided layouts are deferred. SDK must detect and fall
+  back to the current path to preserve semantics.
+- **No external-target verification in Phase 1**: integrity checks are skipped for
+  region-backed writes. Mitigate by adding plan-based verification in Phase 2 and
+  instrumenting a metric that flags verification skips.
+- **Retry behavior**: region-backed failures poison the region and are non-retryable
+  until the region is re-registered.
+- **Plan caching**: stale cache entries must be invalidated on generation changes.
+- **Compact offsets**: reduced on-wire metadata shifts more validation to the index;
+  debugging may require optional alias mode.
+
+# Compatibility & Acceptance Criteria
+
+## Compatibility
+- Compatibility is not a primary constraint pre-launch; proto changes may be breaking.
+- Region-backed writes use `MaterializeIntoTarget`; existing get/get_into paths remain
+  available but are not extended with `target_layout`.
+- `region_backed_mode` affects only into paths; `get` / `get_view` remain unchanged.
+- SDKs still gate the feature on `supports_region_backed_get_into` to allow mixed
+  daemon/client deployments during rollout.
+
+## Acceptance Criteria
+- Daemon VRAM usage does not exceed target region size during `tensor_dict_into`.
+- IPC handle count per `tensor_dict_into` is limited to region handles only.
+- Phase 1 skips external-target verification and reports the skip via metrics.
+- Observability: new counters for region-backed get-into success/failure and fallback
+  reasons (no region, non-contiguous, capability missing, layout mismatch).
+- Region-backed transfers are non-cancelable once started; failures mark the region
+  poisoned and return `DATA_LOSS`/`FAILED_PRECONDITION` (non-retryable).
+- Key-based requests or `INDEX_KIND_VIEW` return `INVALID_ARGUMENT` in Phase 1.
+- Subset layouts or non-full `tensor_names` return `INVALID_ARGUMENT` in Phase 1.
+- Non-COALESCED or multi-storage layouts return `INVALID_ARGUMENT`.
+
+# Naming Compliance
+
+Proposed API and type names follow repository conventions:
+- **Proto messages**: `TargetLayout`, `TargetTensorOffset` (PascalCase)
+- **Proto messages**: `MaterializeIntoTargetRequest`, `MaterializeIntoTargetResponse` (PascalCase)
+- **Proto fields**: `target_layout`, `layout_kind`, `region_base_offset` (snake_case)
+- **RPCs**: `MaterializeIntoTarget` (PascalCase)
+- **C++ functions**: `materialize_into_target` (snake_case)
+- **Python types**: `RegionBackedMode`, `TargetLayout` (PascalCase)
+- **Constants/enums**: `LAYOUT_KIND_COALESCED_UNSPECIFIED` (ALL_CAPS for generated enum values)
+
+# References
+
+- `docs/designs/0021-region‑backed-registration.md`
+- `docs/internals/tensor_dict_into_dataflow.md`
+- `core/store/materialization/dataplane/runtime/pump.h`
+- `daemon/service/controllers/materialization_controller.cc`

--- a/docs/internals/model-loading.md
+++ b/docs/internals/model-loading.md
@@ -81,6 +81,18 @@ sequenceDiagram
     Note left of LocalStoreDaemon: RPC: UnloadReplica (drops refs/leases)
 ```
 
+## Region-backed tensor_dict_into
+
+Region-backed into calls bypass daemon-owned replicas by streaming bytes into a
+client-registered CUDA region using `MaterializeIntoTarget`. The SDK computes a
+full coalesced `TargetLayout` from the target tensors, validates against the
+canonical index, and invokes the v2 RPC directly. The daemon maps the IPC handle,
+streams bytes from P2P or disk, and releases the region reference on completion
+without allocating VRAM.
+
+See [tensor_dict_into dataflow](tensor_dict_into_dataflow.md) for the detailed
+sequence and Phase 1 constraints.
+
 ### Lease-In-Place Fast Path & Use Leases
 
 `MaterializeByKey` still resolves the human key via `MetadataGateway::resolve_key_mapping`, but before it coordinates transport it now asks `LipManager::try_satisfy_from_lip` for a replica that already lives on the requested GPU. When this fast path hits, the daemon reuses the existing CUDA IPC handle, marks the status as `ALLOCATED`, and returns both `artifact_id` and `used_disk_path` to the client without invoking the bulk materialization pipeline. If the fast path misses, the controller immediately falls through to the engine-backed path described below.

--- a/docs/internals/tensor_dict_into_dataflow.md
+++ b/docs/internals/tensor_dict_into_dataflow.md
@@ -1,0 +1,89 @@
+---
+title: tensor_dict_into Dataflow
+description: Legacy and region-backed tensor_dict_into flows for SDK, daemon, and StoreEngine
+areas: ["sdk", "daemon", "core"]
+---
+
+# tensor_dict_into Dataflow
+
+This document describes how `tensor_dict_into` / `tensor_into` / `get_into` populate
+caller-owned tensors. It covers the legacy daemon-owned replica path and the
+region-backed path introduced in Design 0042.
+
+## Legacy path (daemon-owned replica)
+
+The legacy flow materializes a daemon-owned replica, exports a CUDA IPC handle,
+and performs client-side copies into the caller’s target tensors.
+
+```mermaid
+sequenceDiagram
+  participant SDK as SDK (Store)
+  participant Daemon as Store Daemon
+  participant Engine as StoreEngine
+  participant GS as Global Store
+
+  SDK->>Daemon: MaterializeByKey/MaterializeReplica (v2)
+  Daemon->>GS: ResolveKeyMapping / RequestReplicaTransport
+  Daemon->>Engine: materialize_replica(AUTO/LOAD_ONLY, hints)
+  Engine-->>Daemon: ReplicaHandle (CUDA IPC)
+  Daemon-->>SDK: mem_handle + descriptor stream
+  SDK->>SDK: Validate target layout
+  SDK->>SDK: Copy payloads into targets
+  SDK->>Daemon: UnloadReplica
+```
+
+Key properties:
+
+- Daemon allocates VRAM and owns the replica lifetime.
+- SDK validates target tensors against the canonical index before copying.
+- Verification applies when requested and uses daemon-owned sources.
+- Cancellation is supported because the daemon holds the replica, not the client.
+
+## Region-backed path (external target)
+
+The region-backed flow streams bytes directly into a client-registered CUDA
+region. The daemon does not allocate VRAM, and no CUDA IPC handle is returned.
+
+```mermaid
+sequenceDiagram
+  participant SDK as SDK (Store)
+  participant Daemon as Store Daemon
+  participant Engine as StoreEngine
+  participant GS as Global Store
+
+  SDK->>SDK: Build TargetLayout + TargetTensorOffset
+  SDK->>Daemon: MaterializeIntoTarget (artifact_id, layout, device_uuid)
+  Daemon->>Daemon: Acquire IpcRegionRegistry ref + map IPC handle
+  Daemon->>Engine: materialize_into_target(target_ptr, total_size, index_json)
+  Engine->>GS: RequestReplicaTransport (if P2P)
+  Engine-->>Daemon: OK (data streamed into target)
+  Daemon-->>SDK: success (no mem_handle)
+```
+
+Phase 1 constraints:
+
+- `artifact_id` required; key-based resolution is not supported.
+- Canonical index only; no view/subset (no `tensor_names` or `view_subset_hash`).
+- Single coalesced storage; `storage_length` must match the logical total size.
+- `device_uuid` is required and must match `storage.device_id`.
+- Verification is skipped for external targets; metrics record the skip.
+
+Failure handling:
+
+- If the data pump starts and fails, the daemon marks the region as poisoned and
+  returns `DATA_LOSS`. The SDK evicts the region from its cache so it can be
+  re-registered before retrying.
+- If validation fails before transfer, the SDK either falls back to the legacy
+  path (`region_backed_mode=auto`) or raises `INVALID_ARGUMENT`
+  (`region_backed_mode=require`).
+
+## Capability and config gating
+
+The SDK uses daemon capabilities (`supports_region_backed_get_into`) to decide
+whether it can call `MaterializeIntoTarget`. A new `region_backed_mode` default
+in the unified runtime config controls the fallback behavior for into APIs:
+
+- `auto`: try region-backed first; fall back when validation fails.
+- `require`: enforce region-backed and surface errors.
+
+`get` and `get_view` always use the legacy daemon-owned replica path.

--- a/docs/plans/0042-region-backed-tensor-dict-into.md
+++ b/docs/plans/0042-region-backed-tensor-dict-into.md
@@ -1,0 +1,148 @@
+---
+title: Region-Backed tensor_dict_into (Plan)
+links:
+  design: ../designs/0042-region-backed-tensor-dict-into.md
+---
+
+# Current State
+
+`tensor_dict_into` materializes a daemon-owned replica, exports a single IPC handle, and performs client-side copies. The v2 materialization path assumes `mem_handle` on completion, so there is no RPC that writes directly into client regions. Region-backed registration exists but is only used for LIP and transport staging.
+
+# Latest Status
+
+Phase 1–3 implementation is complete (proto + daemon + core + SDK + docs). Added basic
+daemon validation tests; remaining Phase 4 tests (region bounds, tensor name mismatch,
+device_uuid mismatch, poison paths, SDK tests) are still pending.
+
+# Phases & Milestones
+
+- [x] Phase 1: RPC + proto surface
+- [x] Add `MaterializeIntoTarget` RPC and `MaterializeIntoTargetRequest/Response`,
+      plus `TargetLayout` / `TargetTensorOffset` in `proto/tensorcast/daemon/v2/store_daemon.proto`
+- [x] Define `logical_layout_hash` as a logical-only optional field in `TargetLayout`;
+      document `selection_hash` as Phase 5 (view/subset) only
+- [x] Wire `MaterializeIntoTarget` in `daemon/grpc_service_impl.h/.cc`
+- [x] Add `supports_region_backed_get_into` to materialize capabilities
+- [x] Document Phase 1 constraints: `artifact_id` required, `disk_fallback` hint-only,
+      `tensor_names` / `view_subset_hash` reserved (no subset support)
+- [x] Regenerate stubs with `bash tools/build_proto_python.sh`
+
+- [x] Phase 2: Daemon materialize-into path (artifact_id only, canonical only, no verification)
+- [x] Implement `MaterializeIntoTarget` handler in `daemon/service/controllers/materialization_controller.cc`
+- [x] Add `StoreEngine::materialize_into_target` + `MaterializationFacade` wiring so the
+      daemon delegates to core rather than owning dataplane logic
+- [x] Add target layout validation (COALESCED only, single storage, `index_kind=CANONICAL`)
+- [x] Require `artifact_id`; reject key-based requests and `disk_fallback` without `artifact_id`
+- [x] Reject `tensor_names` / `view_subset_hash` and any non-full layout (Phase 1)
+- [x] Require `device_uuid`; resolve UUID to device ordinal and validate `storage.device_id`
+- [x] Reject `view` / `view_id` for region-backed targets in Phase 1
+- [x] Acquire/release region refs via `IpcRegionRegistry` and map IPC handles
+- [x] Extend `IpcRegionRegistry` to track region state (active/poisoned) and reject
+      poisoned regions; clear poison on `UnregisterVramRegion`
+- [x] Add external GPU target path in `core/store/materialization/runtime/pipeline/*`
+- [x] Skip verification for external targets; ignore `enable_verification` and emit a
+      "verification_skipped" metric
+- [x] Emit `tc_store_materialize_into_target_total{result,reason,source}` in
+      `daemon/service/controllers/materialization_controller.cc`
+- [x] Add SegmentPlan cache keyed by `logical_layout_hash` (or `index_multihash`) + `generation`
+- [x] Compute `logical_total_size = max(offset + size)` from canonical index and require
+      `storage_length == logical_total_size`
+- [x] Treat gRPC cancellation as pre-transfer only; once pump starts, ignore cancellation
+- [x] On transfer failure after start, mark region poisoned and return `DATA_LOSS`
+      (retryable=false); use `FAILED_PRECONDITION` for poisoned region
+
+- [x] Phase 3: SDK region-backed get_into
+- [x] Add `MaterializeIntoTarget` method to `tensorcast/daemon_ctl.py`
+- [x] Build `TargetLayout` from target tensors in `tensorcast/api/store/materialization.py`
+- [x] Scope `region_backed_mode` to into APIs only; `get` / `get_view` always use the
+      daemon-owned replica path
+- [x] Enforce contiguous + single-storage + region coverage; require `artifact_id` in Phase 1
+- [x] Populate `device_uuid` from the resolved CUDA device and treat it as authoritative
+- [x] Require full layout: `tensor_names` empty or full set; reject subsets when
+      `region_backed_mode=require` and fallback in `auto`
+- [x] Validate target dtype/shape/stride against canonical index without relying on `mem_handle`
+- [x] Compute `logical_total_size` and require `storage_length` to match
+- [x] Call `MaterializeIntoTarget` RPC and return a dedicated into result type (no
+      `mem_handle`, no `UnloadReplica`)
+- [x] Make `get_into_async.cancel()` return `False` for in-flight region-backed transfers;
+      optionally fall back pre-transfer when `region_backed_mode=auto`
+- [x] Evict poisoned regions from the SDK registry/cache on `DATA_LOSS` / `FAILED_PRECONDITION`
+- [x] Mark region-backed failures as non-retryable in SDK error surfaces
+- [x] Add `region_backed_mode` enum to `proto/tensorcast/config/v1/client_config.proto`
+- [x] Wire `region_backed_mode` through client config loader and `client_runtime.client_defaults()`
+- [x] Extend `apply_client_load_defaults_if_present` in `tensorcast/api/_runtime.py` and
+      `GetArtifactOptions` in `tensorcast/api/_config.py` to respect config defaults
+- [x] Regenerate stubs after config proto updates (`bash tools/build_proto_python.sh`)
+- [x] Gate on `supports_region_backed_get_into` capability
+- [x] Extend `StoreCapabilities` in `tensorcast/api/store/types.py` and session init in
+      `tensorcast/api/store/runtime.py` to call `GetMaterializeCapabilities`
+- [x] Add SDK counters for fallback reasons and verification skips in
+      `tensorcast/api/_metrics.py` and emit them from `tensorcast/api/store/materialization.py`
+
+- [ ] Phase 4: Tests and docs
+- [x] Add daemon unit tests for `MaterializeIntoTarget` validation (missing artifact_id,
+      disk_fallback empty, subset/view, missing device_uuid)
+- [ ] Add daemon unit tests for `MaterializeIntoTarget` region bounds
+- [x] Add daemon tests for `view` / `view_id` rejection
+- [ ] Add daemon tests for tensor name mismatch
+- [ ] Add daemon tests for `device_uuid` mismatch and `disk_fallback` without `artifact_id`
+- [ ] Add daemon tests for subset rejection (`tensor_names` / `view_subset_hash`)
+- [ ] Add SDK tests for layout building and fallback behavior
+- [x] Update `docs/internals/tensor_dict_into_dataflow.md`
+- [x] Update module README.md files (`daemon/README.md`, `tensorcast/api/README.md`)
+
+- [ ] Phase 5 (follow-up): Key path, view layouts, verification
+- [ ] Implement key-based `MaterializeIntoTarget`
+- [ ] Add `INDEX_KIND_VIEW` support and view-index preflight if needed
+- [ ] Introduce `selection_hash` for view/subset identity and update SegmentPlan cache
+      to key on `logical_layout_hash + selection_hash + generation`
+- [ ] Split `GetArtifactOptions` into `GetIntoOptions` / `TargetSpec` so into-specific
+      options do not affect `get` / `get_view`
+- [ ] Implement external-target verification (SegmentPlan hashing)
+- [ ] Add range-based GPU→external target copy helper to enable local-replica fast path
+
+# Acceptance Checks
+
+- `MaterializeIntoTarget` completes without allocating daemon VRAM replicas.
+- Responses return no `mem_handle`; IPC handle count equals number of regions.
+- Phase 1 rejects key-based requests and `INDEX_KIND_VIEW` layouts.
+- Phase 1 rejects non-full layouts (`tensor_names` / `view_subset_hash`).
+- Phase 1 requires `device_uuid` and validates against `storage.device_id`.
+- External-target verification is skipped and reported via metrics.
+- `get` / `get_view` remain unchanged; `region_backed_mode` only affects into paths.
+- Region-backed transfers are non-cancelable once started; failures poison the region
+  and return non-retryable `DATA_LOSS` / `FAILED_PRECONDITION`.
+- Fallback path remains unchanged when region-backed requirements are not met.
+
+# Test Plan
+
+- `bazel test //daemon:materialize_into_target_test` (new)
+- `bazel test //daemon:grpc_service_impl_registration_test`
+- `bazel test //daemon:materialize_into_target_validation_test` (new)
+- `bazel test //daemon:materialize_into_target_poison_test` (new)
+- `uv run pytest tests/python/api/test_materialize_into_target.py` (new)
+- `uv run pytest tests/python/api/test_get_into_cancel.py` (new)
+- `uv run pytest tests/python/test_store_region_registration.py`
+- `uv run pytest tests/python/api/test_client_defaults.py` (if adding config defaults)
+
+# Rollout / Backout
+
+- Rollout: deploy daemon and SDK together, enable `region_backed_mode=auto` to start
+  using `MaterializeIntoTarget`.
+- Backout: disable via config or revert SDK to use legacy `get_into` copies.
+
+# Risk Tracking
+
+- Risk: partial writes on retry when `region_backed_mode=require`.
+- Risk: poisoned regions reduce reuse and require explicit re-registration.
+- Risk: non-contiguous targets silently mis-copied if validation is incomplete.
+- Risk: region TTL expiry mid-transfer without refresh.
+- Risk: no external-target verification in Phase 1 could mask corruption.
+- Risk: device_id/UUID mismatches across processes if validation is lax.
+
+# Owner Checklist
+
+- Confirm proto regeneration and RPC wiring.
+- Validate metrics and tracing in both daemon and SDK.
+- Update module READMEs if behavior or API surface changes.
+- Document Phase 1 limits (artifact_id only, canonical only, verification skipped).

--- a/proto/tensorcast/config/v1/client_config.proto
+++ b/proto/tensorcast/config/v1/client_config.proto
@@ -16,6 +16,14 @@ message ClientDefaults {
   google.protobuf.Duration pinned_allocation_timeout = 1;
   bool enable_verification = 2;
   bool wait_for_completion = 3;
+  RegionBackedMode region_backed_mode = 4;
+}
+
+enum RegionBackedMode {
+  REGION_BACKED_MODE_UNSPECIFIED = 0;
+  REGION_BACKED_MODE_AUTO = 1;
+  REGION_BACKED_MODE_REQUIRE = 2;
+  REGION_BACKED_MODE_DISABLED = 3;
 }
 
 message ClientStorage {

--- a/proto/tensorcast/daemon/v2/store_daemon.proto
+++ b/proto/tensorcast/daemon/v2/store_daemon.proto
@@ -8,6 +8,7 @@ import "tensorcast/daemon/v1/store_daemon.proto";
 // Materialization v2 RPC surface focused on streaming payload descriptors.
 service StoreDaemonService {
   rpc MaterializeReplica(MaterializeReplicaRequest) returns (MaterializeReplicaResponse) {}
+  rpc MaterializeIntoTarget(MaterializeIntoTargetRequest) returns (MaterializeIntoTargetResponse) {}
   rpc MaterializeByKey(MaterializeByKeyRequest) returns (MaterializeByKeyResponse) {}
   rpc ResolveArtifactFromDisk(ResolveArtifactFromDiskRequest) returns (ResolveArtifactFromDiskResponse) {}
   rpc GetMaterializeCapabilities(GetMaterializeCapabilitiesRequest) returns (GetMaterializeCapabilitiesResponse) {}
@@ -29,6 +30,39 @@ message TensorPayloadDescriptor {
   uint64 storage_offset = 6;
   string dtype = 7;
   string device_uuid = 8;
+}
+
+message TargetTensorOffset {
+  string name = 1;
+  string storage_id = 2;
+  uint64 storage_offset = 3;
+  uint64 logical_length = 4;
+}
+
+message TargetLayout {
+  enum LayoutKind {
+    LAYOUT_KIND_COALESCED_UNSPECIFIED = 0;
+    LAYOUT_KIND_TENSOR_TABLE = 1;
+  }
+
+  enum IndexKind {
+    INDEX_KIND_CANONICAL_UNSPECIFIED = 0;
+    INDEX_KIND_VIEW = 1;
+  }
+
+  enum TensorSpecKind {
+    TENSOR_SPEC_KIND_ALIAS_UNSPECIFIED = 0;
+    TENSOR_SPEC_KIND_OFFSETS = 1;
+  }
+
+  repeated tensorcast.daemon.v1.StorageEntry storages = 1;
+  repeated tensorcast.daemon.v1.TensorAlias aliases = 2;
+  repeated TargetTensorOffset offsets = 3;
+  LayoutKind layout_kind = 4;
+  IndexKind index_kind = 5;
+  string view_id = 6;
+  TensorSpecKind tensor_spec_kind = 7;
+  bytes logical_layout_hash = 8;
 }
 
 message ViewSubset {
@@ -86,6 +120,40 @@ message MaterializeReplicaResponse {
   uint64 generation = 11;
 }
 
+message MaterializeIntoTargetRequest {
+  oneof artifact_ref {
+    string artifact_id = 1;
+    string key = 2;
+  }
+  DiskFallbackHint disk_fallback = 3;
+
+  TargetLayout target_layout = 4;
+  int32 pid = 5;
+  string device_uuid = 6;
+
+  tensorcast.daemon.v1.SourcePreference preference = 7;
+
+  repeated string tensor_names = 8;
+  bytes view_subset_hash = 9;
+
+  oneof view_identity {
+    tensorcast.daemon.v1.ViewSpec view = 1001;
+    string view_id = 1002;
+  }
+
+  tensorcast.daemon.v1.TransformPlacement placement = 1003;
+}
+
+message MaterializeIntoTargetResponse {
+  string artifact_id = 1;
+  tensorcast.daemon.v1.MaterializeReplicaStatus status = 2;
+  tensorcast.daemon.v1.MaterializationSource source = 3;
+  bytes canonical_index_bytes = 4;
+  ViewSubset view_subset = 5;
+  bytes view_index_bytes = 6;
+  uint64 generation = 7;
+}
+
 message MaterializeByKeyRequest {
   string key = 1;
   int32 device_id = 2;
@@ -131,6 +199,7 @@ message GetMaterializeCapabilitiesRequest {}
 
 message GetMaterializeCapabilitiesResponse {
   bool supports_view_subset_hash = 1;
+  bool supports_region_backed_get_into = 2;
 }
 
 message QueryReplicaStatusResponse {

--- a/tensorcast/api/README.md
+++ b/tensorcast/api/README.md
@@ -47,6 +47,27 @@ Module-level helpers (`tensorcast.api.store.register`, `get`, etc.) reuse a proc
 - Telemetry attaches per-descriptor attributes (`tc.tensor.count`/`tc.tensor.bytes`) and a subset/full selector to the materialization span, and the client metrics surface attaches the same selector to latency/error/retry series.
 - Disk fallbacks are forwarded to the daemon through `DiskFallbackHint` + `SourcePreference=PREFER_DISK` (including the `verify_checksums` hint) so all disk reads stay in the daemon data path.
 
+## Region-backed get_into
+
+`tensor_dict_into` / `tensor_into` / `get_into` can stream bytes directly into
+caller-owned CUDA regions via the v2 `MaterializeIntoTarget` RPC. The SDK
+computes a full coalesced `TargetLayout` (`layout_kind=LAYOUT_KIND_COALESCED_UNSPECIFIED`,
+`index_kind=INDEX_KIND_CANONICAL_UNSPECIFIED`, `tensor_spec_kind=TENSOR_SPEC_KIND_OFFSETS`)
+from the target tensors, validates
+dtype/shape/stride against the canonical index, and requests the daemon to
+materialize into the mapped region. The daemon does not allocate VRAM, and the
+SDK does not call `UnloadReplica` for this path.
+
+The `region_backed_mode` default in the unified runtime config controls the
+behavior:
+
+- `auto`: try region-backed first; fall back to the legacy replica path on
+  validation failures.
+- `require`: enforce region-backed and surface errors.
+
+`get` / `get_view` always use the daemon-owned replica path and ignore
+`region_backed_mode`.
+
 ## Device requirements
 
 `Artifact.tensor*`/`tensor_dict*` default to materializing replicas onto CUDA

--- a/tensorcast/api/_config.py
+++ b/tensorcast/api/_config.py
@@ -101,6 +101,27 @@ class PlacementPolicy(Enum):
         )
 
 
+class RegionBackedMode(Enum):
+    AUTO = "auto"
+    REQUIRE = "require"
+    DISABLE = "disable"
+
+    @staticmethod
+    def parse(value: object) -> "RegionBackedMode":
+        if isinstance(value, RegionBackedMode):
+            return value
+        normalized = str(value).strip().lower()
+        if normalized in {"auto", ""}:
+            return RegionBackedMode.AUTO
+        if normalized in {"require", "required"}:
+            return RegionBackedMode.REQUIRE
+        if normalized in {"disable", "disabled", "off", "false"}:
+            return RegionBackedMode.DISABLE
+        raise ValueError(
+            f"Unknown region_backed_mode '{value}'; expected auto, require, or disable."
+        )
+
+
 class RegisterArtifactOptions(BaseModel):
     model_config = ConfigDict(frozen=True)
 
@@ -148,6 +169,7 @@ class GetArtifactOptions(BaseModel):
     pinned_allocation_timeout_ms: int = DEFAULT_PINNED_TIMEOUT_MS
     wait_for_completion: bool = True
     enable_verification: bool = True
+    region_backed_mode: RegionBackedMode = RegionBackedMode.AUTO
     # Hint for P2P transport lock TTL extension; forwarded by daemons
     transport_hold_ms: int | None = None
 
@@ -161,6 +183,11 @@ class GetArtifactOptions(BaseModel):
             )
         return normalized
 
+    @field_validator("region_backed_mode", mode="before")
+    @classmethod
+    def _normalize_region_backed_mode(cls, value: object) -> RegionBackedMode:
+        return RegionBackedMode.parse(value)
+
 
 __all__ = [
     "DEFAULT_ALIGN",
@@ -168,6 +195,7 @@ __all__ = [
     "GetArtifactOptions",
     "PlanType",
     "PlacementPolicy",
+    "RegionBackedMode",
     "RegisterArtifactOptions",
     "clear_daemon_address",
     "get_daemon_address",

--- a/tensorcast/api/_materialize.py
+++ b/tensorcast/api/_materialize.py
@@ -113,10 +113,12 @@ def materialize_artifact_v2(
         pinned_ms,
         enable_ver,
         wait_for_completion,
+        region_backed_mode,
     ) = apply_client_load_defaults_if_present(
         opts.pinned_allocation_timeout_ms,
         opts.enable_verification,
         opts.wait_for_completion,
+        opts.region_backed_mode,
         runtime_address=daemon_address,
     )
 
@@ -125,6 +127,7 @@ def materialize_artifact_v2(
             "pinned_allocation_timeout_ms": pinned_ms,
             "enable_verification": enable_ver,
             "wait_for_completion": wait_for_completion,
+            "region_backed_mode": region_backed_mode,
         }
     )
 

--- a/tensorcast/api/_metrics.py
+++ b/tensorcast/api/_metrics.py
@@ -35,6 +35,8 @@ class _MeterState:
         self._batch_coalesced: _Counter | None = None
         self._batch_latency: _Histogram | None = None
         self._prefetch_events: _Counter | None = None
+        self._region_backed_fallbacks: _Counter | None = None
+        self._region_backed_verification_skipped: _Counter | None = None
         self._disabled = False
 
     @property
@@ -120,6 +122,16 @@ class _MeterState:
                     unit="1",
                     description="Prefetch ticket lifecycle events.",
                 )
+                self._region_backed_fallbacks = meter.create_counter(
+                    name="tc_store_region_backed_fallback_total",
+                    unit="1",
+                    description="Count of region-backed get_into fallbacks.",
+                )
+                self._region_backed_verification_skipped = meter.create_counter(
+                    name="tc_store_region_backed_verification_skipped_total",
+                    unit="1",
+                    description="Count of region-backed get_into verification skips.",
+                )
             except Exception as exc:  # noqa: BLE001
                 self._disabled = True
                 self._latency = None
@@ -133,6 +145,8 @@ class _MeterState:
                 self._batch_coalesced = None
                 self._batch_latency = None
                 self._prefetch_events = None
+                self._region_backed_fallbacks = None
+                self._region_backed_verification_skipped = None
                 _logger.debug("Failed to initialise store OTel metrics", exc_info=exc)
                 return False
         return True
@@ -309,6 +323,34 @@ class _MeterState:
         except Exception:  # noqa: BLE001
             _logger.debug("Failed to record prefetch event", exc_info=True)
 
+    def record_region_backed_fallback(self, daemon: str, reason: str) -> None:
+        if not self.ensure():
+            return
+        if self._region_backed_fallbacks is None:
+            return
+        try:
+            self._region_backed_fallbacks.add(
+                1, attributes={"daemon": daemon, "reason": reason}
+            )
+        except Exception:  # noqa: BLE001
+            _logger.debug(
+                "Failed to record region-backed fallback event", exc_info=True
+            )
+
+    def record_region_backed_verification_skipped(self, daemon: str) -> None:
+        if not self.ensure():
+            return
+        if self._region_backed_verification_skipped is None:
+            return
+        try:
+            self._region_backed_verification_skipped.add(
+                1, attributes={"daemon": daemon}
+            )
+        except Exception:  # noqa: BLE001
+            _logger.debug(
+                "Failed to record region-backed verification skipped", exc_info=True
+            )
+
 
 _METRICS = _MeterState()
 
@@ -379,3 +421,11 @@ def record_batch_latency(daemon: str, duration_s: float) -> None:
 
 def record_prefetch_event(daemon: str, status: str) -> None:
     _METRICS.record_prefetch_event(daemon, status)
+
+
+def record_region_backed_fallback(daemon: str, reason: str) -> None:
+    _METRICS.record_region_backed_fallback(daemon, reason)
+
+
+def record_region_backed_verification_skipped(daemon: str) -> None:
+    _METRICS.record_region_backed_verification_skipped(daemon)

--- a/tensorcast/api/_runtime.py
+++ b/tensorcast/api/_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Tuple
 
 from tensorcast import startup
+from tensorcast.api._config import RegionBackedMode
 from tensorcast.api._runtime_handle import RuntimeHandle
 from tensorcast.daemon_ctl import DaemonCtl
 
@@ -26,13 +27,14 @@ def apply_client_load_defaults_if_present(
     pinned_allocation_timeout_ms: int,
     enable_verification: bool,
     wait_for_completion: bool,
+    region_backed_mode: "RegionBackedMode",
     *,
     runtime_address: str,
-) -> Tuple[int, bool, bool]:
-    from tensorcast.api._config import DEFAULT_PINNED_TIMEOUT_MS
+) -> Tuple[int, bool, bool, "RegionBackedMode"]:
+    from tensorcast.api._config import DEFAULT_PINNED_TIMEOUT_MS, RegionBackedMode
     from tensorcast.client_runtime import client_defaults, daemon_target_default
 
-    cfg_timeout_ms, cfg_enable_ver, cfg_wait = client_defaults()
+    cfg_timeout_ms, cfg_enable_ver, cfg_wait, cfg_region_mode = client_defaults()
     cfg_target = daemon_target_default()
     if cfg_target and cfg_target != runtime_address:
         raise RuntimeError(
@@ -49,8 +51,19 @@ def apply_client_load_defaults_if_present(
         enable_verification = bool(cfg_enable_ver)
     if wait_for_completion is True and cfg_wait is not None:
         wait_for_completion = bool(cfg_wait)
+    if (
+        isinstance(region_backed_mode, RegionBackedMode)
+        and region_backed_mode is RegionBackedMode.AUTO
+        and cfg_region_mode is not None
+    ):
+        region_backed_mode = cfg_region_mode
 
-    return pinned_allocation_timeout_ms, enable_verification, wait_for_completion
+    return (
+        pinned_allocation_timeout_ms,
+        enable_verification,
+        wait_for_completion,
+        region_backed_mode,
+    )
 
 
 __all__ = [

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import threading
 import time
@@ -13,7 +14,9 @@ import torch
 from opentelemetry.trace import Status, StatusCode
 
 from tensorcast.api import _metrics as store_metrics
-from tensorcast.api._config import GetArtifactOptions
+from tensorcast.api import _region_cache as region_cache
+from tensorcast.api._config import GetArtifactOptions, RegionBackedMode
+from tensorcast.api._device import device_uuid_for
 from tensorcast.api._materialize import (
     MaterializationPayload,
     materialize_artifact_v2,
@@ -34,6 +37,7 @@ from tensorcast.api.store.retry import (
 from tensorcast.api.store.runtime import StoreRuntimeContext
 from tensorcast.api.store.types import (
     ArtifactError,
+    CanonicalIndex,
     FallbackOptions,
     SpanAttributeValue,
 )
@@ -43,6 +47,7 @@ from tensorcast.api.store.views import (
     ViewOrchestrator,
 )
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
+from tensorcast.proto.daemon.v2 import store_daemon_pb2 as store_daemon_v2_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -348,6 +353,45 @@ class MaterializationPipeline:
         view_index_hint: bytes | None = None,
         replica_uuid: str | None = None,
     ) -> None:
+        options = self._apply_client_defaults(
+            self._build_get_options(fallback, options)
+        )
+        start_time = time.monotonic()
+        try:
+            if self._maybe_region_backed_into(
+                target=target,
+                artifact_id=artifact_id,
+                key=key,
+                device_id=self._resolve_device_selector(device, fallback),
+                fallback=fallback,
+                options=options,
+                tensor_names=tensor_names,
+                view=view_spec,
+                view_id=None,
+            ):
+                store_metrics.observe_latency(
+                    "get_into",
+                    self._runtime.daemon_endpoint,
+                    "OK",
+                    time.monotonic() - start_time,
+                    selection="region_backed",
+                )
+                return
+        except ArtifactError as exc:
+            store_metrics.observe_latency(
+                "get_into",
+                self._runtime.daemon_endpoint,
+                exc.status_code,
+                time.monotonic() - start_time,
+                selection="region_backed",
+            )
+            store_metrics.increment_error(
+                "get_into",
+                self._runtime.daemon_endpoint,
+                exc.status_code,
+                selection="region_backed",
+            )
+            raise
         payload, device_id = self._perform_get_with_retry(
             artifact_id=artifact_id,
             key=key,
@@ -389,13 +433,60 @@ class MaterializationPipeline:
         options: GetArtifactOptions | None = None,
         tensor_names: Sequence[str] | None = None,
     ) -> ArtifactFuture[None]:
+        options = self._apply_client_defaults(
+            self._build_get_options(fallback, options)
+        )
         cancel_event = threading.Event()
         mat_lock = threading.Lock()
         mat_ref: dict[str, MaterializationPayload | None] = {"value": None}
+        region_backed_lock = threading.Lock()
+        region_backed_state: dict[str, bool] = {"started": False}
+
+        def _mark_region_backed_started() -> None:
+            with region_backed_lock:
+                region_backed_state["started"] = True
 
         def _task() -> None:
             materialized: MaterializationPayload | None = None
             try:
+                if not cancel_event.is_set():
+                    start_time = time.monotonic()
+                    try:
+                        if self._maybe_region_backed_into(
+                            target=target,
+                            artifact_id=artifact_id,
+                            key=key,
+                            device_id=self._resolve_device_selector(device, fallback),
+                            fallback=fallback,
+                            options=options,
+                            tensor_names=tensor_names,
+                            view=None,
+                            view_id=None,
+                            mark_started=_mark_region_backed_started,
+                        ):
+                            store_metrics.observe_latency(
+                                "get_into",
+                                self._runtime.daemon_endpoint,
+                                "OK",
+                                time.monotonic() - start_time,
+                                selection="region_backed",
+                            )
+                            return
+                    except ArtifactError as exc:
+                        store_metrics.observe_latency(
+                            "get_into",
+                            self._runtime.daemon_endpoint,
+                            exc.status_code,
+                            time.monotonic() - start_time,
+                            selection="region_backed",
+                        )
+                        store_metrics.increment_error(
+                            "get_into",
+                            self._runtime.daemon_endpoint,
+                            exc.status_code,
+                            selection="region_backed",
+                        )
+                        raise
                 materialized, device_id = self._perform_get_with_retry(
                     artifact_id=artifact_id,
                     key=key,
@@ -458,6 +549,9 @@ class MaterializationPipeline:
         def _cancel() -> bool:
             if cancel_event.is_set():
                 return False
+            with region_backed_lock:
+                if region_backed_state["started"]:
+                    return False
             cancel_event.set()
             with mat_lock:
                 materialized = mat_ref["value"]
@@ -686,6 +780,358 @@ class MaterializationPipeline:
         options_override: GetArtifactOptions | None,
     ) -> GetArtifactOptions:
         return options_override or GetArtifactOptions()
+
+    def _apply_client_defaults(self, options: GetArtifactOptions) -> GetArtifactOptions:
+        from tensorcast.api._runtime import apply_client_load_defaults_if_present
+
+        (
+            pinned_ms,
+            enable_ver,
+            wait_for_completion,
+            region_backed_mode,
+        ) = apply_client_load_defaults_if_present(
+            options.pinned_allocation_timeout_ms,
+            options.enable_verification,
+            options.wait_for_completion,
+            options.region_backed_mode,
+            runtime_address=self._runtime.daemon_endpoint,
+        )
+        return options.model_copy(
+            update={
+                "pinned_allocation_timeout_ms": pinned_ms,
+                "enable_verification": enable_ver,
+                "wait_for_completion": wait_for_completion,
+                "region_backed_mode": region_backed_mode,
+            }
+        )
+
+    def _build_region_backed_layout(
+        self,
+        *,
+        canonical_index: CanonicalIndex,
+        canonical_index_bytes: bytes,
+        target: Mapping[str, torch.Tensor],
+        device_id: int,
+    ) -> tuple[store_daemon_v2_pb2.TargetLayout, str, int]:
+        entries_by_name = {entry.name: entry for entry in canonical_index.entries}
+        if not entries_by_name:
+            raise ArtifactError(
+                "Canonical index is empty",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        if set(entries_by_name.keys()) != set(target.keys()):
+            raise ArtifactError(
+                "Target tensors must include every canonical entry for region-backed get_into",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        storage_base_ptr: int | None = None
+        logical_total_size = 0
+        offsets: list[store_daemon_v2_pb2.TargetTensorOffset] = []
+        for entry in canonical_index.entries:
+            tensor = target.get(entry.name)
+            if tensor is None:
+                raise ArtifactError(
+                    f"Target tensor '{entry.name}' missing",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            if not tensor.is_cuda:
+                raise ArtifactError(
+                    f"Target tensor '{entry.name}' must be CUDA",
+                    status_code="FAILED_PRECONDITION",
+                    retryable=False,
+                )
+            if (tensor.device.index or 0) != device_id:
+                raise ArtifactError(
+                    f"Target tensor '{entry.name}' on cuda:{tensor.device.index or 0}, expected cuda:{device_id}",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            if not tensor.is_contiguous():
+                raise ArtifactError(
+                    f"Target tensor '{entry.name}' is not contiguous",
+                    status_code="FAILED_PRECONDITION",
+                    retryable=False,
+                )
+            if tensor.dtype != entry.dtype:
+                raise ArtifactError(
+                    f"Target tensor '{entry.name}' dtype {tensor.dtype} != {entry.dtype}",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            if tuple(tensor.shape) != tuple(entry.shape):
+                raise ArtifactError(
+                    f"Target tensor '{entry.name}' shape {tuple(tensor.shape)} != {entry.shape}",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            if tuple(tensor.stride()) != tuple(entry.stride):
+                raise ArtifactError(
+                    f"Target tensor '{entry.name}' stride {tuple(tensor.stride())} != {entry.stride}",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            if entry.segment_offset != entry.storage_offset:
+                raise ArtifactError(
+                    "Canonical layout is not COALESCED; region-backed get_into requires coalesced offsets",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            logical_offset = int(entry.segment_offset)
+            logical_total_size = max(
+                logical_total_size, logical_offset + int(entry.size_bytes)
+            )
+            base_ptr = int(tensor.data_ptr()) - logical_offset
+            if storage_base_ptr is None:
+                storage_base_ptr = base_ptr
+            elif storage_base_ptr != base_ptr:
+                raise ArtifactError(
+                    "Target tensors do not share a coalesced base pointer",
+                    status_code="FAILED_PRECONDITION",
+                    retryable=False,
+                )
+            offsets.append(
+                store_daemon_v2_pb2.TargetTensorOffset(
+                    name=entry.name,
+                    storage_id="",
+                    storage_offset=logical_offset,
+                    logical_length=int(entry.size_bytes),
+                )
+            )
+        if storage_base_ptr is None:
+            raise ArtifactError(
+                "Target tensors missing base pointer",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        region = region_cache.find_region_for(
+            device_id, storage_base_ptr, logical_total_size
+        )
+        if region is None:
+            raise ArtifactError(
+                "No registered region covers the target tensors",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        region_base_offset = int(storage_base_ptr) - int(region.base_ptr)
+        storage_id = f"storage:{device_id}:{storage_base_ptr:x}:{logical_total_size}"
+        for entry in offsets:
+            entry.storage_id = storage_id
+        layout = store_daemon_v2_pb2.TargetLayout(
+            layout_kind=store_daemon_v2_pb2.TargetLayout.LAYOUT_KIND_COALESCED_UNSPECIFIED,
+            index_kind=store_daemon_v2_pb2.TargetLayout.INDEX_KIND_CANONICAL_UNSPECIFIED,
+            tensor_spec_kind=store_daemon_v2_pb2.TargetLayout.TENSOR_SPEC_KIND_OFFSETS,
+        )
+        layout.storages.add(
+            storage_id=storage_id,
+            device_id=int(device_id),
+            storage_length=int(logical_total_size),
+            vram_region_id=region.region_id,
+            region_base_offset=int(region_base_offset),
+        )
+        layout.offsets.extend(offsets)
+        digest = hashlib.sha256()
+        digest.update(canonical_index_bytes)
+        digest.update(b"|canonical")
+        layout.logical_layout_hash = digest.digest()
+        return layout, region.region_id, logical_total_size
+
+    def _materialize_into_target(
+        self,
+        *,
+        target: dict[str, torch.Tensor],
+        artifact_id: str,
+        device_id: int,
+        fallback: FallbackOptions | None,
+        options: GetArtifactOptions,
+        span=None,
+    ) -> None:
+        if not artifact_id:
+            raise ArtifactError(
+                "artifact_id is required for region-backed get_into",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        cached_entry = self._runtime.get_artifact_index_cached(artifact_id)
+        if cached_entry is not None:
+            canonical_bytes = cached_entry.canonical_index_bytes
+            canonical_index = cached_entry.parsed_index
+        else:
+            client = self._runtime.ensure_client()
+            canonical_bytes = client.get_artifact_index_by_id(artifact_id)
+            canonical_index = canonical_index_from_bytes(canonical_bytes)
+            cache_entry = ArtifactCacheEntry(
+                artifact_id=artifact_id,
+                canonical_index_bytes=canonical_bytes,
+                parsed_index=canonical_index,
+                generation=None,
+                disk_path=None,
+                expires_at=time.monotonic(),
+            )
+            self._runtime.cache_artifact_index(cache_entry)
+
+        layout, region_id, _ = self._build_region_backed_layout(
+            canonical_index=canonical_index,
+            canonical_index_bytes=canonical_bytes,
+            target=target,
+            device_id=device_id,
+        )
+
+        preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO
+        disk_path: str | None = None
+        if fallback is not None:
+            if fallback.prefer == "p2p":
+                preference = (
+                    store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_P2P
+                )
+            elif fallback.prefer == "disk":
+                preference = (
+                    store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
+                )
+            disk_path = fallback.disk_path
+        if (
+            disk_path
+            and preference == store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO
+        ):
+            preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
+
+        client = self._runtime.ensure_client()
+        try:
+            response = client.materialize_into_target_v2(
+                artifact_id=artifact_id,
+                target_layout=layout,
+                device_uuid=device_uuid_for(device_id),
+                preference=preference,
+                disk_path=disk_path,
+            )
+        except Exception as exc:  # noqa: BLE001
+            error = map_materialization_error(exc)
+            if error.status_code in {"DATA_LOSS", "FAILED_PRECONDITION"}:
+                region_cache.unregister_region(region_id)
+            raise ArtifactError(
+                str(error),
+                status_code=error.status_code,
+                retryable=False,
+            ) from exc
+        if (
+            response.status
+            != store_daemon_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_ALLOCATED
+        ):
+            region_cache.unregister_region(region_id)
+            raise ArtifactError(
+                "MaterializeIntoTarget returned non-success status",
+                status_code="DATA_LOSS",
+                retryable=False,
+            )
+        store_metrics.record_region_backed_verification_skipped(
+            self._runtime.daemon_endpoint
+        )
+        return None
+
+    def _maybe_region_backed_into(
+        self,
+        *,
+        target: dict[str, torch.Tensor],
+        artifact_id: str | None,
+        key: str | None,
+        device_id: int,
+        fallback: FallbackOptions | None,
+        options: GetArtifactOptions,
+        tensor_names: Sequence[str] | None,
+        view: store_daemon_pb2.ViewSpec | None,
+        view_id: str | None,
+        span=None,
+        mark_started: Callable[[], None] | None = None,
+    ) -> bool:
+        mode = options.region_backed_mode
+        if mode is RegionBackedMode.DISABLE:
+            return False
+        capabilities = self._runtime.capabilities
+        if not capabilities or not capabilities.supports_region_backed_get_into:
+            if mode is RegionBackedMode.REQUIRE:
+                raise ArtifactError(
+                    "Store daemon does not support region-backed get_into",
+                    status_code="FAILED_PRECONDITION",
+                    retryable=False,
+                )
+            store_metrics.record_region_backed_fallback(
+                self._runtime.daemon_endpoint, "capability_missing"
+            )
+            return False
+        if key is not None:
+            if mode is RegionBackedMode.REQUIRE:
+                raise ArtifactError(
+                    "region_backed_mode requires artifact_id (key not supported)",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            store_metrics.record_region_backed_fallback(
+                self._runtime.daemon_endpoint, "key_not_supported"
+            )
+            return False
+        if not artifact_id:
+            if mode is RegionBackedMode.REQUIRE:
+                raise ArtifactError(
+                    "region_backed_mode requires artifact_id",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            store_metrics.record_region_backed_fallback(
+                self._runtime.daemon_endpoint, "missing_artifact_id"
+            )
+            return False
+        if view is not None or view_id is not None:
+            if mode is RegionBackedMode.REQUIRE:
+                raise ArtifactError(
+                    "region_backed_mode does not support view/view_id",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            store_metrics.record_region_backed_fallback(
+                self._runtime.daemon_endpoint, "view_not_supported"
+            )
+            return False
+        if tensor_names is not None:
+            cached = self._runtime.get_artifact_index_cached(artifact_id)
+            if cached is not None:
+                canonical_names = {entry.name for entry in cached.parsed_index.entries}
+                if set(tensor_names) != canonical_names:
+                    if mode is RegionBackedMode.REQUIRE:
+                        raise ArtifactError(
+                            "region_backed_mode requires full tensor layout",
+                            status_code="INVALID_ARGUMENT",
+                            retryable=False,
+                        )
+                    store_metrics.record_region_backed_fallback(
+                        self._runtime.daemon_endpoint, "subset_not_supported"
+                    )
+                    return False
+        try:
+            if mark_started is not None:
+                mark_started()
+            self._materialize_into_target(
+                target=target,
+                artifact_id=artifact_id,
+                device_id=device_id,
+                fallback=fallback,
+                options=options,
+                span=span,
+            )
+        except ArtifactError:
+            if mode is RegionBackedMode.REQUIRE:
+                raise
+            store_metrics.record_region_backed_fallback(
+                self._runtime.daemon_endpoint, "layout_mismatch"
+            )
+            if span is not None:
+                span.add_event(
+                    "store.region_backed.fallback",
+                    {"tc.store.reason": "layout_mismatch"},
+                )
+            return False
+        return True
 
     def _materialize(
         self,

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -917,8 +917,8 @@ class MaterializationPipeline:
             )
         region_base_offset = int(storage_base_ptr) - int(region.base_ptr)
         storage_id = f"storage:{device_id}:{storage_base_ptr:x}:{logical_total_size}"
-        for entry in offsets:
-            entry.storage_id = storage_id
+        for offset_entry in offsets:
+            offset_entry.storage_id = storage_id
         layout = store_daemon_v2_pb2.TargetLayout(
             layout_kind=store_daemon_v2_pb2.TargetLayout.LAYOUT_KIND_COALESCED_UNSPECIFIED,
             index_kind=store_daemon_v2_pb2.TargetLayout.INDEX_KIND_CANONICAL_UNSPECIFIED,

--- a/tensorcast/api/store/runtime.py
+++ b/tensorcast/api/store/runtime.py
@@ -13,6 +13,7 @@ import uuid
 import weakref
 from collections.abc import Callable
 from contextlib import contextmanager
+from dataclasses import replace
 from typing import Iterator, Mapping
 
 from opentelemetry import trace
@@ -137,6 +138,7 @@ class StoreRuntimeContext:
             artifact_chunk_bytes=0,
             supports_coalesced=False,
             supports_lease=False,
+            supports_region_backed_get_into=False,
             server_config=None,
         )
 
@@ -152,6 +154,7 @@ class StoreRuntimeContext:
             artifact_chunk_bytes=artifact_chunk,
             supports_coalesced=supports_coalesced,
             supports_lease=supports_lease,
+            supports_region_backed_get_into=False,
             server_config=config if isinstance(config, ServerConfig) else None,
         )
 
@@ -213,6 +216,9 @@ class StoreRuntimeContext:
             "artifact_chunk_bytes": int(capabilities.artifact_chunk_bytes),
             "supports_coalesced": bool(capabilities.supports_coalesced),
             "supports_lease": bool(capabilities.supports_lease),
+            "supports_region_backed_get_into": bool(
+                capabilities.supports_region_backed_get_into
+            ),
         }
         if capabilities.server_config is not None:
             try:
@@ -387,6 +393,24 @@ class StoreRuntimeContext:
             )
         else:
             capabilities = self._capabilities_from_config(config)
+        try:
+            mat_caps = client.get_materialize_capabilities()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "store.materialize_capabilities_fetch_failed",
+                extra={
+                    "tc.store.daemon": self._daemon_endpoint,
+                    "tc.store.session_id": self._session_id,
+                },
+                exc_info=exc,
+            )
+        else:
+            capabilities = replace(
+                capabilities,
+                supports_region_backed_get_into=bool(
+                    getattr(mat_caps, "supports_region_backed_get_into", False)
+                ),
+            )
         self._capabilities = capabilities
         self._update_session_record(capabilities=capabilities, activity=True)
         self._record_session_start(capabilities)
@@ -396,6 +420,9 @@ class StoreRuntimeContext:
                 "tx_slice_bytes": str(capabilities.tx_slice_bytes),
                 "supports_coalesced": str(capabilities.supports_coalesced),
                 "supports_lease": str(capabilities.supports_lease),
+                "supports_region_backed_get_into": str(
+                    capabilities.supports_region_backed_get_into
+                ),
             }
         )
 

--- a/tensorcast/api/store/types.py
+++ b/tensorcast/api/store/types.py
@@ -225,6 +225,7 @@ class StoreCapabilities:
     artifact_chunk_bytes: int
     supports_coalesced: bool
     supports_lease: bool
+    supports_region_backed_get_into: bool
     server_config: ServerConfig | None = None
 
 

--- a/tensorcast/client_runtime.py
+++ b/tensorcast/client_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from tensorcast.api._config import RegionBackedMode
 from tensorcast.proto.config.v1 import client_config_pb2 as cc_pb2
 
 _CLIENT_CFG: Optional[cc_pb2.ClientConfig] = None
@@ -37,8 +38,22 @@ def daemon_target_default() -> Optional[str]:
     return None
 
 
-def client_defaults() -> tuple[Optional[int], Optional[bool], Optional[bool]]:
-    """Return (pinned_allocation_timeout_ms, enable_verification, wait_for_completion)."""
+def _region_backed_mode_from_proto(
+    value: int,
+) -> RegionBackedMode | None:
+    if value == cc_pb2.RegionBackedMode.REGION_BACKED_MODE_AUTO:
+        return RegionBackedMode.AUTO
+    if value == cc_pb2.RegionBackedMode.REGION_BACKED_MODE_REQUIRE:
+        return RegionBackedMode.REQUIRE
+    if value == cc_pb2.RegionBackedMode.REGION_BACKED_MODE_DISABLED:
+        return RegionBackedMode.DISABLE
+    return None
+
+
+def client_defaults() -> tuple[
+    Optional[int], Optional[bool], Optional[bool], RegionBackedMode | None
+]:
+    """Return (pinned_allocation_timeout_ms, enable_verification, wait_for_completion, region_backed_mode)."""
     if _CLIENT_CFG and _CLIENT_CFG.HasField("defaults"):
         d = _CLIENT_CFG.defaults
         timeout_ms = (
@@ -49,5 +64,6 @@ def client_defaults() -> tuple[Optional[int], Optional[bool], Optional[bool]]:
             timeout_ms if timeout_ms > 0 else None,
             d.enable_verification,
             d.wait_for_completion,
+            _region_backed_mode_from_proto(d.region_backed_mode),
         )
-    return (None, None, None)
+    return (None, None, None, None)

--- a/tensorcast/daemon_ctl.py
+++ b/tensorcast/daemon_ctl.py
@@ -539,8 +539,66 @@ class DaemonCtl:
                 if e.code() == grpc.StatusCode.UNIMPLEMENTED:
                     return store_daemon_v2_pb2.GetMaterializeCapabilitiesResponse(
                         supports_view_subset_hash=False,
+                        supports_region_backed_get_into=False,
                     )
                 raise RuntimeError("GetMaterializeCapabilities failed") from e
+        return response
+
+    def materialize_into_target_v2(
+        self,
+        *,
+        artifact_id: str,
+        target_layout: store_daemon_v2_pb2.TargetLayout,
+        device_uuid: str,
+        preference: store_daemon_pb2.SourcePreference | None = None,
+        disk_path: str | None = None,
+        pid: int | None = None,
+        return_response: bool = True,
+    ) -> store_daemon_v2_pb2.MaterializeIntoTargetResponse:
+        if not artifact_id:
+            raise ValueError("artifact_id is required")
+        if not device_uuid:
+            raise ValueError("device_uuid is required")
+        pid_value = self._get_effective_pid() if pid is None else int(pid)
+        with self._client_span("Client/MaterializeIntoTarget") as span:
+            request = store_daemon_v2_pb2.MaterializeIntoTargetRequest(
+                artifact_id=artifact_id,
+                target_layout=target_layout,
+                device_uuid=device_uuid,
+                pid=pid_value,
+                preference=preference
+                if preference is not None
+                else store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO,
+            )
+            if disk_path:
+                request.disk_fallback.disk_path = disk_path
+                request.disk_fallback.verify_checksums = True
+            try:
+                response: store_daemon_v2_pb2.MaterializeIntoTargetResponse = (
+                    self._unary_call(
+                        self.stub_v2.MaterializeIntoTarget,
+                        request,
+                        timeout=60,
+                        span=span,
+                        retries=1,
+                    )
+                )
+            except grpc.RpcError as e:  # noqa: BLE001
+                span.record_exception(e)
+                code = e.code()
+                if code == grpc.StatusCode.UNAVAILABLE:
+                    raise RuntimeError(
+                        f"Local StoreDaemon ({self.server_address}) is not available."
+                    ) from e
+                if code == grpc.StatusCode.NOT_FOUND:
+                    raise RuntimeError(
+                        f"Artifact id '{artifact_id}' was not found by StoreDaemon at {self.server_address}."
+                    ) from e
+                raise RuntimeError(f"Error: {e}") from e
+        if not return_response:
+            raise RuntimeError(
+                "materialize_into_target_v2 requires return_response=True"
+            )
         return response
 
     def query_replica_status(

--- a/tests/python/api/test_materialization_pipeline_v2.py
+++ b/tests/python/api/test_materialization_pipeline_v2.py
@@ -17,7 +17,12 @@ from tensorcast.api.store.cache import ArtifactCache, ArtifactCacheEntry
 from tensorcast.api.store.common import canonical_index_from_bytes
 from tensorcast.api.store.materialization import MaterializationPipeline
 from tensorcast.api.store.retry import build_retry_policies
-from tensorcast.api.store.types import ArtifactError, FallbackOptions, StoreOptions
+from tensorcast.api.store.types import (
+    ArtifactError,
+    FallbackOptions,
+    StoreCapabilities,
+    StoreOptions,
+)
 from tensorcast.api.store.views import ViewOrchestrator
 from tensorcast.proto.daemon.v1 import store_daemon_pb2
 from tensorcast.proto.daemon.v2 import store_daemon_pb2 as store_daemon_v2_pb2
@@ -114,6 +119,15 @@ class _RuntimeStub:
         self._artifact_cache = ArtifactCache(
             daemon_endpoint="daemon", ttl_seconds=10, max_entries=8
         )
+        self._capabilities = StoreCapabilities(
+            mem_pool_bytes=0,
+            tx_slice_bytes=0,
+            artifact_chunk_bytes=0,
+            supports_coalesced=False,
+            supports_lease=False,
+            supports_region_backed_get_into=False,
+            server_config=None,
+        )
 
     def track_future(self, future: concurrent.futures.Future[object]) -> None:
         self.futures.append(future)
@@ -137,6 +151,10 @@ class _RuntimeStub:
         self, *, key: str
     ) -> tuple[str | None, str | None]:  # pragma: no cover - noop
         return None, None
+
+    @property
+    def capabilities(self) -> StoreCapabilities:
+        return self._capabilities
 
     @contextmanager
     def operation_span(self, *_args, **_kwargs):

--- a/tests/python/cli/test_runtime_orchestrator.py
+++ b/tests/python/cli/test_runtime_orchestrator.py
@@ -172,10 +172,27 @@ def test_runtime_start_injects_global_store(monkeypatch):
 def test_runtime_stop_cascades_global_store(monkeypatch):
     stop_calls: dict[str, Any] = {}
 
+    def _fake_start_global_store(**_kwargs):
+        return SimpleNamespace(
+            id="gs-own",
+            pid=1111,
+            address="127.0.0.1:50051",
+            listen_host="127.0.0.1",
+            listen_port=50051,
+            metrics_port=8000,
+            logs_dir=None,
+            cluster_token="tok-1",
+            db_file=None,
+            owner=True,
+        )
+
     def _fake_stop_global_store(**kwargs):
         stop_calls["session_id"] = kwargs.get("session_id")
         stop_calls["force"] = kwargs.get("force")
 
+    monkeypatch.setattr(
+        runtime.global_store_manager, "start_global_store", _fake_start_global_store
+    )
     monkeypatch.setattr(
         runtime.global_store_manager, "stop_global_store", _fake_stop_global_store
     )

--- a/tests/python/test_store_pipelines_unit.py
+++ b/tests/python/test_store_pipelines_unit.py
@@ -26,6 +26,7 @@ from tensorcast.api.store.types import (
     ArtifactError,
     FallbackOptions,
     RetryPolicy,
+    StoreCapabilities,
     StoreOptions,
 )
 from tensorcast.api.store.views import ViewOrchestrator
@@ -120,16 +121,16 @@ class _DummyRuntime:
         yield _DummySpan()
 
     @property
-    def capabilities(self):
-        class _Caps:
-            mem_pool_bytes = 0
-            tx_slice_bytes = 0
-            artifact_chunk_bytes = 0
-            supports_coalesced = False
-            supports_lease = False
-            server_config = None
-
-        return _Caps()
+    def capabilities(self) -> StoreCapabilities:
+        return StoreCapabilities(
+            mem_pool_bytes=0,
+            tx_slice_bytes=0,
+            artifact_chunk_bytes=0,
+            supports_coalesced=False,
+            supports_lease=False,
+            supports_region_backed_get_into=False,
+            server_config=None,
+        )
 
     def close(self) -> None:
         self.executor.shutdown(wait=True)

--- a/third_party/glog/patches/0001-export-macros.patch
+++ b/third_party/glog/patches/0001-export-macros.patch
@@ -1,0 +1,36 @@
+diff --git a/src/glog/logging.h b/src/glog/logging.h
+index 0e9d3e4..7c0ac1a 100644
+--- a/src/glog/logging.h
++++ b/src/glog/logging.h
+@@ -52,6 +52,13 @@
+ #if defined(GLOG_USE_GLOG_EXPORT)
+ #  include "glog/export.h"
+ #endif
++
++#if !defined(_WIN32)
++#undef GLOG_EXPORT
++#undef GLOG_NO_EXPORT
++#define GLOG_EXPORT __attribute__((visibility("default")))
++#define GLOG_NO_EXPORT __attribute__((visibility("default")))
++#endif
+
+ #if !defined(GLOG_EXPORT) || !defined(GLOG_NO_EXPORT)
+ #  error <glog/logging.h> was not included correctly. See the documentation for how to consume the library.
+ #endif
+diff --git a/src/glog/flags.h b/src/glog/flags.h
+index 02d63c0..2d96d10 100644
+--- a/src/glog/flags.h
++++ b/src/glog/flags.h
+@@ -36,6 +36,11 @@
+ #if defined(GLOG_USE_GLOG_EXPORT)
+ #  include "glog/export.h"
+ #endif
++
++#if !defined(_WIN32)
++#undef GLOG_EXPORT
++#define GLOG_EXPORT __attribute__((visibility("default")))
++#endif
+
+ #if !defined(GLOG_EXPORT)
+ #  error <glog/flags.h> was not included correctly. See the documentation for how to consume the library.
+ #endif

--- a/third_party/glog/patches/BUILD
+++ b/third_party/glog/patches/BUILD
@@ -1,0 +1,1 @@
+exports_files(["0001-export-macros.patch"])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables region‑backed into (no daemon VRAM allocation) that streams bytes directly into client‑registered CUDA regions.
> 
> - **Proto/API**: Adds v2 `MaterializeIntoTarget` RPC, `TargetLayout`/`TargetTensorOffset`, and `supports_region_backed_get_into`; config adds `RegionBackedMode` default
> - **Daemon**: Wires new RPC; implements strict request validation (canonical, coalesced, single storage, full coverage, device UUID); integrates `IpcRegionRegistry` with poison state and bounds checks; maps CUDA IPC and delegates to engine; exposes metrics for result/reason and verification skipped
> - **Core**: Adds `StoreEngine::materialize_into_target` and facade implementation that builds segment plans from canonical index and pumps ranges into `GpuMemorySink`; caches plans; returns `MaterializeIntoTargetResult`
> - **SDK (Python)**: Attempts region‑backed `get_into` first (gated by capability and `RegionBackedMode`), builds/coalesces target layout from tensors, falls back on mismatch, records metrics; updates client defaults plumb‑through
> - **Tests/Docs**: New validation and region‑poison tests; extensive docs (design 0042, dataflow, READMEs)
> - **Build**: Adds `glog` dep with patch; minor include/BUILD updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d42be7da827bc58d09a6273ad8be7c2c3700aaa1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->