### PR TITLE
chore: add vmm test

### DIFF
--- a/core/common/cuda_api.h
+++ b/core/common/cuda_api.h
@@ -109,6 +109,13 @@ typedef struct cudaPointerAttributes {
 
 typedef int CUresult;
 
+typedef int CUdevice;
+
+typedef enum CUdevice_attribute_enum {
+  CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED = 1,
+  CU_DEVICE_ATTRIBUTE_HOST_ALLOC_DMA_BUF_SUPPORTED = 2,
+} CUdevice_attribute;
+
 typedef std::uintptr_t CUdeviceptr;
 typedef std::uint64_t CUmemGenericAllocationHandle;
 
@@ -155,6 +162,11 @@ typedef struct CUmemAccessDesc_st {
   CUmemLocation location;
   CUmemAccess_flags flags;
 } CUmemAccessDesc;
+
+// cuMemGetHandleForAddressRange types (subset).
+typedef enum CUmemRangeHandleType_enum {
+  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD = 1,
+} CUmemRangeHandleType;
 #endif
 
 namespace tensorcast::cuda {
@@ -254,6 +266,8 @@ absl::Status memcpy_peer_async(
 // CUDA VMM (Driver API) wrappers.
 // ---------------------------------------------------------------------------
 absl::Status cu_init(unsigned int flags = 0);
+absl::Status cu_device_get(CUdevice* device, int ordinal);
+absl::Status cu_device_get_attribute(int* value, CUdevice_attribute attribute, CUdevice device);
 absl::Status cu_mem_get_allocation_granularity(
     size_t* granularity,
     const CUmemAllocationProp* prop,
@@ -274,6 +288,12 @@ absl::Status cu_mem_set_access(CUdeviceptr ptr, size_t size, const CUmemAccessDe
 absl::Status cu_mem_unmap(CUdeviceptr ptr, size_t size);
 absl::Status cu_mem_release(CUmemGenericAllocationHandle handle);
 absl::Status cu_mem_address_free(CUdeviceptr ptr, size_t size);
+absl::Status cu_mem_get_handle_for_address_range(
+    void* handle,
+    CUdeviceptr dptr,
+    size_t size,
+    CUmemRangeHandleType handle_type,
+    unsigned long long flags);
 
 // Helper macro for operations not supported by fake backend
 #ifdef USE_FAKE_CUDA

--- a/core/common/cuda_fake.cc
+++ b/core/common/cuda_fake.cc
@@ -1156,6 +1156,23 @@ absl::Status cu_init(unsigned int flags) {
   return absl::OkStatus();
 }
 
+absl::Status cu_device_get(CUdevice* device, int ordinal) {
+  static_cast<void>(ordinal);
+  if (device == nullptr) {
+    return absl::InvalidArgumentError("device pointer is null");
+  }
+  SC_RETURN_IF_FAKE_CUDA_UNSUPPORTED(cuDeviceGet);
+}
+
+absl::Status cu_device_get_attribute(int* value, CUdevice_attribute attribute, CUdevice device) {
+  static_cast<void>(attribute);
+  static_cast<void>(device);
+  if (value == nullptr) {
+    return absl::InvalidArgumentError("value pointer is null");
+  }
+  SC_RETURN_IF_FAKE_CUDA_UNSUPPORTED(cuDeviceGetAttribute);
+}
+
 absl::Status cu_mem_get_allocation_granularity(
     size_t* granularity,
     const CUmemAllocationProp* prop,
@@ -1326,6 +1343,20 @@ absl::Status cu_mem_address_free(CUdeviceptr ptr, size_t size) {
     return absl::ErrnoToStatus(errno, "munmap failed in fake cu_mem_address_free");
   }
   return absl::OkStatus();
+}
+
+absl::Status cu_mem_get_handle_for_address_range(
+    void* handle,
+    CUdeviceptr dptr,
+    size_t size,
+    CUmemRangeHandleType handle_type,
+    unsigned long long flags) {
+  static_cast<void>(handle);
+  static_cast<void>(dptr);
+  static_cast<void>(size);
+  static_cast<void>(handle_type);
+  static_cast<void>(flags);
+  SC_RETURN_IF_FAKE_CUDA_UNSUPPORTED(cuMemGetHandleForAddressRange);
 }
 
 } // namespace tensorcast::cuda

--- a/core/common/cuda_real.cc
+++ b/core/common/cuda_real.cc
@@ -29,9 +29,12 @@ constexpr const char* kCudaDriverLibraryNames[] = {"libcuda.so.1", "libcuda.so"}
 // NOLINTBEGIN(readability-identifier-naming)
 struct CudaDriverVmmSymbols {
   decltype(&::cuInit) cuInit = nullptr;
+  decltype(&::cuDeviceGet) cuDeviceGet = nullptr;
+  decltype(&::cuDeviceGetAttribute) cuDeviceGetAttribute = nullptr;
   decltype(&::cuGetErrorName) cuGetErrorName = nullptr;
   decltype(&::cuGetErrorString) cuGetErrorString = nullptr;
   decltype(&::cuMemGetAllocationGranularity) cuMemGetAllocationGranularity = nullptr;
+  decltype(&::cuMemGetHandleForAddressRange) cuMemGetHandleForAddressRange = nullptr;
   decltype(&::cuMemAddressReserve) cuMemAddressReserve = nullptr;
   decltype(&::cuMemCreate) cuMemCreate = nullptr;
   decltype(&::cuMemMap) cuMemMap = nullptr;
@@ -104,6 +107,14 @@ absl::Status ensure_cuda_driver_loaded() {
       load_status = status;
       return;
     }
+    if (auto status = load_or(symbols.cuDeviceGet, "cuDeviceGet"); !status.ok()) {
+      load_status = status;
+      return;
+    }
+    if (auto status = load_or(symbols.cuDeviceGetAttribute, "cuDeviceGetAttribute"); !status.ok()) {
+      load_status = status;
+      return;
+    }
     if (auto status = load_or(symbols.cuGetErrorName, "cuGetErrorName"); !status.ok()) {
       load_status = status;
       return;
@@ -113,6 +124,10 @@ absl::Status ensure_cuda_driver_loaded() {
       return;
     }
     if (auto status = load_or(symbols.cuMemGetAllocationGranularity, "cuMemGetAllocationGranularity"); !status.ok()) {
+      load_status = status;
+      return;
+    }
+    if (auto status = load_or(symbols.cuMemGetHandleForAddressRange, "cuMemGetHandleForAddressRange"); !status.ok()) {
       load_status = status;
       return;
     }
@@ -619,6 +634,30 @@ absl::Status cu_init(unsigned int flags) {
   return cu_result_as_status(symbols.cuInit(flags), "cuInit");
 }
 
+absl::Status cu_device_get(CUdevice* device, int ordinal) {
+  if (device == nullptr) {
+    return absl::InvalidArgumentError("device pointer is null");
+  }
+  auto status = ensure_cuda_driver_loaded();
+  if (!status.ok()) {
+    return status;
+  }
+  const CudaDriverVmmSymbols& symbols = cuda_driver_symbols();
+  return cu_result_as_status(symbols.cuDeviceGet(device, ordinal), "cuDeviceGet");
+}
+
+absl::Status cu_device_get_attribute(int* value, CUdevice_attribute attribute, CUdevice device) {
+  if (value == nullptr) {
+    return absl::InvalidArgumentError("value pointer is null");
+  }
+  auto status = ensure_cuda_driver_loaded();
+  if (!status.ok()) {
+    return status;
+  }
+  const CudaDriverVmmSymbols& symbols = cuda_driver_symbols();
+  return cu_result_as_status(symbols.cuDeviceGetAttribute(value, attribute, device), "cuDeviceGetAttribute");
+}
+
 absl::Status cu_mem_get_allocation_granularity(
     size_t* granularity,
     const CUmemAllocationProp* prop,
@@ -720,6 +759,28 @@ absl::Status cu_mem_address_free(CUdeviceptr ptr, size_t size) {
   }
   const CudaDriverVmmSymbols& symbols = cuda_driver_symbols();
   return cu_result_as_status(symbols.cuMemAddressFree(ptr, size), "cuMemAddressFree");
+}
+
+absl::Status cu_mem_get_handle_for_address_range(
+    void* handle,
+    CUdeviceptr dptr,
+    size_t size,
+    CUmemRangeHandleType handle_type,
+    unsigned long long flags) {
+  if (handle == nullptr) {
+    return absl::InvalidArgumentError("handle is null");
+  }
+  if (dptr == 0 || size == 0) {
+    return absl::InvalidArgumentError("dptr/size invalid");
+  }
+
+  auto status = ensure_cuda_driver_loaded();
+  if (!status.ok()) {
+    return status;
+  }
+  const CudaDriverVmmSymbols& symbols = cuda_driver_symbols();
+  return cu_result_as_status(
+      symbols.cuMemGetHandleForAddressRange(handle, dptr, size, handle_type, flags), "cuMemGetHandleForAddressRange");
 }
 
 absl::Status close_ipc_mem_handle(void* dev_ptr) {

--- a/core/communicator/BUILD
+++ b/core/communicator/BUILD
@@ -433,6 +433,37 @@ cc_test(
 )
 
 cc_test(
+    name = "rdma_vmm_test",
+    srcs = ["engine/rdma_vmm_test.cc"],
+    tags = [
+        "rdma",
+        "requires_cuda",
+    ],
+    deps = [
+        ":engine_lib",
+        "//core/testing:catch_main",
+        "//core/testing:test_helpers",
+        "@catch2//:catch2_main",
+    ],
+)
+
+cc_test(
+    name = "rdma_vmm_ub_test",
+    srcs = ["engine/rdma_vmm_ub_test.cc"],
+    tags = [
+        "manual",
+        "rdma",
+        "requires_cuda",
+    ],
+    deps = [
+        ":engine_lib",
+        "//core/testing:catch_main",
+        "//core/testing:test_helpers",
+        "@catch2//:catch2_main",
+    ],
+)
+
+cc_test(
     name = "staging_flow_controller_test",
     srcs = ["engine/staging_flow_controller_test.cc"],
     deps = [

--- a/core/communicator/BUILD
+++ b/core/communicator/BUILD
@@ -436,6 +436,7 @@ cc_test(
     name = "rdma_vmm_test",
     srcs = ["engine/rdma_vmm_test.cc"],
     tags = [
+        "manual",
         "rdma",
         "requires_cuda",
     ],

--- a/core/communicator/engine/rdma_vmm_test.cc
+++ b/core/communicator/engine/rdma_vmm_test.cc
@@ -1,0 +1,521 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <unistd.h>
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <string>
+#include <vector>
+
+#include "absl/cleanup/cleanup.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "core/common/cuda_api.h"
+#include "core/communicator/engine/engine.h"
+#include "core/communicator/misc/ibv_wrap.h"
+#include "core/communicator/transport/rdma_context.h"
+#include "core/testing/test_helpers.h"
+
+namespace tensorcast::communicator::engine {
+
+class CommunicatorTestPeer {
+ public:
+  static auto& rdma_context(Communicator& communicator) {
+    return communicator.rdma_context_;
+  }
+};
+
+} // namespace tensorcast::communicator::engine
+
+namespace {
+
+constexpr int kGpuId = 0;
+constexpr int kMrAccessFlags = IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_RELAXED_ORDERING;
+
+absl::StatusOr<size_t> get_vmm_granularity(int device_id) {
+  absl::Status status = tensorcast::cuda::cu_init(0);
+  if (!status.ok()) {
+    return status;
+  }
+
+  CUmemAllocationProp prop{};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = device_id;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+
+  size_t granularity = 0;
+  status = tensorcast::cuda::cu_mem_get_allocation_granularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+  if (!status.ok()) {
+    return status;
+  }
+  if (granularity == 0) {
+    return absl::InternalError("cuMemGetAllocationGranularity returned 0");
+  }
+  return granularity;
+}
+
+CUmemAllocationProp make_vmm_prop(int device_id) {
+  CUmemAllocationProp prop{};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = device_id;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  return prop;
+}
+
+absl::Status map_vmm_region(CUdeviceptr base, size_t bytes, CUmemGenericAllocationHandle handle, int device_id) {
+  absl::Status status = tensorcast::cuda::cu_mem_map(base, bytes, /*offset=*/0, handle, /*flags=*/0);
+  if (!status.ok()) {
+    return status;
+  }
+  CUmemAccessDesc access_desc{};
+  access_desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access_desc.location.id = device_id;
+  access_desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  return tensorcast::cuda::cu_mem_set_access(base, bytes, &access_desc, /*count=*/1);
+}
+
+void log_if_error(absl::string_view operation, const absl::Status& status) {
+  if (!status.ok()) {
+    LOG(WARNING) << operation << " failed during cleanup: " << status;
+  }
+}
+
+void log_if_ibv_error(absl::string_view operation, tensorcast::communicator::misc::result_t result) {
+  if (result != tensorcast::communicator::misc::SUCCESS) {
+    LOG(WARNING) << operation << " failed during cleanup";
+  }
+}
+
+bool gpu_mr_registration_supported(const tensorcast::communicator::transport::net_dev_t& net_dev, size_t bytes) {
+  void* gpu_ptr = nullptr;
+  absl::Status alloc_status = tensorcast::cuda::malloc(&gpu_ptr, bytes);
+  if (!alloc_status.ok()) {
+    LOG(WARNING) << "cudaMalloc failed while probing GPUDirect RDMA support: " << alloc_status;
+    return false;
+  }
+  absl::Cleanup free_gpu = [&]() { log_if_error("cudaFree", tensorcast::cuda::free(gpu_ptr)); };
+
+  ibv_mr* mr = nullptr;
+  auto reg_res = net_dev->reg_mr(&mr, gpu_ptr, bytes, kMrAccessFlags);
+  if (reg_res != tensorcast::communicator::misc::SUCCESS || mr == nullptr) {
+    return false;
+  }
+  log_if_ibv_error("ibv_dereg_mr", tensorcast::communicator::misc::wrap_ibv_dereg_mr(mr));
+  return true;
+}
+
+absl::StatusOr<int> get_dmabuf_supported_attr(int device_id) {
+  if (absl::Status init_status = tensorcast::cuda::cu_init(0); !init_status.ok()) {
+    return init_status;
+  }
+  CUdevice cuda_device = 0;
+  if (absl::Status device_status = tensorcast::cuda::cu_device_get(&cuda_device, device_id); !device_status.ok()) {
+    return device_status;
+  }
+  int dmabuf_supported = 0;
+  if (absl::Status attr_status = tensorcast::cuda::cu_device_get_attribute(
+          &dmabuf_supported, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, cuda_device);
+      !attr_status.ok()) {
+    return attr_status;
+  }
+  return dmabuf_supported;
+}
+
+} // namespace
+
+namespace tensorcast::unittests {
+
+TEST_CASE("CUDA VMM address mapping gates ibv_reg_dmabuf_mr", "[rdma][vmm]") {
+  int device_count = 0;
+  absl::Status cuda_status = tensorcast::cuda::get_device_count(&device_count);
+  if (!cuda_status.ok() || device_count == 0) {
+    WARN("CUDA unavailable for rdma_vmm_test: " + cuda_status.ToString());
+    return;
+  }
+  if (tensorcast::cuda::is_fake()) {
+    WARN("Skipping rdma_vmm_test: requires real CUDA backend");
+    return;
+  }
+
+  auto dmabuf_supported_or = get_dmabuf_supported_attr(kGpuId);
+  INFO("cu_device_get_attribute(CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED): " + dmabuf_supported_or.status().ToString());
+  if (!dmabuf_supported_or.ok()) {
+    WARN(
+        "Skipping rdma_vmm_test: cuDeviceGetAttribute(DMA_BUF_SUPPORTED) failed: " +
+        dmabuf_supported_or.status().ToString());
+    return;
+  }
+  LOG(INFO) << "cu_device_get_attribute(CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED) status=" << dmabuf_supported_or.status()
+            << " value=" << *dmabuf_supported_or;
+  INFO("CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED: " + std::to_string(*dmabuf_supported_or));
+  if (*dmabuf_supported_or == 0) {
+    WARN("Skipping rdma_vmm_test: CUDA device does not support dma-buf (CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED=0)");
+    return;
+  }
+
+  if (tensorcast::communicator::misc::wrap_ibv_symbols() != tensorcast::communicator::misc::SUCCESS) {
+    WARN("Skipping rdma_vmm_test: libibverbs not available (wrap_ibv_symbols failed)");
+    return;
+  }
+
+  auto set_device_status = tensorcast::cuda::set_device(kGpuId);
+  REQUIRE(set_device_status.ok());
+
+  auto granularity_or = get_vmm_granularity(kGpuId);
+  if (!granularity_or.ok()) {
+    WARN("Skipping rdma_vmm_test: CUDA VMM unavailable: " + granularity_or.status().ToString());
+    return;
+  }
+
+  INFO("CUDA VMM granularity: " + std::to_string(*granularity_or));
+  const size_t granularity = *granularity_or;
+  const auto prop = make_vmm_prop(kGpuId);
+
+  auto rdma_ctx = std::make_shared<tensorcast::communicator::transport::RdmaContext>();
+  auto net_dev = rdma_ctx->get_best_dev(kGpuId);
+  if (net_dev == nullptr) {
+    WARN("Skipping rdma_vmm_test: no active RDMA device for GPU 0");
+    return;
+  }
+
+  const long page_size = sysconf(_SC_PAGESIZE);
+  INFO("Page size: " + std::to_string(page_size));
+  REQUIRE(page_size > 0);
+  REQUIRE(granularity % static_cast<size_t>(page_size) == 0);
+
+  SECTION("Reserved-only VA cannot export dma-buf handle") {
+    CUdeviceptr va = 0;
+    auto reserve_status = tensorcast::cuda::cu_mem_address_reserve(&va, granularity, granularity, /*addr=*/0, 0);
+    REQUIRE(reserve_status.ok());
+    absl::Cleanup free_va = [&]() {
+      log_if_error("cuMemAddressFree", tensorcast::cuda::cu_mem_address_free(va, granularity));
+    };
+
+    int dmabuf_fd = -1;
+    absl::Status handle_status = tensorcast::cuda::cu_mem_get_handle_for_address_range(
+        &dmabuf_fd, va, granularity, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, /*flags=*/0);
+    REQUIRE_FALSE(handle_status.ok());
+  }
+
+  SECTION("Partially-mapped VA rejects handle export across unmapped pages") {
+    const size_t total_bytes = granularity * 2;
+    CUdeviceptr va = 0;
+    auto reserve_status =
+        tensorcast::cuda::cu_mem_address_reserve(&va, total_bytes, granularity, /*addr=*/0, /*flags=*/0);
+    REQUIRE(reserve_status.ok());
+    absl::Cleanup free_va = [&]() {
+      log_if_error("cuMemAddressFree", tensorcast::cuda::cu_mem_address_free(va, total_bytes));
+    };
+
+    CUmemGenericAllocationHandle handle = 0;
+    auto create_status = tensorcast::cuda::cu_mem_create(&handle, granularity, &prop, /*flags=*/0);
+    REQUIRE(create_status.ok());
+    absl::Cleanup release_handle = [&]() { log_if_error("cuMemRelease", tensorcast::cuda::cu_mem_release(handle)); };
+
+    auto map_status = map_vmm_region(va, granularity, handle, kGpuId);
+    REQUIRE(map_status.ok());
+    absl::Cleanup unmap = [&]() { log_if_error("cuMemUnmap", tensorcast::cuda::cu_mem_unmap(va, granularity)); };
+
+    int dmabuf_fd = -1;
+    absl::Status handle_status = tensorcast::cuda::cu_mem_get_handle_for_address_range(
+        &dmabuf_fd, va, total_bytes, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, /*flags=*/0);
+    REQUIRE_FALSE(handle_status.ok());
+
+    // Exporting handle for the unmapped sub-range should also fail (even if the first page is mapped).
+    const CUdeviceptr unmapped_va = va + static_cast<CUdeviceptr>(granularity);
+    dmabuf_fd = -1;
+    handle_status = tensorcast::cuda::cu_mem_get_handle_for_address_range(
+        &dmabuf_fd, unmapped_va, granularity, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, /*flags=*/0);
+    REQUIRE_FALSE(handle_status.ok());
+
+    // Once the requested range is fully backed, we can export dma-buf and register it.
+    dmabuf_fd = -1;
+    handle_status = tensorcast::cuda::cu_mem_get_handle_for_address_range(
+        &dmabuf_fd, va, granularity, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, /*flags=*/0);
+    if (!handle_status.ok() || dmabuf_fd < 0) {
+      WARN("cuMemGetHandleForAddressRange(DMA_BUF_FD) not available for mapped CUDA VMM memory; skipping");
+      return;
+    }
+    absl::Cleanup close_dmabuf_fd = [&]() {
+      if (dmabuf_fd >= 0 && close(dmabuf_fd) != 0) {
+        PLOG(WARNING) << "close(dmabuf_fd) failed during cleanup";
+      }
+    };
+
+    ibv_mr* mr = tensorcast::communicator::misc::wrap_direct_ibv_reg_dmabuf_mr(
+        net_dev->get_pd(),
+        /*offset=*/0,
+        granularity,
+        /*iova=*/static_cast<uint64_t>(va),
+        dmabuf_fd,
+        kMrAccessFlags);
+    if (mr == nullptr) {
+      WARN("ibv_reg_dmabuf_mr failed for mapped CUDA VMM memory; skipping mapped registration check");
+      return;
+    }
+    log_if_ibv_error("ibv_dereg_mr", tensorcast::communicator::misc::wrap_ibv_dereg_mr(mr));
+  }
+
+  SECTION("Mapped & backed VA allows ibv_reg_dmabuf_mr") {
+    CUdeviceptr va = 0;
+    auto reserve_status = tensorcast::cuda::cu_mem_address_reserve(&va, granularity, granularity, /*addr=*/0, 0);
+    REQUIRE(reserve_status.ok());
+    absl::Cleanup free_va = [&]() {
+      log_if_error("cuMemAddressFree", tensorcast::cuda::cu_mem_address_free(va, granularity));
+    };
+
+    CUmemGenericAllocationHandle handle = 0;
+    auto create_status = tensorcast::cuda::cu_mem_create(&handle, granularity, &prop, /*flags=*/0);
+    REQUIRE(create_status.ok());
+    absl::Cleanup release_handle = [&]() { log_if_error("cuMemRelease", tensorcast::cuda::cu_mem_release(handle)); };
+
+    auto map_status = map_vmm_region(va, granularity, handle, kGpuId);
+    REQUIRE(map_status.ok());
+    absl::Cleanup unmap = [&]() { log_if_error("cuMemUnmap", tensorcast::cuda::cu_mem_unmap(va, granularity)); };
+
+    int dmabuf_fd = -1;
+    absl::Status handle_status = tensorcast::cuda::cu_mem_get_handle_for_address_range(
+        &dmabuf_fd, va, granularity, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, /*flags=*/0);
+    if (!handle_status.ok() || dmabuf_fd < 0) {
+      WARN("cuMemGetHandleForAddressRange(DMA_BUF_FD) error: " + handle_status.ToString());
+      WARN("cuMemGetHandleForAddressRange(DMA_BUF_FD) not available for mapped CUDA VMM memory; skipping");
+      REQUIRE(false);
+    }
+
+    absl::Cleanup close_dmabuf_fd = [&]() {
+      if (dmabuf_fd >= 0 && close(dmabuf_fd) != 0) {
+        PLOG(WARNING) << "close(dmabuf_fd) failed during cleanup";
+      }
+    };
+
+    ibv_mr* mr = tensorcast::communicator::misc::wrap_direct_ibv_reg_dmabuf_mr(
+        net_dev->get_pd(),
+        /*offset=*/0,
+        granularity,
+        /*iova=*/static_cast<uint64_t>(va),
+        dmabuf_fd,
+        kMrAccessFlags);
+    if (mr == nullptr) {
+      WARN("ibv_reg_dmabuf_mr failed for mapped CUDA VMM memory; skipping mapped registration check");
+      REQUIRE(false);
+    }
+    log_if_ibv_error("ibv_dereg_mr", tensorcast::communicator::misc::wrap_ibv_dereg_mr(mr));
+  }
+}
+
+TEST_CASE("CUDA VMM + Communicator direct RDMA read", "[rdma][vmm][integration]") {
+  int device_count = 0;
+  absl::Status cuda_status = tensorcast::cuda::get_device_count(&device_count);
+  if (!cuda_status.ok() || device_count == 0) {
+    WARN("CUDA unavailable for rdma_vmm_test: " + cuda_status.ToString());
+    return;
+  }
+  if (tensorcast::cuda::is_fake()) {
+    WARN("Skipping rdma_vmm_test: requires real CUDA backend");
+    return;
+  }
+
+  auto dmabuf_supported_or = get_dmabuf_supported_attr(kGpuId);
+  INFO("cu_device_get_attribute(CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED): " + dmabuf_supported_or.status().ToString());
+  if (!dmabuf_supported_or.ok()) {
+    WARN(
+        "Skipping rdma_vmm_test: cuDeviceGetAttribute(DMA_BUF_SUPPORTED) failed: " +
+        dmabuf_supported_or.status().ToString());
+    return;
+  }
+  LOG(INFO) << "cu_device_get_attribute(CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED) status=" << dmabuf_supported_or.status()
+            << " value=" << *dmabuf_supported_or;
+  INFO("CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED: " + std::to_string(*dmabuf_supported_or));
+  if (*dmabuf_supported_or == 0) {
+    WARN("Skipping rdma_vmm_test: CUDA device does not support dma-buf (CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED=0)");
+    return;
+  }
+
+  if (tensorcast::communicator::misc::wrap_ibv_symbols() != tensorcast::communicator::misc::SUCCESS) {
+    WARN("Skipping rdma_vmm_test: libibverbs not available (wrap_ibv_symbols failed)");
+    return;
+  }
+
+  auto set_device_status = tensorcast::cuda::set_device(kGpuId);
+  REQUIRE(set_device_status.ok());
+
+  auto granularity_or = get_vmm_granularity(kGpuId);
+  if (!granularity_or.ok()) {
+    WARN("Skipping rdma_vmm_test: CUDA VMM unavailable: " + granularity_or.status().ToString());
+    return;
+  }
+  const size_t tensor_bytes = *granularity_or;
+  const auto prop = make_vmm_prop(kGpuId);
+
+  auto cfg = tensorcast::testing::make_tcp_communicator_config(
+      /*enable_rdma=*/true,
+      /*gpu_chunk_mb=*/1,
+      /*cpu_chunk_mb=*/1,
+      /*buffers_per_flow=*/2);
+
+  tensorcast::communicator::engine::Communicator server(cfg, /*channel_expire_sec=*/5);
+  tensorcast::communicator::engine::Communicator client(cfg, /*channel_expire_sec=*/5);
+
+  const int server_port = tensorcast::testing::find_available_port(60000);
+  const int client_port = tensorcast::testing::find_available_port(60100);
+  REQUIRE(server_port > 0);
+  REQUIRE(client_port > 0);
+  REQUIRE(server.init("127.0.0.1", static_cast<uint16_t>(server_port), /*conn_count=*/2).ok());
+  REQUIRE(client.init("127.0.0.1", static_cast<uint16_t>(client_port), /*conn_count=*/2).ok());
+
+  auto& rdma_ctx = tensorcast::communicator::engine::CommunicatorTestPeer::rdma_context(server);
+  auto net_dev = rdma_ctx->get_best_dev(kGpuId);
+  if (net_dev == nullptr) {
+    WARN("Skipping rdma_vmm_test: no active RDMA device for GPU 0");
+    return;
+  }
+
+  if (!gpu_mr_registration_supported(net_dev, tensor_bytes)) {
+    WARN("GPUDirect RDMA not available for CUDA device memory; skipping CUDA VMM direct RDMA test");
+    return;
+  }
+
+  CUdeviceptr va = 0;
+  auto reserve_status =
+      tensorcast::cuda::cu_mem_address_reserve(&va, tensor_bytes, tensor_bytes, /*addr=*/0, /*flags=*/0);
+  REQUIRE(reserve_status.ok());
+  absl::Cleanup free_va = [&]() {
+    log_if_error("cuMemAddressFree", tensorcast::cuda::cu_mem_address_free(va, tensor_bytes));
+  };
+
+  uint8_t* dst_gpu = nullptr;
+  auto alloc_status = tensorcast::cuda::malloc(reinterpret_cast<void**>(&dst_gpu), tensor_bytes);
+  REQUIRE(alloc_status.ok());
+  absl::Cleanup free_dst = [&]() { log_if_error("cudaFree", tensorcast::cuda::free(dst_gpu)); };
+  REQUIRE(tensorcast::cuda::memset(dst_gpu, 0, tensor_bytes).ok());
+
+  auto run_roundtrip = [&](uint8_t seed, CUmemGenericAllocationHandle handle) -> bool {
+    auto map_status = map_vmm_region(va, tensor_bytes, handle, kGpuId);
+    REQUIRE(map_status.ok());
+    absl::Cleanup unmap_guard = [&]() { log_if_error("cuMemUnmap", tensorcast::cuda::cu_mem_unmap(va, tensor_bytes)); };
+
+    const auto pattern = tensorcast::testing::create_test_pattern(tensor_bytes, seed);
+    REQUIRE(
+        tensorcast::cuda::memcpy(reinterpret_cast<void*>(va), pattern.data(), tensor_bytes, cudaMemcpyHostToDevice)
+            .ok());
+    REQUIRE(tensorcast::cuda::device_synchronize().ok());
+
+    tensorcast::communicator::engine::Communicator::RegisterTensorOptions opts;
+    opts.register_mr = true;
+    opts.needs_staging = false;
+    opts.async = false;
+    opts.direct_rdma_enabled = true;
+    const std::string tensor_key = "RDMA_VMM_TENSOR";
+    auto register_status = server.register_tensor_ex(
+        tensor_key,
+        static_cast<uint64_t>(va),
+        static_cast<uint64_t>(tensor_bytes),
+        tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+        kGpuId,
+        opts);
+    if (!register_status.ok()) {
+      WARN("GPUDirect RDMA registration for CUDA VMM memory is unavailable: " + register_status.ToString());
+      return false;
+    }
+    absl::Cleanup unregister_guard = [&]() {
+      log_if_error("client.unregister_tensor", client.unregister_tensor(tensor_key));
+      log_if_error("server.unregister_tensor", server.unregister_tensor(tensor_key));
+    };
+
+    auto future = client.read_tensor(
+        tensor_key,
+        reinterpret_cast<uint64_t>(dst_gpu),
+        static_cast<uint64_t>(tensor_bytes),
+        tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+        kGpuId,
+        "127.0.0.1",
+        static_cast<uint16_t>(server_port),
+        /*remote_offset=*/0);
+
+    constexpr auto kTimeout = std::chrono::seconds(30);
+    REQUIRE(future.valid());
+    REQUIRE(future.wait_for(kTimeout) == std::future_status::ready);
+    auto result = future.get();
+    REQUIRE(result.status.ok());
+
+    REQUIRE(tensorcast::cuda::device_synchronize().ok());
+    std::vector<uint8_t> host_dst(tensor_bytes);
+    REQUIRE(tensorcast::cuda::memcpy(host_dst.data(), dst_gpu, tensor_bytes, cudaMemcpyDeviceToHost).ok());
+    REQUIRE(tensorcast::testing::verify_pattern(host_dst.data(), tensor_bytes, seed));
+
+    // Also verify a non-zero remote_offset read works for CUDA VMM memory.
+    {
+      const size_t slice_offset = tensor_bytes / 4;
+      const size_t slice_bytes = std::min<size_t>(tensor_bytes / 2, 4096);
+      REQUIRE(slice_offset + slice_bytes <= tensor_bytes);
+
+      REQUIRE(tensorcast::cuda::memset(dst_gpu, 0, slice_bytes).ok());
+      auto slice_future = client.read_tensor(
+          tensor_key,
+          reinterpret_cast<uint64_t>(dst_gpu),
+          static_cast<uint64_t>(slice_bytes),
+          tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+          kGpuId,
+          "127.0.0.1",
+          static_cast<uint16_t>(server_port),
+          static_cast<uint64_t>(slice_offset));
+
+      REQUIRE(slice_future.valid());
+      REQUIRE(slice_future.wait_for(kTimeout) == std::future_status::ready);
+      auto slice_result = slice_future.get();
+      REQUIRE(slice_result.status.ok());
+
+      std::vector<uint8_t> host_slice(slice_bytes);
+      REQUIRE(tensorcast::cuda::memcpy(host_slice.data(), dst_gpu, slice_bytes, cudaMemcpyDeviceToHost).ok());
+      REQUIRE(std::equal(host_slice.begin(), host_slice.end(), pattern.begin() + slice_offset));
+    }
+
+    REQUIRE(client.unregister_tensor(tensor_key).ok());
+    REQUIRE(server.unregister_tensor(tensor_key).ok());
+    std::move(unregister_guard).Cancel();
+
+    REQUIRE(tensorcast::cuda::cu_mem_unmap(va, tensor_bytes).ok());
+    std::move(unmap_guard).Cancel();
+    return true;
+  };
+
+  CUmemGenericAllocationHandle handle1 = 0;
+  REQUIRE(tensorcast::cuda::cu_mem_create(&handle1, tensor_bytes, &prop, /*flags=*/0).ok());
+  absl::Cleanup release_handle1 = [&]() { log_if_error("cuMemRelease", tensorcast::cuda::cu_mem_release(handle1)); };
+  if (!run_roundtrip(/*seed=*/0x11, handle1)) {
+    return;
+  }
+
+  // With the mapping removed (VA reserved only), Communicator registration should fail.
+  {
+    tensorcast::communicator::engine::Communicator::RegisterTensorOptions opts;
+    opts.register_mr = true;
+    opts.needs_staging = false;
+    opts.async = false;
+    opts.direct_rdma_enabled = true;
+    auto status = server.register_tensor_ex(
+        "RDMA_VMM_TENSOR",
+        static_cast<uint64_t>(va),
+        static_cast<uint64_t>(tensor_bytes),
+        tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+        kGpuId,
+        opts);
+    REQUIRE_FALSE(status.ok());
+  }
+
+  CUmemGenericAllocationHandle handle2 = 0;
+  REQUIRE(tensorcast::cuda::cu_mem_create(&handle2, tensor_bytes, &prop, /*flags=*/0).ok());
+  absl::Cleanup release_handle2 = [&]() { log_if_error("cuMemRelease", tensorcast::cuda::cu_mem_release(handle2)); };
+  (void)run_roundtrip(/*seed=*/0x22, handle2);
+}
+
+} // namespace tensorcast::unittests

--- a/core/communicator/engine/rdma_vmm_ub_test.cc
+++ b/core/communicator/engine/rdma_vmm_ub_test.cc
@@ -1,0 +1,263 @@
+// Copyright (c) 2025, TensorCast Team.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <future>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/cleanup/cleanup.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "core/common/cuda_api.h"
+#include "core/communicator/engine/engine.h"
+#include "core/communicator/misc/ibv_wrap.h"
+#include "core/communicator/transport/rdma_context.h"
+#include "core/testing/test_helpers.h"
+
+namespace {
+
+constexpr int kGpuId = 0;
+constexpr int kMrAccessFlags = IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_RELAXED_ORDERING;
+
+constexpr std::string_view kEnableEnv = "TENSORCAST_RUN_RDMA_VMM_UB_TEST";
+
+bool env_enabled(std::string_view name) {
+  const std::string key(name);
+  const char* value = std::getenv(key.c_str());
+  if (value == nullptr) {
+    return false;
+  }
+  std::string_view sv(value);
+  return sv == "1" || sv == "true" || sv == "TRUE" || sv == "yes" || sv == "YES";
+}
+
+void log_if_error(absl::string_view operation, const absl::Status& status) {
+  if (!status.ok()) {
+    LOG(WARNING) << operation << " failed during cleanup: " << status;
+  }
+}
+
+void log_if_ibv_error(absl::string_view operation, tensorcast::communicator::misc::result_t result) {
+  if (result != tensorcast::communicator::misc::SUCCESS) {
+    LOG(WARNING) << operation << " failed during cleanup";
+  }
+}
+
+absl::StatusOr<size_t> get_vmm_granularity(int device_id) {
+  absl::Status status = tensorcast::cuda::cu_init(0);
+  if (!status.ok()) {
+    return status;
+  }
+
+  CUmemAllocationProp prop{};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = device_id;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+
+  size_t granularity = 0;
+  status = tensorcast::cuda::cu_mem_get_allocation_granularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+  if (!status.ok()) {
+    return status;
+  }
+  if (granularity == 0) {
+    return absl::InternalError("cuMemGetAllocationGranularity returned 0");
+  }
+  return granularity;
+}
+
+CUmemAllocationProp make_vmm_prop(int device_id) {
+  CUmemAllocationProp prop{};
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = device_id;
+  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  return prop;
+}
+
+absl::Status map_vmm_region(CUdeviceptr base, size_t bytes, CUmemGenericAllocationHandle handle, int device_id) {
+  absl::Status status = tensorcast::cuda::cu_mem_map(base, bytes, /*offset=*/0, handle, /*flags=*/0);
+  if (!status.ok()) {
+    return status;
+  }
+  CUmemAccessDesc access_desc{};
+  access_desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access_desc.location.id = device_id;
+  access_desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  return tensorcast::cuda::cu_mem_set_access(base, bytes, &access_desc, /*count=*/1);
+}
+
+bool gpu_mr_registration_supported(const tensorcast::communicator::transport::net_dev_t& net_dev, size_t bytes) {
+  void* gpu_ptr = nullptr;
+  absl::Status alloc_status = tensorcast::cuda::malloc(&gpu_ptr, bytes);
+  if (!alloc_status.ok()) {
+    LOG(WARNING) << "cudaMalloc failed while probing GPUDirect RDMA support: " << alloc_status;
+    return false;
+  }
+  absl::Cleanup free_gpu = [&]() { log_if_error("cudaFree", tensorcast::cuda::free(gpu_ptr)); };
+
+  ibv_mr* mr = nullptr;
+  auto reg_res = net_dev->reg_mr(&mr, gpu_ptr, bytes, kMrAccessFlags);
+  if (reg_res != tensorcast::communicator::misc::SUCCESS || mr == nullptr) {
+    return false;
+  }
+  log_if_ibv_error("ibv_dereg_mr", tensorcast::communicator::misc::wrap_ibv_dereg_mr(mr));
+  return true;
+}
+
+} // namespace
+
+namespace tensorcast::unittests {
+
+TEST_CASE("UB repro: cuMemUnmap/cuMemRelease while MR alive (manual)", "[rdma][vmm][ub]") {
+  if (!env_enabled(kEnableEnv)) {
+    WARN(
+        "UB repro is disabled by default. Enable explicitly with:\n"
+        "  bazel test //core/communicator:rdma_vmm_ub_test --test_output=all \\\n"
+        "    --test_env=TENSORCAST_RUN_RDMA_VMM_UB_TEST=1\n"
+        "WARNING: This can crash the process or the host (undefined behavior).");
+    return;
+  }
+
+  int device_count = 0;
+  absl::Status device_status = tensorcast::cuda::get_device_count(&device_count);
+  REQUIRE(device_status.ok());
+  REQUIRE(device_count > 0);
+  REQUIRE_FALSE(tensorcast::cuda::is_fake());
+
+  REQUIRE(tensorcast::communicator::misc::wrap_ibv_symbols() == tensorcast::communicator::misc::SUCCESS);
+  REQUIRE(tensorcast::cuda::set_device(kGpuId).ok());
+
+  auto granularity_or = get_vmm_granularity(kGpuId);
+  REQUIRE(granularity_or.ok());
+  const size_t tensor_bytes = *granularity_or;
+  const auto prop = make_vmm_prop(kGpuId);
+
+  auto cfg = tensorcast::testing::make_tcp_communicator_config(
+      /*enable_rdma=*/true,
+      /*gpu_chunk_mb=*/1,
+      /*cpu_chunk_mb=*/1,
+      /*buffers_per_flow=*/2);
+
+  tensorcast::communicator::engine::Communicator server(cfg, /*channel_expire_sec=*/5);
+  tensorcast::communicator::engine::Communicator client(cfg, /*channel_expire_sec=*/5);
+
+  const int server_port = tensorcast::testing::find_available_port(61000);
+  const int client_port = tensorcast::testing::find_available_port(61100);
+  REQUIRE(server_port > 0);
+  REQUIRE(client_port > 0);
+  REQUIRE(server.init("127.0.0.1", static_cast<uint16_t>(server_port), /*conn_count=*/2).ok());
+  REQUIRE(client.init("127.0.0.1", static_cast<uint16_t>(client_port), /*conn_count=*/2).ok());
+
+  auto rdma_ctx = std::make_shared<tensorcast::communicator::transport::RdmaContext>();
+  auto net_dev = rdma_ctx->get_best_dev(kGpuId);
+  REQUIRE(net_dev != nullptr);
+
+  REQUIRE(gpu_mr_registration_supported(net_dev, tensor_bytes));
+
+  CUdeviceptr va = 0;
+  REQUIRE(tensorcast::cuda::cu_mem_address_reserve(&va, tensor_bytes, tensor_bytes, /*addr=*/0, /*flags=*/0).ok());
+  absl::Cleanup free_va = [&]() {
+    log_if_error("cuMemAddressFree", tensorcast::cuda::cu_mem_address_free(va, tensor_bytes));
+  };
+
+  CUmemGenericAllocationHandle handle = 0;
+  REQUIRE(tensorcast::cuda::cu_mem_create(&handle, tensor_bytes, &prop, /*flags=*/0).ok());
+  absl::Cleanup release_handle = [&]() { log_if_error("cuMemRelease", tensorcast::cuda::cu_mem_release(handle)); };
+  REQUIRE(map_vmm_region(va, tensor_bytes, handle, kGpuId).ok());
+  absl::Cleanup unmap_guard = [&]() { log_if_error("cuMemUnmap", tensorcast::cuda::cu_mem_unmap(va, tensor_bytes)); };
+
+  uint8_t* dst_gpu = nullptr;
+  REQUIRE(tensorcast::cuda::malloc(reinterpret_cast<void**>(&dst_gpu), tensor_bytes).ok());
+  absl::Cleanup free_dst = [&]() { log_if_error("cudaFree", tensorcast::cuda::free(dst_gpu)); };
+  REQUIRE(tensorcast::cuda::memset(dst_gpu, 0, tensor_bytes).ok());
+
+  const auto pattern = tensorcast::testing::create_test_pattern(tensor_bytes, /*seed=*/0x5A);
+  REQUIRE(
+      tensorcast::cuda::memcpy(reinterpret_cast<void*>(va), pattern.data(), tensor_bytes, cudaMemcpyHostToDevice).ok());
+  REQUIRE(tensorcast::cuda::device_synchronize().ok());
+
+  tensorcast::communicator::engine::Communicator::RegisterTensorOptions opts;
+  opts.register_mr = true;
+  opts.needs_staging = false;
+  opts.async = false;
+  opts.direct_rdma_enabled = true;
+
+  const std::string tensor_key = "RDMA_VMM_UB_TENSOR";
+  absl::Status register_status = server.register_tensor_ex(
+      tensor_key,
+      static_cast<uint64_t>(va),
+      static_cast<uint64_t>(tensor_bytes),
+      tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+      kGpuId,
+      opts);
+  REQUIRE(register_status.ok());
+
+  // Baseline: verify RDMA can read from the VMM tensor when mapping is valid.
+  {
+    auto future = client.read_tensor(
+        tensor_key,
+        reinterpret_cast<uint64_t>(dst_gpu),
+        static_cast<uint64_t>(tensor_bytes),
+        tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+        kGpuId,
+        "127.0.0.1",
+        static_cast<uint16_t>(server_port),
+        /*remote_offset=*/0);
+
+    constexpr auto kTimeout = std::chrono::seconds(30);
+    REQUIRE(future.valid());
+    REQUIRE(future.wait_for(kTimeout) == std::future_status::ready);
+    auto result = future.get();
+    REQUIRE(result.status.ok());
+
+    std::vector<uint8_t> host_dst(tensor_bytes);
+    REQUIRE(tensorcast::cuda::memcpy(host_dst.data(), dst_gpu, tensor_bytes, cudaMemcpyDeviceToHost).ok());
+    REQUIRE(tensorcast::testing::verify_pattern(host_dst.data(), tensor_bytes, /*seed=*/0x5A));
+  }
+
+  // UB: Break the required lifetime ordering:
+  // Map -> Register(MR) -> Unmap/Release -> ... (MR still alive)
+  LOG(ERROR) << "[UB] About to call cuMemUnmap/cuMemRelease while MR is still registered for tensor=" << tensor_key;
+  absl::Status ub_unmap_status = tensorcast::cuda::cu_mem_unmap(va, tensor_bytes);
+  LOG(ERROR) << "[UB] cuMemUnmap returned: " << ub_unmap_status;
+  std::move(unmap_guard).Cancel();
+  absl::Status ub_release_status = tensorcast::cuda::cu_mem_release(handle);
+  LOG(ERROR) << "[UB] cuMemRelease returned: " << ub_release_status;
+  std::move(release_handle).Cancel();
+
+  // Trigger an RDMA READ after unmapping to amplify the effect. Outcome is undefined:
+  // - may crash the process or the host
+  // - may hang
+  // - may return a verbs error (WC status != SUCCESS)
+  // - may appear to work (still UB)
+  auto future = client.read_tensor(
+      tensor_key,
+      reinterpret_cast<uint64_t>(dst_gpu),
+      static_cast<uint64_t>(tensor_bytes),
+      tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+      kGpuId,
+      "127.0.0.1",
+      static_cast<uint16_t>(server_port),
+      /*remote_offset=*/0);
+
+  constexpr auto kTimeout = std::chrono::seconds(10);
+  REQUIRE(future.valid());
+  auto status = future.wait_for(kTimeout);
+  if (status == std::future_status::ready) {
+    auto result = future.get();
+    WARN("UB repro completed without crashing; final read status: " + result.status.ToString());
+  } else {
+    WARN("UB repro did not complete within timeout; process may be hung (expected for UB).");
+  }
+}
+
+} // namespace tensorcast::unittests

--- a/core/communicator/misc/ibv_wrap.cc
+++ b/core/communicator/misc/ibv_wrap.cc
@@ -78,6 +78,8 @@ struct ibv_symbols_t {
   struct ibv_pd* (*alloc_pd)(struct ibv_context* context) = NULL;
   int (*dealloc_pd)(struct ibv_pd* pd) = NULL;
   struct ibv_mr* (*reg_mr)(struct ibv_pd* pd, void* addr, size_t length, int access) = NULL;
+  struct ibv_mr* (
+      *reg_dmabuf_mr)(struct ibv_pd* pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access) = NULL;
   int (*dereg_mr)(struct ibv_mr* mr) = NULL;
   struct ibv_cq* (*create_cq)(
       struct ibv_context* context,
@@ -127,6 +129,11 @@ result_t init_symbols() {
   LOAD_SYM("ibv_alloc_pd", alloc_pd);
   LOAD_SYM("ibv_dealloc_pd", dealloc_pd);
   LOAD_SYM("ibv_reg_mr", reg_mr);
+  dlerror();
+  if (void* dmabuf_sym = dlsym(ibvhandle, "ibv_reg_dmabuf_mr"); dmabuf_sym != nullptr) {
+    void** cast = reinterpret_cast<void**>(&g_symbols.reg_dmabuf_mr);
+    *cast = dmabuf_sym;
+  }
   LOAD_SYM("ibv_dereg_mr", dereg_mr);
   LOAD_SYM("ibv_create_cq", create_cq);
   LOAD_SYM("ibv_destroy_cq", destroy_cq);
@@ -233,12 +240,38 @@ result_t wrap_ibv_reg_mr(struct ibv_mr** ret, struct ibv_pd* pd, void* addr, siz
   IBV_PTR_CHECK_ERRNO(reg_mr, reg_mr(pd, addr, length, access), *ret, nullptr, "ibv_reg_mr");
 }
 
+result_t wrap_ibv_reg_dmabuf_mr(
+    struct ibv_mr** ret,
+    struct ibv_pd* pd,
+    uint64_t offset,
+    size_t length,
+    uint64_t iova,
+    int fd,
+    int access) {
+  IBV_PTR_CHECK_ERRNO(
+      reg_dmabuf_mr, reg_dmabuf_mr(pd, offset, length, iova, fd, access), *ret, nullptr, "ibv_reg_dmabuf_mr");
+}
+
 struct ibv_mr* wrap_direct_ibv_reg_mr(struct ibv_pd* pd, void* addr, size_t length, int access) {
   if (g_symbols.reg_mr == nullptr) {
     LOG(WARNING) << "lib wrapper not initialized.";
     return nullptr;
   }
   return g_symbols.reg_mr(pd, addr, length, access);
+}
+
+struct ibv_mr* wrap_direct_ibv_reg_dmabuf_mr(
+    struct ibv_pd* pd,
+    uint64_t offset,
+    size_t length,
+    uint64_t iova,
+    int fd,
+    int access) {
+  if (g_symbols.reg_dmabuf_mr == nullptr) {
+    LOG(WARNING) << "ibv_reg_dmabuf_mr not available in loaded libibverbs";
+    return nullptr;
+  }
+  return g_symbols.reg_dmabuf_mr(pd, offset, length, iova, fd, access);
 }
 
 result_t wrap_ibv_dereg_mr(struct ibv_mr* mr) {

--- a/core/communicator/misc/ibv_wrap.h
+++ b/core/communicator/misc/ibv_wrap.h
@@ -44,6 +44,14 @@ result_t wrap_ibv_query_qp(
 result_t wrap_ibv_alloc_pd(struct ibv_pd** ret, struct ibv_context* context);
 result_t wrap_ibv_dealloc_pd(struct ibv_pd* pd);
 result_t wrap_ibv_reg_mr(struct ibv_mr** ret, struct ibv_pd* pd, void* addr, size_t length, int access);
+result_t wrap_ibv_reg_dmabuf_mr(
+    struct ibv_mr** ret,
+    struct ibv_pd* pd,
+    uint64_t offset,
+    size_t length,
+    uint64_t iova,
+    int fd,
+    int access);
 struct ibv_mr* wrap_direct_ibv_reg_mr(struct ibv_pd* pd, void* addr, size_t length, int access);
 struct ibv_mr* wrap_direct_ibv_reg_dmabuf_mr(
     struct ibv_pd* pd,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces CUDA VMM dma-buf handle export and RDMA registration support with focused tests.
> 
> - Add driver wrappers: `cu_device_get`, `cu_device_get_attribute`, and `cu_mem_get_handle_for_address_range`; load corresponding symbols in the real backend and validate params
> - Extend fake CUDA with stubs for the above (returning unimplemented) and keep existing VMM map/unmap behavior
> - Update `ibv_wrap` to optionally load `ibv_reg_dmabuf_mr` and expose `wrap_ibv_reg_dmabuf_mr`/`wrap_direct_ibv_reg_dmabuf_mr`
> - New tests: `rdma_vmm_test` validates VMM VA mapping requirements for dma-buf export and direct RDMA reads; `rdma_vmm_ub_test` (manual) reproduces unmapping/handle-release UB while MR is alive
> - BUILD: add the two tests and their deps/tags
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9315178c117fb81fd617fd32a4a9a746fb156aa5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->