### PR TITLE
refactor(daemon): enforce shared disk root for disk paths and remove fallback directory

### DIFF
--- a/core/store/README.md
+++ b/core/store/README.md
@@ -110,12 +110,12 @@ graph TB
 ## Public API Surface (StoreEngine)
 
 - Construction: `StoreEngine::StoreEngine(const StoreEngineOptions& opts)`
-  - Configures `storage_path`, pinned pool size/chunk size, UMA chunk size, and optional `CommunicationManager` and `GlobalStore` address.
+  - Configures the shared `storage_path` root, pinned pool size/chunk size, UMA chunk size, and optional `CommunicationManager` and `GlobalStore` address.
 
 - Materialization (multi-device):
   - `absl::StatusOr<loading::ReplicaHandle> materialize_replica(const DeviceKey&, MaterializeMode, const MaterializeHints&)`
   - Modes:
-    - `AUTO`: Uses `MaterializeOrchestrator` to request a P2P transport from Global Store. If `hints.disk_path` is populated it will fall back to disk; when `disk_path` is empty the orchestrator now returns the transport status directly (no implicit fallback).
+    - `AUTO`: Uses `MaterializeOrchestrator` to request a P2P transport from Global Store. If `hints.disk_path` is populated it will fall back to disk unless `hints.source_preference` is `PREFER_P2P`; when `disk_path` is empty the orchestrator returns the transport status directly (no implicit fallback).
     - `LOAD_ONLY`: Loads from disk only and requires `hints.disk_path`; when a content-addressed ID (`mi2:`) is provided it is validated against the on-disk `artifact_descriptor.json` to keep canonical identity aligned with the loaded replica.
     - `COPY_ONLY`: GPU→GPU copy from an already-loaded GPU instance; requires `hints.artifact_id` and a GPU target.
   - Safetensors disk fallback rebuilds canonical index JSON bytes and re-hashes them via `common::compute_index_multihash` so `mi2` identities stay stable even when the original `tensor_index.json` is absent.
@@ -123,7 +123,7 @@ graph TB
   - Variant-aware hints: populate `MaterializeHints::variant` (canonical id, optional view id/spec, placement) to request a view. The resulting `ReplicaKey` includes `view_id` so the registry differentiates canonical and variant replicas on the same device.
   - The staged ingestion pipeline emits structured events for each request; `TelemetryService` updates metrics/read-only snapshots, and `GlobalStorePublisher` registers successful loads with Global Store automatically so callers do not need to invoke the registration helper manually.
 
-  Note: In the key-based client flow (RFC‑0014), the Store Daemon is responsible for resolving the human key via Global Store and supplying `hints.artifact_id` and, when applicable, `hints.disk_path` (derived from key mapping). Clients do not pass `disk_path` directly; fallback is orchestrated entirely inside the daemon/engine.
+  Note: In the key-based client flow (RFC‑0014), the Store Daemon is responsible for resolving the human key via Global Store and supplying `hints.artifact_id` and, when applicable, `hints.disk_path` (canonicalized under the shared root). Clients do not pass `disk_path` directly; fallback is orchestrated entirely inside the daemon/engine.
 
 - In-memory registration (RFC-0006/0007):
   - `begin_register_artifact(const ArtifactRegistration&) -> RegistrationBeginResult`

--- a/core/store/materialization/runtime/pipeline/source_adapter.cc
+++ b/core/store/materialization/runtime/pipeline/source_adapter.cc
@@ -145,7 +145,9 @@ absl::Status P2PSourceAdapter::prepare(const P2PSource& source, IngestionContext
   P2PSource normalized = source;
   normalized.comm_engine =
       gsl::not_null<std::shared_ptr<communicator::engine::Communicator>>{comm_manager->get_shared_engine()};
-  normalized.fallback_disk_dir = ctx.options->p2p_fallback_disk_dir;
+  if (!ctx.hints.disk_path.empty() && ctx.hints.source_preference != loading::SourcePreference::kPreferP2P) {
+    normalized.fallback_disk_dir = ctx.hints.disk_path;
+  }
 
   ctx.p2p.source = std::move(normalized);
   return absl::OkStatus();

--- a/core/store/store_engine_options.h
+++ b/core/store/store_engine_options.h
@@ -82,10 +82,6 @@ struct StoreEngineOptions {
   // caller needing to set MaterializeHints::verify = FULL_DIGEST.
   bool force_full_digest_on_load{false};
 
-  // Optional on-disk fallback directory for P2P loads. When set, P2PLoader
-  // will mux remote source with the local disk partitions in this directory.
-  std::string p2p_fallback_disk_dir;
-
   // Stable/preemptible memory tier settings (optional). When unset, the
   // engine preserves legacy preemptible behavior.
   std::optional<MemoryTierConfig> memory_tier_config;

--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -710,6 +710,17 @@ cc_test(
 )
 
 cc_test(
+    name = "grpc_service_impl_publish_replica_key_test",
+    srcs = ["grpc_service_impl_publish_replica_key_test.cc"],
+    deps = [
+        ":grpc_service_impl",
+        "//core/store:store_engine",
+        "//proto/tensorcast/daemon/v1:daemon_grpc_cc",
+        "@catch2//:catch2_main",
+    ],
+)
+
+cc_test(
     name = "grpc_service_impl_disk_index_test",
     srcs = ["grpc_service_impl_disk_index_test.cc"],
     deps = [

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -21,7 +21,7 @@ The Store Daemon is the data-plane service process that exposes a stable gRPC AP
 - Observability wrappers that attach unified metrics and tracing to each RPC.
 - Handles view registration uploads (slice/transpose) without feature flags: `RegistrationController` streams view chunks to the StoreEngine and publishes variant telemetry through Global Store (see [Variant View Registration Telemetry](../docs/architecture/p2p-transfer-strategies.md#variant-view-registration-telemetry)).
 - Enforces non-loopback advertisement when registering with Global Store; startup fails if no routable IP can be determined and `--advertise_host` is unset.
-- Requires `server.storage_path` as a shared disk root; all `disk_path` inputs are canonicalized under this root and rejected when they escape it.
+- Requires `server.storage_path` as a shared disk root; the daemon canonicalizes this root on startup, and all `disk_path` inputs are canonicalized under it and rejected when they escape it.
 - Immediate reclaim: when the last UseLease retires and no PlacementPins remain for a daemon-owned GPU replica, the lifecycle finalizer unloads the replica immediately (best-effort).
 - Eviction consults lifecycle counters (use_count, placement_pins); request-level cache hints removed.
 - Join TTL via leases: duplicate coalesced commits (`existed=true`) create a TTL-bound UseLease for the owner PID. On expiry, the lease finalizer drops the lightweight RefTracker ref and may reclaim memory immediately.

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -21,6 +21,7 @@ The Store Daemon is the data-plane service process that exposes a stable gRPC AP
 - Observability wrappers that attach unified metrics and tracing to each RPC.
 - Handles view registration uploads (slice/transpose) without feature flags: `RegistrationController` streams view chunks to the StoreEngine and publishes variant telemetry through Global Store (see [Variant View Registration Telemetry](../docs/architecture/p2p-transfer-strategies.md#variant-view-registration-telemetry)).
 - Enforces non-loopback advertisement when registering with Global Store; startup fails if no routable IP can be determined and `--advertise_host` is unset.
+- Requires `server.storage_path` as a shared disk root; all `disk_path` inputs are canonicalized under this root and rejected when they escape it.
 - Immediate reclaim: when the last UseLease retires and no PlacementPins remain for a daemon-owned GPU replica, the lifecycle finalizer unloads the replica immediately (best-effort).
 - Eviction consults lifecycle counters (use_count, placement_pins); request-level cache hints removed.
 - Join TTL via leases: duplicate coalesced commits (`existed=true`) create a TTL-bound UseLease for the owner PID. On expiry, the lease finalizer drops the lightweight RefTracker ref and may reclaim memory immediately.

--- a/daemon/grpc_service_impl.cc
+++ b/daemon/grpc_service_impl.cc
@@ -6,10 +6,15 @@
 #include <unistd.h>
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <memory>
 #include <optional>
+#include <string_view>
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/time/time.h"
 #include "core/store/components/global_store_client.h"
@@ -23,6 +28,56 @@ namespace tensorcast::daemon {
 using ::grpc::Status;
 using ::grpc::StatusCode;
 using status_utils::to_grpc_status;
+
+namespace {
+
+bool path_has_prefix(const std::filesystem::path& path, const std::filesystem::path& prefix) {
+  auto path_it = path.begin();
+  for (auto prefix_it = prefix.begin(); prefix_it != prefix.end(); ++prefix_it, ++path_it) {
+    if (path_it == path.end() || *path_it != *prefix_it) {
+      return false;
+    }
+  }
+  return true;
+}
+
+absl::StatusOr<std::filesystem::path> normalize_disk_path(
+    std::string_view disk_path,
+    const std::filesystem::path& storage_root) {
+  if (storage_root.empty()) {
+    return absl::InvalidArgumentError("storage_path is required for disk materialization");
+  }
+  std::error_code ec;
+  std::filesystem::path candidate(disk_path);
+  if (!candidate.is_absolute()) {
+    candidate = storage_root / candidate;
+  }
+  auto normalized = std::filesystem::weakly_canonical(candidate, ec);
+  if (!ec) {
+    if (!path_has_prefix(normalized, storage_root)) {
+      return absl::InvalidArgumentError(
+          absl::StrCat(
+              "disk_path must resolve under storage_path: ",
+              normalized.string(),
+              " (root=",
+              storage_root.string(),
+              ")"));
+    }
+    return normalized;
+  }
+  normalized = candidate.lexically_normal();
+  if (normalized.empty()) {
+    return absl::ErrnoToStatus(ec.value(), "Failed to canonicalize disk_path");
+  }
+  if (!path_has_prefix(normalized, storage_root)) {
+    return absl::InvalidArgumentError(
+        absl::StrCat(
+            "disk_path must resolve under storage_path: ", normalized.string(), " (root=", storage_root.string(), ")"));
+  }
+  return normalized;
+}
+
+} // namespace
 
 absl::StatusOr<std::vector<uint8_t>> StoreDaemonServiceImpl::lip_copy_to_new_coalesced_int(
     int target_device_id,
@@ -74,8 +129,17 @@ Status StoreDaemonServiceImpl::PublishReplicaKey(
     return {grpc::StatusCode::UNAVAILABLE, "daemon is shutting down"};
   }
 
+  std::string normalized_disk_path;
+  if (!req->disk_path().empty()) {
+    auto normalized_or = normalize_disk_path(req->disk_path(), opts_.storage_path);
+    if (!normalized_or.ok()) {
+      return to_grpc_status(normalized_or.status());
+    }
+    normalized_disk_path = normalized_or->string();
+  }
+
   // Use engine's configured Global Store client for upsert.
-  auto up = engine_->upsert_key_mapping(req->key(), req->artifact_descriptor().artifact_id(), req->disk_path());
+  auto up = engine_->upsert_key_mapping(req->key(), req->artifact_descriptor().artifact_id(), normalized_disk_path);
   if (!up.ok()) {
     // For conflicts, return OK with ok=false for idempotency.
     if (absl::IsAlreadyExists(up)) {

--- a/daemon/grpc_service_impl.h
+++ b/daemon/grpc_service_impl.h
@@ -99,6 +99,16 @@ class StoreDaemonServiceImpl final : public v1::StoreDaemonService::Service {
         verif_tracker_(gsl::not_null<std::unique_ptr<VerificationTracker>>(std::make_unique<VerificationTracker>())),
         reg_mgr_(gsl::not_null<std::unique_ptr<RegistrationManager>>(std::make_unique<RegistrationManager>())),
         opts_(opts) {
+    if (!opts_.storage_path.empty()) {
+      std::error_code ec;
+      auto canonical = std::filesystem::weakly_canonical(opts_.storage_path, ec);
+      if (ec) {
+        ec.clear();
+        canonical = opts_.storage_path.lexically_normal();
+      }
+      opts_.storage_path = std::move(canonical);
+    }
+
     verif_tracker_->set_serial_executor(async_runtime_->serial_executor());
     start_sweepers();
     persistence_mgr_ = std::make_unique<PersistenceManager>(

--- a/daemon/grpc_service_impl.h
+++ b/daemon/grpc_service_impl.h
@@ -66,13 +66,14 @@ class StoreDaemonServiceImpl final : public v1::StoreDaemonService::Service {
     // Persistence
     std::filesystem::path persistence_log_path{"/tmp/tensorcast_persistence.log"};
 
+    // Shared storage root for disk paths (required).
+    std::filesystem::path storage_path;
+
     // API behavior flags
     // If true, GetLoadedReplicasV2 uses opaque cursor tokens based on a stable
     // ordering (artifact_id, device_id). If false (default), uses numeric
     // index tokens.
     bool use_cursor_pagination{false};
-
-    std::vector<std::filesystem::path> disk_path_whitelist;
   };
 
   explicit StoreDaemonServiceImpl(std::shared_ptr<store::StoreEngine> engine)
@@ -119,7 +120,7 @@ class StoreDaemonServiceImpl final : public v1::StoreDaemonService::Service {
         .regions = *region_registry_,
         .is_shutting_down = is_shutting_down_,
         .lifecycle = lifecycle_mgr_.get(),
-        .disk_path_whitelist = opts_.disk_path_whitelist};
+        .storage_path = opts_.storage_path};
     materialization_controller_ = std::make_unique<MaterializationController>(dep);
     RegistrationController::Dep rdep{
         .engine = *engine_,

--- a/daemon/grpc_service_impl_disk_index_test.cc
+++ b/daemon/grpc_service_impl_disk_index_test.cc
@@ -50,7 +50,10 @@ TEST_CASE(
   REQUIRE(tensorcast::testing::write_rfc0007_descriptor_for_standard_artifact_dir(artifact_dir).ok());
 
   auto engine = std::make_shared<tensorcast::store::StoreEngine>(make_opts());
-  StoreDaemonServiceImpl svc(engine);
+  StoreDaemonServiceImpl::Options svc_opts;
+  svc_opts.storage_path = test_tmpdir();
+  std::filesystem::create_directories(svc_opts.storage_path);
+  StoreDaemonServiceImpl svc(engine, svc_opts);
 
   tensorcast::daemon::v1::MaterializeReplicaRequest req;
   req.set_disk_path(artifact_dir.string());

--- a/daemon/grpc_service_impl_parity_test.cc
+++ b/daemon/grpc_service_impl_parity_test.cc
@@ -19,9 +19,15 @@ static tensorcast::store::StoreEngineOptions make_opts_basic() {
   return opts;
 }
 
+static StoreDaemonServiceImpl::Options make_service_opts() {
+  StoreDaemonServiceImpl::Options opts;
+  opts.storage_path = std::filesystem::temp_directory_path();
+  return opts;
+}
+
 TEST_CASE("DISK unload is idempotent success", "[daemon][parity]") {
   auto engine = std::make_shared<tensorcast::store::StoreEngine>(make_opts_basic());
-  StoreDaemonServiceImpl svc(engine);
+  StoreDaemonServiceImpl svc(engine, make_service_opts());
 
   tensorcast::daemon::v1::UnloadReplicaRequest req;
   req.set_disk_path("/tmp/does-not-matter");
@@ -35,7 +41,7 @@ TEST_CASE("DISK unload is idempotent success", "[daemon][parity]") {
 
 TEST_CASE("MaterializeReplica rejects while shutting down", "[daemon][parity]") {
   auto engine = std::make_shared<tensorcast::store::StoreEngine>(make_opts_basic());
-  StoreDaemonServiceImpl svc(engine);
+  StoreDaemonServiceImpl svc(engine, make_service_opts());
   svc.begin_shutdown();
 
   tensorcast::daemon::v1::MaterializeReplicaRequest req;
@@ -50,7 +56,7 @@ TEST_CASE("MaterializeReplica rejects while shutting down", "[daemon][parity]") 
 
 TEST_CASE("MaterializeReplica validates one-of inputs", "[daemon][parity]") {
   auto engine = std::make_shared<tensorcast::store::StoreEngine>(make_opts_basic());
-  StoreDaemonServiceImpl svc(engine);
+  StoreDaemonServiceImpl svc(engine, make_service_opts());
 
   // Both missing -> INVALID_ARGUMENT
   {
@@ -64,8 +70,9 @@ TEST_CASE("MaterializeReplica validates one-of inputs", "[daemon][parity]") {
 
   // Both present are accepted (may still fail deeper in the stack, but not on input validation)
   {
+    const auto storage_root = std::filesystem::temp_directory_path();
     tensorcast::daemon::v1::MaterializeReplicaRequest req;
-    req.set_disk_path("/tmp/x");
+    req.set_disk_path((storage_root / "x").string());
     req.set_artifact_id("mi2:abc:def");
     req.set_target_device_type(tensorcast::daemon::v1::DeviceType::DEVICE_TYPE_GPU);
     tensorcast::daemon::v1::MaterializeReplicaResponse resp;
@@ -75,14 +82,14 @@ TEST_CASE("MaterializeReplica validates one-of inputs", "[daemon][parity]") {
   }
 }
 
-TEST_CASE("MaterializeReplica enforces disk whitelist", "[daemon][parity]") {
+TEST_CASE("MaterializeReplica enforces shared storage root", "[daemon][parity]") {
   auto engine = std::make_shared<tensorcast::store::StoreEngine>(make_opts_basic());
-  StoreDaemonServiceImpl::Options opts;
-  opts.disk_path_whitelist = {std::filesystem::path("/allowed")};
+  StoreDaemonServiceImpl::Options opts = make_service_opts();
+  opts.storage_path = std::filesystem::temp_directory_path();
   StoreDaemonServiceImpl svc(engine, opts);
 
   tensorcast::daemon::v1::MaterializeReplicaRequest req;
-  req.set_disk_path("/denied/path");
+  req.set_disk_path("/var/denied/path");
   req.set_target_device_type(tensorcast::daemon::v1::DeviceType::DEVICE_TYPE_GPU);
   tensorcast::daemon::v1::MaterializeReplicaResponse resp;
   grpc::ServerContext ctx;
@@ -92,7 +99,7 @@ TEST_CASE("MaterializeReplica enforces disk whitelist", "[daemon][parity]") {
 
 TEST_CASE("WaitReplicaVerification unknown returns UNKNOWN", "[daemon][parity]") {
   auto engine = std::make_shared<tensorcast::store::StoreEngine>(make_opts_basic());
-  StoreDaemonServiceImpl svc(engine);
+  StoreDaemonServiceImpl svc(engine, make_service_opts());
 
   tensorcast::daemon::v1::WaitReplicaVerificationRequest req;
   req.set_artifact_id("nonexistent");

--- a/daemon/grpc_service_impl_publish_replica_key_test.cc
+++ b/daemon/grpc_service_impl_publish_replica_key_test.cc
@@ -1,0 +1,282 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include "daemon/grpc_service_impl.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+#include "core/store/store_engine.h"
+#include "grpcpp/server_context.h"
+
+using tensorcast::daemon::StoreDaemonServiceImpl;
+
+namespace {
+
+std::filesystem::path test_root() {
+  const char* env = std::getenv("TEST_TMPDIR");
+  if (env && *env) {
+    return std::filesystem::path(env) / "tensorcast_daemon_publish_replica_key_test";
+  }
+  return std::filesystem::temp_directory_path() / "tensorcast_daemon_publish_replica_key_test";
+}
+
+tensorcast::store::StoreEngineOptions make_engine_opts(const std::filesystem::path& storage_root) {
+  tensorcast::store::StoreEngineOptions opts;
+  opts.storage_path = storage_root.string();
+  std::filesystem::create_directories(storage_root);
+  opts.p2p_port = 0; // let the OS pick an ephemeral port during tests
+  opts.memory_pool_size = 32ULL << 20;
+  opts.tx_slice_bytes = 1ULL << 20;
+  opts.num_thread = 2;
+  opts.global_store_address.clear(); // explicit offline mode (test supplies a stub client)
+  return opts;
+}
+
+class KeyMappingGlobalStoreClient final : public tensorcast::store::components::IGlobalStoreClient {
+ public:
+  absl::Status initialize() override {
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::string> register_worker(
+      std::string_view,
+      std::string_view,
+      uint32_t,
+      uint32_t,
+      uint64_t,
+      uint64_t,
+      bool,
+      std::string_view) override {
+    return absl::UnimplementedError("register_worker not needed for key-mapping tests");
+  }
+
+  absl::Status send_heartbeat(std::string_view, uint64_t, bool) override {
+    return absl::UnimplementedError("send_heartbeat not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<tensorcast::global_store::v1::WorkerHeartbeatResponse> send_heartbeat_enhanced(
+      std::string_view,
+      uint64_t,
+      bool,
+      uint64_t,
+      std::string_view,
+      const std::vector<std::string>&,
+      int64_t,
+      tensorcast::global_store::v1::ConnectionStatus) override {
+    return absl::UnimplementedError("send_heartbeat_enhanced not needed for key-mapping tests");
+  }
+
+  absl::Status unregister_worker(std::string_view, bool) override {
+    return absl::UnimplementedError("unregister_worker not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<std::string> register_replica(
+      std::string_view,
+      std::string_view,
+      const tensorcast::store::DeviceKey&,
+      tensorcast::common::memory::MemoryLocation,
+      uint64_t,
+      uint32_t) override {
+    return absl::UnimplementedError("register_replica not needed for key-mapping tests");
+  }
+
+  absl::Status record_variant_residency(std::string_view, std::string_view, uint64_t, std::optional<std::string_view>)
+      override {
+    return absl::UnimplementedError("record_variant_residency not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<std::string> register_memory_replica(
+      std::string_view,
+      std::string_view,
+      const tensorcast::store::DeviceKey&,
+      uint64_t,
+      std::string_view,
+      const std::vector<std::string>&,
+      const std::vector<uint64_t>&,
+      const std::optional<std::string>&,
+      std::string_view,
+      std::string_view,
+      uint32_t,
+      const std::optional<std::string>&) override {
+    return absl::UnimplementedError("register_memory_replica not needed for key-mapping tests");
+  }
+
+  absl::Status unregister_replica(std::string_view, std::string_view) override {
+    return absl::UnimplementedError("unregister_replica not needed for key-mapping tests");
+  }
+
+  absl::Status unregister_replica_by_worker(
+      std::string_view,
+      std::string_view,
+      std::optional<tensorcast::common::memory::MemoryLocation>,
+      std::optional<uint32_t>) override {
+    return absl::UnimplementedError("unregister_replica_by_worker not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<tensorcast::store::components::TransportSession> request_replica_transport(
+      std::string_view,
+      std::string_view,
+      std::string_view,
+      uint32_t,
+      const tensorcast::store::DeviceKey&,
+      uint32_t) override {
+    return absl::UnimplementedError("request_replica_transport not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<tensorcast::store::components::TransportSession> request_view_transport(
+      std::string_view,
+      std::string_view,
+      std::string_view,
+      std::string_view,
+      uint32_t,
+      const tensorcast::store::DeviceKey&,
+      uint32_t) override {
+    return absl::UnimplementedError("request_view_transport not needed for key-mapping tests");
+  }
+
+  absl::Status complete_replica_transport(std::string_view) override {
+    return absl::UnimplementedError("complete_replica_transport not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<std::vector<tensorcast::store::components::RemoteReplicaInfo>> get_artifact_replicas(
+      std::string_view) override {
+    return absl::UnimplementedError("get_artifact_replicas not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<std::vector<tensorcast::store::components::ChunkLocationInfo>> query_chunk_locations(
+      std::string_view,
+      const std::vector<uint32_t>&) override {
+    return absl::UnimplementedError("query_chunk_locations not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<std::pair<uint64_t, std::string>> synchronize_worker_state(
+      const tensorcast::global_store::v1::WorkerLocalState&,
+      bool,
+      std::vector<tensorcast::global_store::v1::StateChange>*) override {
+    return absl::UnimplementedError("synchronize_worker_state not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<std::pair<uint64_t, std::string>> request_full_state_sync(
+      std::string_view,
+      uint64_t,
+      std::vector<tensorcast::common::v1::ReplicaInfo>*) override {
+    return absl::UnimplementedError("request_full_state_sync not needed for key-mapping tests");
+  }
+
+  bool is_connected() const override {
+    return true;
+  }
+
+  absl::Status batch_update_chunk_states(
+      std::string_view,
+      std::string_view,
+      const std::vector<tensorcast::store::components::ChunkStateUpdate>&) override {
+    return absl::UnimplementedError("batch_update_chunk_states not needed for key-mapping tests");
+  }
+
+  absl::StatusOr<tensorcast::store::components::KeyMapping> resolve_key_mapping(std::string_view key) override {
+    auto it = mappings_.find(std::string(key));
+    if (it == mappings_.end()) {
+      return absl::NotFoundError("key not found");
+    }
+    return it->second;
+  }
+
+  absl::StatusOr<std::string> get_artifact_index_by_id(std::string_view) override {
+    return absl::UnimplementedError("get_artifact_index_by_id not needed for key-mapping tests");
+  }
+
+  absl::Status upsert_key_mapping(
+      std::string_view key,
+      std::string_view artifact_id,
+      std::string_view disk_path,
+      absl::Duration) override {
+    tensorcast::store::components::KeyMapping mapping;
+    mapping.artifact_id = std::string(artifact_id);
+    mapping.disk_path = std::string(disk_path);
+    last_disk_path = mapping.disk_path;
+    mappings_[std::string(key)] = std::move(mapping);
+    return absl::OkStatus();
+  }
+
+  absl::Status revoke_key_mapping(std::string_view key) override {
+    mappings_.erase(std::string(key));
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<tensorcast::store::components::PlacementPlanResult> plan_placement(
+      std::string_view,
+      tensorcast::global_store::v1::PlacementPolicy,
+      const std::vector<tensorcast::store::components::PlacementShardSpec>&,
+      std::string_view) override {
+    return absl::UnimplementedError("plan_placement not needed for key-mapping tests");
+  }
+
+  absl::Status report_persistence_status(const tensorcast::store::components::PersistenceReport&) override {
+    return absl::UnimplementedError("report_persistence_status not needed for key-mapping tests");
+  }
+
+  void update_local_endpoint(std::string, std::string, uint32_t, uint32_t) override {}
+
+  absl::Status update_artifact_view_state(const tensorcast::store::components::VariantViewUpdate&) override {
+    return absl::UnimplementedError("update_artifact_view_state not needed for key-mapping tests");
+  }
+
+  std::string last_disk_path;
+
+ private:
+  std::unordered_map<std::string, tensorcast::store::components::KeyMapping> mappings_;
+};
+
+} // namespace
+
+TEST_CASE("PublishReplicaKey canonicalizes storage_path before validating disk_path", "[daemon][key-mapping][disk]") {
+  const auto root = test_root();
+  std::filesystem::remove_all(root);
+  std::filesystem::create_directories(root);
+
+  const auto storage_real = root / "storage_real";
+  const auto storage_link = root / "storage_link";
+  const auto storage_link_via_dotdot = root / "subdir" / ".." / "storage_link";
+  std::filesystem::create_directories(storage_real);
+  std::filesystem::create_directories(root / "subdir");
+
+  std::error_code ec;
+  std::filesystem::remove(storage_link, ec);
+  ec.clear();
+  std::filesystem::create_directory_symlink(storage_real, storage_link, ec);
+  REQUIRE_FALSE(ec);
+
+  const auto artifact_dir = storage_real / "artifact";
+  std::filesystem::create_directories(artifact_dir);
+
+  auto engine = std::make_shared<tensorcast::store::StoreEngine>(make_engine_opts(storage_real));
+  auto gs_client = std::make_shared<KeyMappingGlobalStoreClient>();
+  engine->set_global_store_client_for_testing(gs_client);
+
+  StoreDaemonServiceImpl::Options svc_opts;
+  svc_opts.storage_path = storage_link_via_dotdot;
+  StoreDaemonServiceImpl svc(engine, svc_opts);
+
+  tensorcast::daemon::v1::PublishReplicaKeyRequest req;
+  req.set_key("key-1");
+  req.mutable_artifact_descriptor()->set_artifact_id("mi2:test");
+  req.set_disk_path(artifact_dir.string());
+
+  grpc::ServerContext ctx;
+  tensorcast::daemon::v1::PublishReplicaKeyResponse resp;
+  auto status = svc.PublishReplicaKey(&ctx, &req, &resp);
+  REQUIRE(status.ok());
+  REQUIRE(resp.ok());
+
+  std::error_code canonical_ec;
+  const auto expected = std::filesystem::weakly_canonical(artifact_dir, canonical_ec);
+  REQUIRE_FALSE(canonical_ec);
+  REQUIRE(gs_client->last_disk_path == expected.string());
+}

--- a/daemon/materialize_into_target_validation_test.cc
+++ b/daemon/materialize_into_target_validation_test.cc
@@ -36,6 +36,11 @@ std::filesystem::path test_tmpdir() {
   return std::filesystem::temp_directory_path() / "tensorcast_daemon_materialize_into_target_test";
 }
 
+std::filesystem::path ensure_dir(std::filesystem::path path) {
+  std::filesystem::create_directories(path);
+  return path;
+}
+
 tensorcast::store::StoreEngineOptions make_opts() {
   tensorcast::store::StoreEngineOptions opts;
   opts.storage_path = (test_tmpdir() / "engine").string();
@@ -60,6 +65,7 @@ struct ValidationFixture {
   tensorcast::daemon::SessionsService sessions_svc;
   tensorcast::daemon::DeviceResolver devices;
   std::atomic<bool> shutting_down{false};
+  std::filesystem::path storage_root;
   MaterializationController controller;
 
   ValidationFixture()
@@ -72,6 +78,7 @@ struct ValidationFixture {
         scheduler(),
         sessions_svc(session_mgr, verif_tracker, &scheduler, /*lifecycle=*/nullptr, absl::Seconds(60)),
         devices(tensorcast::store::DeviceRegistry::instance()),
+        storage_root(ensure_dir(test_tmpdir())),
         controller(MaterializationController(
             MaterializationController::Dep{
                 .engine = *engine,
@@ -82,6 +89,7 @@ struct ValidationFixture {
                 .regions = regions,
                 .is_shutting_down = shutting_down,
                 .lifecycle = nullptr,
+                .storage_path = storage_root,
             })) {}
 };
 

--- a/daemon/resolve_artifact_from_disk_test.cc
+++ b/daemon/resolve_artifact_from_disk_test.cc
@@ -44,6 +44,11 @@ std::filesystem::path test_tmpdir() {
   return std::filesystem::temp_directory_path() / "tensorcast_daemon_resolve_disk_test";
 }
 
+std::filesystem::path ensure_dir(std::filesystem::path path) {
+  std::filesystem::create_directories(path);
+  return path;
+}
+
 tensorcast::store::StoreEngineOptions make_opts() {
   tensorcast::store::StoreEngineOptions opts;
   opts.storage_path = (test_tmpdir() / "engine").string();
@@ -82,7 +87,7 @@ struct ResolveFixture {
   std::atomic<bool> shutting_down{false};
   MaterializationController controller;
 
-  explicit ResolveFixture(std::vector<std::filesystem::path> whitelist = {})
+  explicit ResolveFixture(std::filesystem::path storage_root = test_tmpdir())
       : engine(std::make_shared<tensorcast::store::StoreEngine>(make_opts())),
         regions(tensorcast::daemon::IpcRegionRegistry::Options{}),
         lip_mgr(engine, &regions),
@@ -99,9 +104,10 @@ struct ResolveFixture {
                 .sessions = sessions_svc,
                 .lip = lip_bridge,
                 .devices = devices,
+                .regions = regions,
                 .is_shutting_down = shutting_down,
                 .lifecycle = nullptr,
-                .disk_path_whitelist = std::move(whitelist),
+                .storage_path = ensure_dir(std::move(storage_root)),
             })) {}
 };
 
@@ -132,11 +138,11 @@ TEST_CASE(
   REQUIRE_FALSE(resp.canonical_index_bytes().empty());
 }
 
-TEST_CASE("ResolveArtifactFromDisk enforces whitelist and missing paths", "[daemon][disk][resolve]") {
+TEST_CASE("ResolveArtifactFromDisk enforces shared root and missing paths", "[daemon][disk][resolve]") {
   const auto artifact_dir = test_tmpdir() / "artifact_denied";
   std::filesystem::remove_all(artifact_dir);
   std::filesystem::create_directories(artifact_dir);
-  ResolveFixture denied_fix({artifact_dir.parent_path() / "unrelated"});
+  ResolveFixture denied_fix(artifact_dir.parent_path() / "unrelated_root");
   grpc::ServerContext ctx;
   tensorcast::daemon::RpcContext denied_rctx{"ResolveArtifactFromDiskTest", ctx, /*allow_high_card_attrs=*/true};
   ResolveArtifactFromDiskRequest req;
@@ -146,7 +152,7 @@ TEST_CASE("ResolveArtifactFromDisk enforces whitelist and missing paths", "[daem
   REQUIRE_FALSE(status.ok());
   REQUIRE(status.error_code() == grpc::StatusCode::INVALID_ARGUMENT);
 
-  ResolveFixture ok_fix({artifact_dir.parent_path()});
+  ResolveFixture ok_fix(artifact_dir.parent_path());
   tensorcast::daemon::RpcContext ok_rctx{"ResolveArtifactFromDiskTest", ctx, /*allow_high_card_attrs=*/true};
   ResolveArtifactFromDiskResponse missing_resp;
   auto missing_status = ok_fix.controller.resolve_artifact_from_disk(ok_rctx, req, missing_resp);

--- a/daemon/server_main.cc
+++ b/daemon/server_main.cc
@@ -56,6 +56,38 @@ int main(int argc, char** argv) {
     return 2;
   }
   const auto& cfg = *cfg_or;
+  const std::filesystem::path storage_root_cfg = cfg.server().storage_path();
+  if (storage_root_cfg.empty()) {
+    LOG(ERROR) << "INVALID_ARGUMENT: server.storage_path is required";
+    return 2;
+  }
+  std::error_code storage_ec;
+  const bool storage_exists = std::filesystem::exists(storage_root_cfg, storage_ec);
+  if (storage_ec) {
+    LOG(ERROR) << "INVALID_ARGUMENT: Failed to stat server.storage_path (" << storage_root_cfg.string()
+               << "): " << storage_ec.message();
+    return 2;
+  }
+  if (!storage_exists) {
+    LOG(ERROR) << "INVALID_ARGUMENT: server.storage_path does not exist: " << storage_root_cfg.string();
+    return 2;
+  }
+  const bool storage_is_dir = std::filesystem::is_directory(storage_root_cfg, storage_ec);
+  if (storage_ec) {
+    LOG(ERROR) << "INVALID_ARGUMENT: Failed to stat server.storage_path (" << storage_root_cfg.string()
+               << "): " << storage_ec.message();
+    return 2;
+  }
+  if (!storage_is_dir) {
+    LOG(ERROR) << "INVALID_ARGUMENT: server.storage_path must be a directory: " << storage_root_cfg.string();
+    return 2;
+  }
+  std::filesystem::path storage_root = std::filesystem::weakly_canonical(storage_root_cfg, storage_ec);
+  if (storage_ec) {
+    LOG(ERROR) << "INVALID_ARGUMENT: Failed to canonicalize server.storage_path (" << storage_root_cfg.string()
+               << "): " << storage_ec.message();
+    return 2;
+  }
 
   // Block SIGINT/SIGTERM in this main thread BEFORE starting any threads so that
   // all subsequently created threads inherit the blocked mask. We'll handle
@@ -74,7 +106,7 @@ int main(int argc, char** argv) {
 
   // Map config to StoreEngineOptions
   store::StoreEngineOptions opts;
-  opts.storage_path = cfg.server().storage_path();
+  opts.storage_path = storage_root.string();
   opts.num_thread = static_cast<int>(cfg.server().num_threads());
   opts.memory_pool_size = static_cast<size_t>(cfg.engine().mem_pool_size_bytes());
   opts.tx_slice_bytes = static_cast<size_t>(cfg.engine().tx_slice_bytes());
@@ -86,7 +118,6 @@ int main(int argc, char** argv) {
         cfg.engine().pinned_allocation_timeout().seconds() * 1000 +
         cfg.engine().pinned_allocation_timeout().nanos() / 1000000);
   }
-  opts.p2p_fallback_disk_dir = cfg.engine().p2p_fallback_disk_dir();
   if (cfg.engine().has_memory_tiers()) {
     store::MemoryTierConfig tiers;
     const auto& mt = cfg.engine().memory_tiers();
@@ -188,13 +219,11 @@ int main(int argc, char** argv) {
     const auto& d = cfg.lifecycle().eviction_loop_interval();
     svc_opts.eviction_check_interval = std::chrono::milliseconds(d.seconds() * 1000 + d.nanos() / 1000000);
   }
+  svc_opts.storage_path = storage_root;
   // Observability high-cardinality attributes: default off (config hook TBD)
   svc_opts.allow_high_card_attrs = false;
   // Feature flags (override via flags for now)
   svc_opts.use_cursor_pagination = absl::GetFlag(FLAGS_use_cursor_pagination);
-  for (const auto& prefix : cfg.engine().disk_path_whitelist()) {
-    svc_opts.disk_path_whitelist.emplace_back(prefix);
-  }
 
   daemon::StoreDaemonServiceImpl service(engine, svc_opts, async_runtime);
   daemon::StoreDaemonServiceV2Impl service_v2(service.materialization_controller(), svc_opts.allow_high_card_attrs);

--- a/daemon/service/controllers/materialization_controller.cc
+++ b/daemon/service/controllers/materialization_controller.cc
@@ -57,17 +57,40 @@ bool path_has_prefix(const std::filesystem::path& path, const std::filesystem::p
   return true;
 }
 
-absl::StatusOr<std::filesystem::path> normalize_disk_path(std::string_view disk_path) {
+absl::StatusOr<std::filesystem::path> normalize_disk_path(
+    std::string_view disk_path,
+    const std::filesystem::path& storage_root) {
+  if (storage_root.empty()) {
+    return absl::InvalidArgumentError("storage_path is required for disk materialization");
+  }
   std::error_code ec;
-  const auto normalized = std::filesystem::weakly_canonical(disk_path, ec);
+  std::filesystem::path candidate(disk_path);
+  if (!candidate.is_absolute()) {
+    candidate = storage_root / candidate;
+  }
+  auto normalized = std::filesystem::weakly_canonical(candidate, ec);
   if (!ec) {
+    if (!path_has_prefix(normalized, storage_root)) {
+      return absl::InvalidArgumentError(
+          absl::StrCat(
+              "disk_path must resolve under storage_path: ",
+              normalized.string(),
+              " (root=",
+              storage_root.string(),
+              ")"));
+    }
     return normalized;
   }
-  const std::filesystem::path lex = std::filesystem::path(disk_path).lexically_normal();
-  if (lex.empty()) {
+  normalized = candidate.lexically_normal();
+  if (normalized.empty()) {
     return absl::ErrnoToStatus(ec.value(), "Failed to canonicalize disk_path");
   }
-  return lex;
+  if (!path_has_prefix(normalized, storage_root)) {
+    return absl::InvalidArgumentError(
+        absl::StrCat(
+            "disk_path must resolve under storage_path: ", normalized.string(), " (root=", storage_root.string(), ")"));
+  }
+  return normalized;
 }
 
 void record_disk_path_denied() {
@@ -598,6 +621,13 @@ absl::StatusOr<std::string> resolve_layout_json(
   if (!v1_resp.artifact_id().empty()) {
     return engine.get_canonical_index_by_id(v1_resp.artifact_id());
   }
+  if (!v1_resp.disk_path().empty()) {
+    auto local_or = store::loader::read_from_artifact_dir(v1_resp.disk_path(), /*target_device_id=*/0);
+    if (!local_or.ok()) {
+      return local_or.status();
+    }
+    return local_or->canonical_index_json;
+  }
   if (v2_req.has_disk_fallback() && !v2_req.disk_fallback().disk_path().empty()) {
     auto local_or = store::loader::read_from_artifact_dir(v2_req.disk_fallback().disk_path(), /*target_device_id=*/0);
     if (!local_or.ok()) {
@@ -620,21 +650,14 @@ absl::StatusOr<std::string> resolve_layout_json_by_key(
 } // namespace
 
 MaterializationController::MaterializationController(Dep d) : d_(std::move(d)) {
-  std::error_code ec;
-  for (const auto& entry : d_.disk_path_whitelist) {
-    if (entry.empty()) {
-      continue;
-    }
-    auto normalized = std::filesystem::weakly_canonical(entry, ec);
+  if (!d_.storage_path.empty()) {
+    std::error_code ec;
+    storage_path_ = std::filesystem::weakly_canonical(d_.storage_path, ec);
     if (ec) {
       ec.clear();
-      normalized = entry.lexically_normal();
-    }
-    if (!normalized.empty()) {
-      disk_path_whitelist_.push_back(normalized);
+      storage_path_ = d_.storage_path.lexically_normal();
     }
   }
-  whitelist_enforced_ = !disk_path_whitelist_.empty();
 }
 
 grpc::Status MaterializationController::materialize_replica(
@@ -671,27 +694,14 @@ grpc::Status MaterializationController::materialize_replica(
 
   std::optional<std::filesystem::path> normalized_disk_path;
   if (request_has_disk) {
-    auto normalized_or = normalize_disk_path(req.disk_path());
+    auto normalized_or = normalize_disk_path(req.disk_path(), storage_path_);
     if (!normalized_or.ok()) {
+      record_disk_path_denied();
+      LOG(WARNING) << "disk_path rejected: " << req.disk_path() << ": " << normalized_or.status();
       resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
       return to_grpc_status(normalized_or.status());
     }
     const auto& normalized = *normalized_or;
-    if (whitelist_enforced_) {
-      bool allowed = false;
-      for (const auto& prefix : disk_path_whitelist_) {
-        if (path_has_prefix(normalized, prefix)) {
-          allowed = true;
-          break;
-        }
-      }
-      if (!allowed) {
-        record_disk_path_denied();
-        LOG(WARNING) << "disk_path not permitted by whitelist: " << normalized;
-        resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
-        return {StatusCode::INVALID_ARGUMENT, "disk_path not permitted by daemon whitelist"};
-      }
-    }
     normalized_disk_path = normalized;
     resp.set_disk_path(normalized.string());
     if (rctx.allow_high_card_attrs()) {
@@ -988,6 +998,16 @@ grpc::Status MaterializationController::materialize_by_key(
   }
   const auto& mapping = *mapping_or;
   span->SetAttribute("tc.artifact.id", mapping.artifact_id);
+  std::string used_disk_path;
+  if (!mapping.disk_path.empty()) {
+    auto normalized_or = normalize_disk_path(mapping.disk_path, storage_path_);
+    if (!normalized_or.ok()) {
+      record_disk_path_denied();
+      resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_FAILED);
+      return to_grpc_status(normalized_or.status());
+    }
+    used_disk_path = normalized_or->string();
+  }
 
   // Try LIP fast path first
   {
@@ -1031,7 +1051,7 @@ grpc::Status MaterializationController::materialize_by_key(
     if (*satisfied) {
       resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_ALLOCATED);
       resp.set_artifact_id(mapping.artifact_id);
-      resp.set_used_disk_path(mapping.disk_path);
+      resp.set_used_disk_path(used_disk_path);
       resp.set_source(v1::MaterializationSource::MATERIALIZATION_SOURCE_LOCAL_REPLICA);
       span->SetAttribute("tc.store.source", static_cast<int64_t>(resp.source()));
       rctx.mark_success();
@@ -1050,8 +1070,9 @@ grpc::Status MaterializationController::materialize_by_key(
     hints.pinned_timeout = std::chrono::milliseconds(req.pinned_allocation_timeout_ms());
   }
   hints.artifact_id = mapping.artifact_id;
-  if (!mapping.disk_path.empty())
-    hints.disk_path = mapping.disk_path;
+  if (!used_disk_path.empty()) {
+    hints.disk_path = used_disk_path;
+  }
 
   auto result = d_.engine.materialize_replica(dev, store::StoreEngine::MaterializeMode::AUTO, hints);
   if (!result.ok()) {
@@ -1088,7 +1109,7 @@ grpc::Status MaterializationController::materialize_by_key(
   }
   resp.set_status(MaterializeReplicaStatus::MATERIALIZE_REPLICA_STATUS_ALLOCATED);
   resp.set_artifact_id(mapping.artifact_id);
-  resp.set_used_disk_path(mapping.disk_path);
+  resp.set_used_disk_path(used_disk_path);
   resp.set_source(to_proto_source(handle.source));
   span->SetAttribute("tc.store.source", static_cast<int64_t>(resp.source()));
   rctx.mark_success();
@@ -1416,7 +1437,14 @@ grpc::Status MaterializationController::materialize_into_target(
   store::loading::MaterializeHints hints;
   hints.artifact_id = req.artifact_id();
   if (req.has_disk_fallback() && !req.disk_fallback().disk_path().empty()) {
-    hints.disk_path = req.disk_fallback().disk_path();
+    auto normalized_or = normalize_disk_path(req.disk_fallback().disk_path(), storage_path_);
+    if (!normalized_or.ok()) {
+      record_disk_path_denied();
+      record_materialize_into_target(
+          "error", "disk_fallback_invalid", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
+      return to_grpc_status(normalized_or.status());
+    }
+    hints.disk_path = normalized_or->string();
   }
   hints.source_preference = to_hint_preference(req.preference());
   hints.verify = store::loading::MaterializeHints::Verify::NONE;
@@ -1524,27 +1552,13 @@ grpc::Status MaterializationController::resolve_artifact_from_disk(
     return {StatusCode::UNAVAILABLE, "daemon is shutting down"};
   }
 
-  auto normalized_or = normalize_disk_path(req.disk_path());
+  auto normalized_or = normalize_disk_path(req.disk_path(), storage_path_);
   if (!normalized_or.ok()) {
+    record_disk_path_denied();
     record_disk_resolution_outcome("invalid_argument");
     return to_grpc_status(normalized_or.status());
   }
   const auto& normalized = *normalized_or;
-  if (whitelist_enforced_) {
-    bool allowed = false;
-    for (const auto& prefix : disk_path_whitelist_) {
-      if (path_has_prefix(normalized, prefix)) {
-        allowed = true;
-        break;
-      }
-    }
-    if (!allowed) {
-      record_disk_path_denied();
-      LOG(WARNING) << "disk_path not permitted by whitelist: " << normalized;
-      record_disk_resolution_outcome("whitelist_denied");
-      return {StatusCode::INVALID_ARGUMENT, "disk_path not permitted by daemon whitelist"};
-    }
-  }
   resp.set_disk_path(normalized.string());
   if (rctx.allow_high_card_attrs()) {
     span->SetAttribute("tc.disk.path", normalized.string());

--- a/daemon/service/controllers/materialization_controller.h
+++ b/daemon/service/controllers/materialization_controller.h
@@ -31,7 +31,7 @@ class MaterializationController {
     IpcRegionRegistry& regions;
     std::atomic<bool>& is_shutting_down;
     SessionLifecycleManager* lifecycle{nullptr};
-    std::vector<std::filesystem::path> disk_path_whitelist;
+    std::filesystem::path storage_path;
   };
 
   explicit MaterializationController(Dep d);
@@ -82,8 +82,7 @@ class MaterializationController {
 
  private:
   Dep d_;
-  std::vector<std::filesystem::path> disk_path_whitelist_;
-  bool whitelist_enforced_{false};
+  std::filesystem::path storage_path_;
 };
 
 } // namespace tensorcast::daemon

--- a/docs/designs/0004-unified-runtime-config.md
+++ b/docs/designs/0004-unified-runtime-config.md
@@ -43,7 +43,7 @@ Authoritative package namespace: `tensorcast.config.v1`. Separate top‑level me
   - `lifecycle`: eviction toggles and intervals, PID scanning, sweeper intervals, TTLs, VRAM fraction.
   - `high_availability`: `global_store_endpoints`, heartbeat/periodic sync/retry.
   - `communicator`: `tensorcast.communicator.v1.CommunicatorConfig` (reused schema).
-  - `engine`: `*_bytes`, streaming and CPU VS sizing, `pinned_allocation_timeout`, `p2p_fallback_disk_dir`.
+  - `engine`: `*_bytes`, streaming and CPU VS sizing, `pinned_allocation_timeout`.
   - `observability`: OTel (lang‑agnostic), logging (enum level, sinks), tracing; `otel_cxx` holds C++‑specific toggles.
   - `compatibility`: targeted compatibility switches (e.g., `confirm_requires_disk_path`, `verification_timeout_status`).
   - `checkpoint.streaming`: `num_buffers`, `io_chunk_bytes`, `pinned_pool_bytes`.
@@ -123,7 +123,7 @@ Tests cover normalization of enum aliases in both Global Store and Client loader
 # Compatibility & Migration
 
 - Communicator: integrate RFC‑0013 outcomes by embedding `tensorcast.communicator.v1.CommunicatorConfig` under `DaemonConfig.communicator`; remove `--comm_config_path` and related flags/ENV.
-- Flags/ENV mapping: legacy flags and environment variables are mapped into explicit fields (e.g., daemon lifecycle intervals, VRAM fraction, OTel/logging, checkpoint streaming, P2P fallback dir). After migration they are ignored by processes.
+- Flags/ENV mapping: legacy flags and environment variables are mapped into explicit fields (e.g., daemon lifecycle intervals, VRAM fraction, OTel/logging, checkpoint streaming). After migration they are ignored by processes.
 - Restart boundary: all fields are startup‑only; changes require a process restart. No partial runtime mutation is supported.
 - Schema discipline: new runtime behavior enters via `.proto` first; code reads from Protobuf messages only. Deprecated fields are removed with `reserved` guards.
 

--- a/docs/designs/0038-daemon-only-disk-materialization.md
+++ b/docs/designs/0038-daemon-only-disk-materialization.md
@@ -156,13 +156,12 @@ flowchart TD
   4. Performs checksum verification (always enabled). On mismatch, returns `DATA_LOSS` error.
   5. Emits `MaterializeReplicaResponse` with `source` field so clients know the actual data path.
 
-### Disk Path Whitelist Enforcement
-- The daemon loads a `disk_path_whitelist` (flag or config entry) consisting of absolute path prefixes.
-- Every incoming `disk_path` is canonicalized (e.g., `realpath`) and must begin with one of the configured prefixes.
-- A non-empty whitelist restricts disk access strictly to those prefixes. An empty whitelist explicitly grants full access (legacy behavior) and should only be used in trusted environments.
-- Violations are rejected with `INVALID_ARGUMENT`, and the daemon emits structured logs plus counters (e.g., `store.materialization.denied_disk_path`) so operators can detect misconfiguration quickly.
-- The SDK surfaces the daemon error directly; it never retries locally, ensuring whitelist mistakes are corrected rather than bypassed.
-- Configuration surface: `engine.disk_path_whitelist` in `DaemonConfig` (YAML/JSON) maps directly into the daemon service options.
+### Shared Disk Root Enforcement
+- The daemon requires `server.storage_path` as the shared disk root mounted on every node.
+- Every incoming `disk_path` is resolved against this root (relative paths are joined) and canonicalized.
+- Requests are rejected with `INVALID_ARGUMENT` when the resolved path falls outside the shared root.
+- The daemon returns the canonical absolute path in responses so callers observe a stable, shared-disk location.
+- Configuration surface: `server.storage_path` in `DaemonConfig` (YAML/JSON) maps into daemon service options and validation.
 
 ## SDK Changes
 
@@ -227,6 +226,7 @@ The SDK sends a simple RPC with `disk_path` and `preference`; all metadata extra
 | Daemon gRPC Status | Condition | SDK Behavior |
 |--------------------|-----------|--------------|
 | `NOT_FOUND` | `disk_path` does not exist or artifact not found | Propagate as `ArtifactError`, retryable=false |
+| `INVALID_ARGUMENT` | `disk_path` resolves outside the shared root | Propagate as `ArtifactError`, retryable=false |
 | `DATA_LOSS` | Checksum verification failed | Propagate as `ArtifactError`, retryable=false |
 | `FAILED_PRECONDITION` | Metadata inconsistent or malformed | Propagate as `ArtifactError`, retryable=false |
 | `UNAVAILABLE` | Daemon temporarily unavailable | Propagate as `ArtifactError`, retryable=true |
@@ -239,7 +239,7 @@ The SDK sends a simple RPC with `disk_path` and `preference`; all metadata extra
 | **Daemon regression affects disk-only workflows** | Add dedicated Bazel tests plus Python integration tests to cover disk preference paths. |
 | **Temporary lack of offline loader** | Keep `tensorcast.api._io_disk.load_dict_from_disk()` for regression tests; document that production flows require a daemon. |
 | **Increased daemon responsibilities** | Disk flows already existed in C++; this change simply exposes them through the unified RPC path. |
-| **disk_path whitelist misconfiguration** | Provide counters/logs for denied paths and document that an empty whitelist restores full access. |
+| **Shared root misconfiguration** | Provide counters/logs for denied paths and document that `server.storage_path` must be a shared mount on every node. |
 | **SDK/daemon version mismatch** | Out of scope: single-version deployments mean all components update together. |
 
 # Compatibility & Acceptance Criteria
@@ -259,11 +259,10 @@ The SDK sends a simple RPC with `disk_path` and `preference`; all metadata extra
 |----------|-------------------|
 | `disk_path` valid, replica exists | Daemon returns `source=P2P` or `LOCAL_REPLICA` |
 | `disk_path` valid, no replica | Daemon returns `source=DISK` |
-| `disk_path` invalid or missing | Daemon returns `NOT_FOUND` |
+| `disk_path` missing under shared root | Daemon returns `NOT_FOUND` |
+| `disk_path` outside shared root | Daemon returns `INVALID_ARGUMENT` and emits denial metrics/logs |
 | `disk_path` valid, checksum mismatch | Daemon returns `DATA_LOSS` |
 | `preference=PREFER_DISK` without `disk_path` | Daemon uses default source selection (AUTO) |
-| `disk_path` outside whitelist prefixes | Daemon returns `INVALID_ARGUMENT` and emits denial metrics/logs |
-| Whitelist configured as empty | Daemon accepts all disk paths (still verifying metadata and checksums) |
 
 # References
 

--- a/examples/config/store_daemon_config.yaml
+++ b/examples/config/store_daemon_config.yaml
@@ -27,7 +27,7 @@ server:
     host: 0.0.0.0
     # P2P port; must be non-zero when high_availability.enabled is true.
     port: 65090
-  # Root directory for daemon-owned artifacts; disk materialization and fallback paths derive from here.
+  # Shared root directory for daemon-owned artifacts; all disk_path values must resolve under this root.
   storage_path: /data/models
   # StoreEngine I/O worker threads; tune for disk/P2P parallelism vs CPU contention.
   num_threads: 16
@@ -79,10 +79,6 @@ engine:
   streaming_buffer_max_concurrent_sessions: 1
   # Wait time for pinned buffer allocation under pressure; raise if large transfers outlive the default.
   pinned_allocation_timeout: 30s
-  # Optional disk fallback directory for P2P loads; invalid paths are ignored with a warning.
-  p2p_fallback_disk_dir: ""
-  # Allowlist for daemon-side disk materialization; empty list permits all paths (use with care).
-  disk_path_whitelist: []
 
 # Global Store registration and heartbeat coordination.
 high_availability:

--- a/proto/tensorcast/config/v1/daemon_config.proto
+++ b/proto/tensorcast/config/v1/daemon_config.proto
@@ -86,9 +86,8 @@ message Engine {
   reserved "chunk_bytes", "cpu_chunk_size_bytes";
   uint32 streaming_buffer_max_concurrent_sessions = 4;
   google.protobuf.Duration pinned_allocation_timeout = 5;
-  string p2p_fallback_disk_dir = 6;
-  // Whitelisted disk path prefixes for daemon-side materialization. Empty list allows all paths.
-  repeated string disk_path_whitelist = 7;
+  reserved 6, 7;
+  reserved "p2p_fallback_disk_dir", "disk_path_whitelist";
   MemoryTiers memory_tiers = 10;
 }
 

--- a/tensorcast/cli_utils/config.py
+++ b/tensorcast/cli_utils/config.py
@@ -148,9 +148,7 @@ def build_embedded_daemon_config(
     """Create an embedded daemon config anchored to a session directory."""
 
     storage_dir = session.root / "data"
-    fallback_dir = session.root / "p2p_cache"
     storage_dir.mkdir(parents=True, exist_ok=True)
-    fallback_dir.mkdir(parents=True, exist_ok=True)
 
     cfg = cfg_pb.DaemonConfig()
     listen_host = (
@@ -169,8 +167,6 @@ def build_embedded_daemon_config(
     cfg.engine.tx_slice_bytes = 256 * 1024 * 1024
     cfg.engine.artifact_chunk_bytes = 256 * 1024 * 1024
     cfg.engine.streaming_buffer_max_concurrent_sessions = 1
-    cfg.engine.p2p_fallback_disk_dir = str(fallback_dir)
-    cfg.engine.disk_path_whitelist.extend([str(storage_dir), str(fallback_dir)])
     cfg.engine.pinned_allocation_timeout.FromSeconds(30)
 
     cfg.lifecycle.gpu_memory_limit_fraction = 0.75

--- a/tests/python/test_shared_storage.py
+++ b/tests/python/test_shared_storage.py
@@ -47,12 +47,13 @@ def test_shared_storage_roundtrip(tmp_path):
         "indep2": indep2,
     }
 
-    save_path = tmp_path / "artifact"
+    storage_root = tmp_path / "daemon-storage"
+    save_path = storage_root / "artifact"
     # Save using the unified writer
     descriptor = save_dict(state_dict, str(save_path))
 
     listen = f"127.0.0.1:{get_free_port()}"
-    daemon_proc = start_daemon_binary(listen, tmp_path / "daemon-storage")
+    daemon_proc = start_daemon_binary(listen, storage_root)
     try:
         startup.init(mode="connect", address=listen)
         try:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens disk-path safety and simplifies config by making the daemon’s `server.storage_path` the single shared root.
> 
> - Enforces/normalizes `disk_path` under `server.storage_path` across RPCs (`PublishReplicaKey`, materialize v1/v2, by-key, resolve-from-disk, into-target); responses now return the normalized path
> - Removes `p2p_fallback_disk_dir` and `disk_path_whitelist` (engine options, daemon options, config proto, example YAML, CLI builder), replacing with shared-root enforcement; startup validates `server.storage_path` exists and is a directory
> - Tweaks P2P fallback: `P2PSourceAdapter` only sets disk fallback when hints include `disk_path` and preference is not `PREFER_P2P`
> - Adds disk canonical index fetch when only `disk_path` is known; updates README/docs and adjusts tests to require/provide `storage_path`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca9cc3acd129a7ba30aba44c567497cf037d5e45. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->