### PR TITLE
refactor(cuda): refactor cuda backend 

### DIFF
--- a/core/checkpoint/README.md
+++ b/core/checkpoint/README.md
@@ -15,6 +15,7 @@ The Checkpoint module provides efficient tensor serialization and deserializatio
 - **Efficient I/O**: Uses 4K-aligned buffers for optimal disk performance
 - **Partitioned Storage**: Automatically splits large models into manageable chunks (10GB per partition)
 - **CUDA Integration**: Native support for GPU memory management and IPC handles
+- **CUDA IPC restores**: When restoring tensors backed by a CUDA IPC mapping, tensors share a single reference-counted owner so the mapping is closed exactly once after the last tensor is released.
 - **Fake CUDA test mode**: When `TENSORCAST_CUDA_BACKEND=fake` is active in tests, device restores use shared-memory mappings and `device_id` restores fall back to CPU tensors.
 - **Verification Support**: Built-in replica integrity verification
 - **Streaming GPU Tensor Saving**: Asynchronous GPU→Host→Disk pipeline using pinned memory (`StreamingTensorWriter`)

--- a/core/checkpoint/checkpoint.cc
+++ b/core/checkpoint/checkpoint.cc
@@ -507,7 +507,7 @@ std::unordered_map<std::string, torch::Tensor> restore_tensors(
   }
 
   std::unordered_map<std::string, torch::Tensor> state_dict;
-  std::unordered_set<std::uint64_t> handled_memory;
+  std::unordered_map<std::uint64_t, std::shared_ptr<void>> owners;
   for (const auto& [device, tensor_offset] : tensor_device_offsets) {
     for (const auto& p : tensor_offset) {
       const std::string name = p.first;
@@ -524,39 +524,33 @@ std::unordered_map<std::string, torch::Tensor> restore_tensors(
         torch::Device tensor_device(torch::kCUDA, device);
         // LOG(INFO) << "Restore tensor " << name << " to device " << device << " with offset " << offset;
 
-        auto deleter = [from_ipc_shm](void* ptr) {
-          absl::Status status;
-          if (from_ipc_shm) {
-            status = cuda::close_ipc_mem_handle(ptr);
-          } else {
-            status = cuda::free(ptr);
-          }
-
-          if (!status.ok()) {
-            LOG(ERROR) << "CUDA memory cleanup failed: " << status.message();
-          }
-        };
-
-        if (offset == 0 && handled_memory.find(base_address) == handled_memory.end()) {
-          const torch::Tensor real_tensor = torch::from_blob(
-              reinterpret_cast<void*>(data_address),
-              c10::makeArrayRef(sizes),
-              c10::makeArrayRef(strides),
-              deleter,
-              torch::TensorOptions().device(tensor_device).dtype(dtype));
-          state_dict[name] = real_tensor;
-          handled_memory.insert(base_address);
-          // std::cerr << "Tensor " << name << " is restored to device " <<
-          // device << std::endl;
+        std::shared_ptr<void> owner;
+        auto it = owners.find(base_address);
+        if (it == owners.end()) {
+          owner = std::shared_ptr<void>(reinterpret_cast<void*>(base_address), [from_ipc_shm, device](void* ptr) {
+            if (device >= 0) {
+              absl::Status device_status = cuda::set_device(device);
+              if (!device_status.ok()) {
+                LOG(WARNING) << "CUDA cleanup set_device failed: " << device_status.message();
+              }
+            }
+            absl::Status status = from_ipc_shm ? cuda::close_ipc_mem_handle(ptr) : cuda::free(ptr);
+            if (!status.ok()) {
+              LOG(ERROR) << "CUDA memory cleanup failed: " << status.message();
+            }
+          });
+          owners.emplace(base_address, owner);
         } else {
-          const torch::Tensor real_tensor = torch::from_blob(
-              reinterpret_cast<void*>(data_address),
-              sizes,
-              strides,
-              [](void* ptr) {},
-              torch::TensorOptions().device(tensor_device).dtype(dtype));
-          state_dict[name] = real_tensor;
+          owner = it->second;
         }
+
+        const torch::Tensor real_tensor = torch::from_blob(
+            reinterpret_cast<void*>(data_address),
+            c10::makeArrayRef(sizes),
+            c10::makeArrayRef(strides),
+            [owner](void*) mutable { owner.reset(); },
+            torch::TensorOptions().device(tensor_device).dtype(dtype));
+        state_dict[name] = real_tensor;
       } else {
         LOG(FATAL) << "Cannot find device " << device;
       }

--- a/core/checkpoint/checkpoint.cc
+++ b/core/checkpoint/checkpoint.cc
@@ -478,8 +478,6 @@ std::unordered_map<std::string, torch::Tensor> restore_tensors(
 
         const size_t element_size = c10::elementSize(dtype);
         const std::uint64_t data_address = base_address + offset + (storage_offset_elems * element_size);
-        const size_t total_bytes = static_cast<size_t>(c10::multiply_integers(sizes)) * element_size;
-
         torch::TensorOptions options = torch::TensorOptions().device(torch::kCPU).dtype(dtype);
 
         std::shared_ptr<void> owner;
@@ -880,6 +878,46 @@ std::string get_cuda_memory_handle(int device_id, std::uint64_t memory_ptr) {
   }
 
   return std::string(reinterpret_cast<const char*>(&handle), sizeof(cudaIpcMemHandle_t));
+}
+
+absl::StatusOr<std::pair<std::string, std::uint64_t>> get_cuda_memory_handle_with_offset(
+    int device_id,
+    std::uint64_t memory_ptr) {
+  if (memory_ptr == 0) {
+    return absl::InvalidArgumentError("memory_ptr must be non-zero");
+  }
+
+  auto set_device_status = cuda::set_device(device_id);
+  if (!set_device_status.ok()) {
+    return set_device_status;
+  }
+
+  void* base = nullptr;
+  size_t range_bytes = 0;
+  auto range_status = cuda::mem_get_address_range(&base, &range_bytes, reinterpret_cast<void*>(memory_ptr));
+  if (!range_status.ok() || base == nullptr) {
+    // Fall back to the legacy behavior: export directly from memory_ptr with a
+    // zero base offset. This preserves previous semantics when address-range
+    // queries are unavailable.
+    const std::string handle = get_cuda_memory_handle(device_id, memory_ptr);
+    if (handle.empty()) {
+      return absl::FailedPreconditionError("Failed to export CUDA IPC handle");
+    }
+    return std::make_pair(handle, static_cast<std::uint64_t>(0));
+  }
+
+  const auto base_addr = reinterpret_cast<std::uint64_t>(base);
+  if (memory_ptr < base_addr) {
+    return absl::FailedPreconditionError("CUDA address range base exceeds memory_ptr");
+  }
+  const std::uint64_t base_offset = memory_ptr - base_addr;
+
+  cudaIpcMemHandle_t handle;
+  auto ipc_status = cuda::get_ipc_mem_handle(&handle, base);
+  if (!ipc_status.ok()) {
+    return ipc_status;
+  }
+  return std::make_pair(std::string(reinterpret_cast<const char*>(&handle), sizeof(cudaIpcMemHandle_t)), base_offset);
 }
 
 absl::StatusOr<std::uint64_t> get_cuda_memory_ptr(int device_id, const std::string& cuda_ipc_handle) {

--- a/core/checkpoint/checkpoint.h
+++ b/core/checkpoint/checkpoint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 //  ServerlessLLM
 //  Copyright (c) ServerlessLLM Team 2024
@@ -55,6 +55,7 @@ class Tensor {
 #endif // Disabled section
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -126,6 +127,13 @@ std::uint64_t allocate_cuda_memory(int device_id, size_t tensor_size);
 
 // Obtain a CUDA-IPC handle for a single allocation.
 std::string get_cuda_memory_handle(int device_id, std::uint64_t memory_ptr);
+
+// Obtain a CUDA-IPC handle for the allocation that backs memory_ptr and return
+// (handle_bytes, base_offset_bytes) where base_offset_bytes is the byte offset
+// of memory_ptr into the exported allocation.
+absl::StatusOr<std::pair<std::string, std::uint64_t>> get_cuda_memory_handle_with_offset(
+    int device_id,
+    std::uint64_t memory_ptr);
 
 absl::StatusOr<std::uint64_t> get_cuda_memory_ptr(int device_id, const std::string& cuda_ipc_handle);
 

--- a/core/common/cuda_api.h
+++ b/core/common/cuda_api.h
@@ -37,6 +37,7 @@ absl::StatusOr<std::string> get_device_name(int device_id);
 absl::Status get_device_properties(int device_id, void* prop); // cudaDeviceProp*
 absl::Status pointer_get_attributes(void* ptr, int* device, void** device_ptr);
 absl::Status pointer_get_attributes_full(const void* ptr, cudaPointerAttributes* attrs);
+absl::Status mem_get_address_range(void** base, size_t* range_bytes, const void* ptr);
 
 // IPC handle operations (string-based for compatibility)
 absl::Status get_ipc_handle(const void* ptr, std::string* handle);

--- a/core/common/cuda_backend.h
+++ b/core/common/cuda_backend.h
@@ -42,6 +42,7 @@ namespace tensorcast::cuda {
   X(absl::Status, get_device_properties, (int device_id, void* prop), device_id, prop)                                \
   X(absl::Status, pointer_get_attributes, (void* ptr, int* device, void** device_ptr), ptr, device, device_ptr)       \
   X(absl::Status, pointer_get_attributes_full, (const void* ptr, cudaPointerAttributes* attrs), ptr, attrs)           \
+  X(absl::Status, mem_get_address_range, (void** base, size_t* range_bytes, const void* ptr), base, range_bytes, ptr) \
   X(absl::Status, get_ipc_handle, (const void* ptr, std::string* handle), ptr, handle)                                \
   X(absl::Status, open_ipc_handle, (const std::string& handle, void** ptr), handle, ptr)                              \
   X(absl::Status, close_ipc_handle, (void* ptr), ptr)                                                                 \

--- a/core/common/cuda_backend_fake.cc
+++ b/core/common/cuda_backend_fake.cc
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/base/no_destructor.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
@@ -133,8 +134,8 @@ struct FakeCudaState {
 };
 
 FakeCudaState& get_state() {
-  static FakeCudaState state;
-  return state;
+  static absl::NoDestructor<FakeCudaState> state;
+  return *state;
 }
 
 std::string generate_random_handle() {

--- a/core/common/cuda_backend_fake.cc
+++ b/core/common/cuda_backend_fake.cc
@@ -748,6 +748,29 @@ absl::Status pointer_get_attributes_full(const void* ptr, cudaPointerAttributes*
   return absl::OkStatus();
 }
 
+absl::Status mem_get_address_range(void** base, size_t* range_bytes, const void* ptr) {
+  if (base == nullptr || range_bytes == nullptr || ptr == nullptr) {
+    return absl::InvalidArgumentError("base/range_bytes/ptr must be non-null");
+  }
+
+  auto& state = get_state();
+  absl::MutexLock lock(&state.mutex);
+
+  const std::uintptr_t needle = reinterpret_cast<std::uintptr_t>(ptr);
+  for (const auto& [alloc_ptr, alloc] : state.allocations) {
+    static_cast<void>(alloc_ptr);
+    const std::uintptr_t start = reinterpret_cast<std::uintptr_t>(alloc.ptr);
+    const std::uintptr_t end = start + alloc.size;
+    if (needle >= start && needle < end) {
+      *base = alloc.ptr;
+      *range_bytes = alloc.size;
+      return absl::OkStatus();
+    }
+  }
+
+  return absl::NotFoundError("pointer not found in fake CUDA allocations");
+}
+
 // Stream management
 absl::Status stream_create(cudaStream_t* stream) {
   if (stream == nullptr) {

--- a/core/common/cuda_backend_real.cc
+++ b/core/common/cuda_backend_real.cc
@@ -655,7 +655,11 @@ absl::Status cu_mem_get_handle_for_address_range(
 }
 
 absl::Status close_ipc_mem_handle(void* dev_ptr) {
-  SC_RETURN_IF_CUDA_ERROR(cudaIpcCloseMemHandle(dev_ptr));
+  const cudaError_t err = cudaIpcCloseMemHandle(dev_ptr);
+  if (err != cudaSuccess) {
+    static_cast<void>(cudaGetLastError());
+    return common::cuda_as_status(err, "cudaIpcCloseMemHandle");
+  }
   return absl::OkStatus();
 }
 

--- a/core/common/cuda_backend_real.cc
+++ b/core/common/cuda_backend_real.cc
@@ -281,6 +281,28 @@ absl::Status pointer_get_attributes_full(const void* ptr, cudaPointerAttributes*
   return absl::OkStatus();
 }
 
+absl::Status mem_get_address_range(void** base, size_t* range_bytes, const void* ptr) {
+  if (base == nullptr || range_bytes == nullptr || ptr == nullptr) {
+    return absl::InvalidArgumentError("base/range_bytes/ptr must be non-null");
+  }
+
+  auto status = ensure_cuda_driver_loaded();
+  if (!status.ok()) {
+    return status;
+  }
+
+  const DriverApi& driver = DriverApi::get();
+  CUdeviceptr base_ptr = 0;
+  status = cu_result_as_status(
+      driver.cuMemGetAddressRange(&base_ptr, range_bytes, reinterpret_cast<CUdeviceptr>(ptr)), "cuMemGetAddressRange");
+  if (!status.ok()) {
+    return status;
+  }
+
+  *base = reinterpret_cast<void*>(base_ptr);
+  return absl::OkStatus();
+}
+
 // Stream management
 absl::Status stream_create(cudaStream_t* stream) {
   SC_RETURN_IF_CUDA_ERROR(cudaStreamCreate(stream));

--- a/core/common/cuda_driver_api.h
+++ b/core/common/cuda_driver_api.h
@@ -13,6 +13,7 @@ namespace tensorcast::cuda {
   X(cuInit)                              \
   X(cuDeviceGet)                         \
   X(cuDeviceGetAttribute)                \
+  X(cuMemGetAddressRange)                \
   X(cuMemGetAllocationGranularity)       \
   X(cuMemAddressReserve)                 \
   X(cuMemCreate)                         \

--- a/core/communicator/BUILD
+++ b/core/communicator/BUILD
@@ -336,10 +336,10 @@ sc_cc_library(
     ],
 )
 
-# GPU Net Stager (header-only)
+# Host-pinned GPU stager (header-only)
 sc_header_only_library(
-    name = "gpu_net_stager_lib",
-    hdrs = ["engine/gpu_net_stager.h"],
+    name = "host_pinned_gpu_stager_lib",
+    hdrs = ["engine/host_pinned_gpu_stager.h"],
     visibility = ["//visibility:public"],
     deps = [
         ":memory_stager_lib",
@@ -350,11 +350,11 @@ sc_header_only_library(
     ],
 )
 
-# DRAM (CPU) stager implementation
+# Host-pinned CPU stager implementation
 sc_cc_library(
-    name = "dram_stager_lib",
-    srcs = ["engine/dram_stager.cc"],
-    hdrs = ["engine/dram_stager.h"],
+    name = "host_pinned_cpu_stager_lib",
+    srcs = ["engine/host_pinned_cpu_stager.cc"],
+    hdrs = ["engine/host_pinned_cpu_stager.h"],
     visibility = ["//visibility:public"],
     deps = [
         ":memory_stager_lib",
@@ -363,6 +363,24 @@ sc_cc_library(
         "@abseil-cpp//absl/base",
         "@abseil-cpp//absl/log:absl_log",
         "@abseil-cpp//absl/synchronization",
+    ],
+)
+
+# GPU VRAM staged-RDMA stager
+sc_cc_library(
+    name = "gpu_vram_rdma_stager_lib",
+    srcs = ["engine/gpu_vram_rdma_stager.cc"],
+    hdrs = ["engine/gpu_vram_rdma_stager.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":constants_lib",
+        ":memory_stager_lib",
+        ":partition_tensor_lib",
+        "//core/common:cuda_api_lib",
+        "@abseil-cpp//absl/log:absl_log",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/synchronization",
+        "@gsl",
     ],
 )
 
@@ -386,8 +404,9 @@ sc_cc_library(
     deps = [
         ":channel_lib",
         ":constants_lib",
-        ":dram_stager_lib",
-        ":gpu_net_stager_lib",
+        ":gpu_vram_rdma_stager_lib",
+        ":host_pinned_cpu_stager_lib",
+        ":host_pinned_gpu_stager_lib",
         ":message_lib",
         ":mr_cache_lib",
         ":mtcp_transport_lib",
@@ -577,6 +596,37 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "stager_mr_normalization_test",
+    srcs = ["engine/stager_mr_normalization_test.cc"],
+    tags = ["requires_cuda"],
+    deps = [
+        ":host_pinned_cpu_stager_lib",
+        ":host_pinned_gpu_stager_lib",
+        ":memory_stager_lib",
+        ":partition_tensor_lib",
+        "//core/common:cuda_api_lib",
+        "//core/common:pinned_buffer_pool_lib",
+        "//core/testing:catch_main",
+        "//core/testing:common",
+        "@catch2//:catch2_main",
+    ],
+)
+
+cc_test(
+    name = "gpu_vram_rdma_stager_test",
+    srcs = ["engine/gpu_vram_rdma_stager_test.cc"],
+    tags = ["requires_cuda"],
+    deps = [
+        ":gpu_vram_rdma_stager_lib",
+        ":partition_tensor_lib",
+        "//core/common:cuda_api_lib",
+        "//core/testing:catch_main",
+        "//core/testing:common",
+        "@catch2//:catch2_main",
+    ],
+)
+
 sc_header_only_library(
     name = "engine_hdrs",
     hdrs = ["engine/engine.h"],
@@ -584,7 +634,7 @@ sc_header_only_library(
     deps = [
         ":channel_lib",
         ":constants_lib",
-        ":dram_stager_lib",
+        ":host_pinned_cpu_stager_lib",
         ":ibv_wrap_lib",
         ":message_lib",
         ":mr_cache_lib",

--- a/core/communicator/BUILD
+++ b/core/communicator/BUILD
@@ -521,6 +521,16 @@ cc_test(
 )
 
 cc_test(
+    name = "rdma_stage_fn_test",
+    srcs = ["engine/rdma_stage_fn_test.cc"],
+    deps = [
+        ":engine_lib",
+        "//core/testing:catch_main",
+        "@catch2//:catch2_main",
+    ],
+)
+
+cc_test(
     name = "tcp_engine_test",
     srcs = ["engine/tcp_engine_test.cc"],
     deps = [

--- a/core/communicator/README.md
+++ b/core/communicator/README.md
@@ -35,7 +35,7 @@ flowchart TB
       TR[Transport Layer]
       MTCP[MTcpTransport]
       RDMA[RdmaTransport]
-      STAGER[GpuNetStager]
+      STAGER[HostPinnedGpuStager]
     end
 
     subgraph "Worker Threads"
@@ -62,7 +62,7 @@ flowchart TB
 * **Channel** — Manages logical connections (control + data) to remote peers, including pending RDMA reads by `<local_dev>|<peer_dev>`.
 * **Transport Layer** — Pluggable I/O mechanisms: TCP control, Multi-TCP (MTCP) bulk data, and RDMA queue pairs.
 * **PartitionTensorStore** — Thread-safe registry for local tensors (CPU and GPU) backed by `misc::Map`.
-* **Memory Stagers** — Unified `MemoryStager` interface with `GpuNetStager` (GPU→pinned) and `DRAMStager` (CPU→pinned) implementations.
+* **Memory Stagers** — Unified `MemoryStager` interface with `HostPinnedGpuStager` (GPU→host-pinned), `HostPinnedCpuStager` (CPU→host-pinned), and optional `GpuVramRdmaStager` (GPU→VRAM, RDMA-only) implementations.
 * **PinnedBufferPool & StreamingPinnedBuffer** — Shared pinned pools sourced from the daemon-wide `pinned_memory` authority (or internal defaults when constructed standalone).
 * **MrCache** — Per-protection-domain cache that reuses RDMA MRs for staged buffers to avoid repeated registrations.
 
@@ -198,7 +198,8 @@ classDiagram
     -thread request_thread_
     -thread gc_thread_
     -thread mtcp_staging_thread_
-    -GpuNetStager gpu_memory_stager_
+    -HostPinnedGpuStager gpu_memory_stager_
+    -Map gpu_vram_stagers_
     -MemoryStager memory_stager_
     -PinnedBufferPool gpu_memory_pool_
     -PinnedBufferPool cpu_memory_pool_
@@ -252,18 +253,23 @@ The transport abstraction allows pluggable implementations:
 
 The communicator routes tensor payloads through `MemoryStager` implementations:
 
-- `GpuNetStager` performs GPU→CPU copies into chunks carved from a shared `PinnedBufferPool` and streams them with `StreamingPinnedBuffer`.
-- `DRAMStager` copies CPU tensors into the same pool and can cooperate with UMA lease providers injected by the Store Engine.
+- `HostPinnedGpuStager` performs GPU→CPU copies into chunks carved from a shared `PinnedBufferPool` and streams them with `StreamingPinnedBuffer`.
+- `HostPinnedCpuStager` copies CPU tensors into the same pool and can cooperate with UMA lease providers injected by the Store Engine.
+- `GpuVramRdmaStager` (RDMA-only, optional) stages GPU tensors into a fixed VRAM pool when `communicator.rdma.staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM`.
 
 `PartitionTensor::needs_staging()` (set via `RegisterTensorOptions`) signals when MTCP transfers must stage GPU tensors. RDMA responses are always staged; staged segments are issued as `StageLease`s and tracked in the channel-scoped `StageLeaseRegistry` until transport completions release the associated credit.
 
-#### GPU staging (GpuNetStager)
+RDMA staging backend selection is explicit:
+- `STAGED_RDMA_BACKEND_HOST_PINNED` (default) uses host-pinned stagers for both CPU and GPU tensors.
+- `STAGED_RDMA_BACKEND_GPU_VRAM` uses `GpuVramRdmaStager` for GPU tensors and keeps `HostPinnedCpuStager` for CPU tensors. `StageLease::exposed_ptr()` may therefore reference host or device memory depending on backend.
+
+#### GPU staging (HostPinnedGpuStager)
 
 ```mermaid
 sequenceDiagram
   participant App
   participant Engine
-  participant Stager as GpuNetStager (MemoryStager)
+  participant Stager as HostPinnedGpuStager (MemoryStager)
   participant CUDA
   participant TCP
 
@@ -271,13 +277,13 @@ sequenceDiagram
   Engine->>Stager: stage(tensor, offset, bytes)
   Stager->>CUDA: cuda::memcpy(D2H)
   CUDA-->>Stager: pinned chunk
-  Stager-->>Engine: host pointer
+  Stager-->>Engine: exposed pointer
   Engine->>TCP: send(chunk)
   TCP-->>Remote: data
   Note over Engine: Release occurs via MemoryStager::release_staged_buffer after send completion or RDMA ACK
 ```
 
-#### CPU staging (DRAMStager)
+#### CPU staging (HostPinnedCpuStager)
 
 - Uses the same `PinnedBufferPool` slices to stage CPU tensors for RDMA or MTCP when required.
 - Optional UMA lease provider supplies short-lived pin leases around memcpy.
@@ -303,8 +309,8 @@ When MTCP is used, `PartitionTensor::needs_staging()` dictates whether the sende
 | ------ | ------ | -------------------------------------------------- | ------ |
 | CPU    | CPU    | Direct transfer                                    | ✅      |
 | CPU    | GPU    | Network→StreamingPinnedBuffer→GPU                  | ✅      |
-| GPU    | CPU    | GPU→GpuNetStager→Network                           | ✅      |
-| GPU    | GPU    | GPU→GpuNetStager→Network→StreamingPinnedBuffer→GPU | ✅      |
+| GPU    | CPU    | GPU→HostPinnedGpuStager→Network                           | ✅      |
+| GPU    | GPU    | GPU→HostPinnedGpuStager→Network→StreamingPinnedBuffer→GPU | ✅      |
 
 ### 3.6 Complete Data Transfer Architecture for TCP Mode
 
@@ -315,7 +321,7 @@ flowchart TB
     subgraph "Source Node"
         SrcCPU["CPU Tensor"]
         SrcGPU["GPU Tensor"]
-        SrcStager["MemoryStager<br/>(GpuNetStager/DRAMStager)"]
+        SrcStager["MemoryStager<br/>(HostPinnedGpuStager/HostPinnedCpuStager)"]
         SrcMTCP["MTcpTransport<br/>(send)"]
     end
 
@@ -373,16 +379,68 @@ Staging uses `CommunicatorConfig` for fan-out and `DaemonConfig.pinned_memory` f
 - `pinned_memory.classes[name=comm_gpu].slice_bytes`: GPU staging slice size (host-pinned).
 - `pinned_memory.classes[name=comm_cpu].slice_bytes`: CPU staging slice size (host-pinned).
 - `pinned_memory.classes[name=comm_*].pool_bytes`: staging pool budgets (capacity is `pool_bytes / slice_bytes`).
-- `pinned_memory.classes[name=comm_*].rdma_preregister`: when RDMA is enabled, preregister slabs once per NIC/PD.
+- `pinned_memory.classes[name=comm_*].rdma_preregister`: when RDMA is enabled, preregister host-pinned slabs once per NIC/PD.
+- `rdma.staging_backend`: staged-RDMA backend selector (`STAGED_RDMA_BACKEND_HOST_PINNED` or `STAGED_RDMA_BACKEND_GPU_VRAM`).
+- `rdma.vram_pool_bytes_per_gpu` / `rdma.vram_slice_bytes`: VRAM staging pool sizing (required when `rdma.staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM`).
 - `stager.buffers_per_flow`: number of buffers per flow (default: 4).
 - `stager.expected_gpu_channels`: optional cap on concurrent GPU MTCP transports (default: 0 = auto).
 
+#### Configuration Examples
+
+Enable RDMA + slab-level preregistration for host-pinned staging:
+
+```yaml
+communicator:
+  enable_rdma: true
+
+pinned_memory:
+  classes:
+    - name: comm_gpu
+      slice_bytes: 16MB
+      pool_bytes: 8GB
+      rdma_preregister: true
+    - name: comm_cpu
+      slice_bytes: 16MB
+      pool_bytes: 2GB
+      rdma_preregister: true
+```
+
+Enable forced GPU VRAM staged RDMA (RDMA-only) for GPU tensors:
+
+```yaml
+communicator:
+  enable_rdma: true
+  rdma:
+    staging_backend: STAGED_RDMA_BACKEND_GPU_VRAM
+    vram_pool_bytes_per_gpu: 2GB
+    vram_slice_bytes: 16MB
+
+# Still required for MTCP and for CPU tensors (and for host-pinned fallbacks).
+pinned_memory:
+  classes:
+    - name: comm_gpu
+      slice_bytes: 16MB
+      pool_bytes: 8GB
+      rdma_preregister: true
+    - name: comm_cpu
+      slice_bytes: 16MB
+      pool_bytes: 2GB
+      rdma_preregister: true
+```
+
+#### VRAM Pool Semantics (forced mode)
+
+When `rdma.staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM`:
+- The daemon allocates exactly one contiguous VRAM pool per initialized CUDA device (VRAM scales with GPU count, not NIC count).
+- The same per-GPU pool is preregistered once per NIC/PD (MR count scales with NIC/PD count, but VRAM allocation does not).
+- `vram_pool_bytes_per_gpu >= vram_slice_bytes` is required; if `vram_pool_bytes_per_gpu % vram_slice_bytes != 0`, the remainder is truncated with a warning.
+
 #### Performance Characteristics
 
-1. **Memory Usage**: staging capacity is capped by pinned class budgets; slices are reused across RDMA and MTCP flows.
+1. **Memory Usage**: staging capacity is capped by pinned class budgets; host-pinned slices are reused across MTCP and host-pinned RDMA flows (VRAM staging uses its own pool).
 2. **Pipelining**: Multiple buffers per flow allow GPU copies to overlap with socket I/O.
-3. **CPU Path**: MTCP can stream CPU tensors without staging, while RDMA stages CPU slices through `DRAMStager` and reuses cached MRs.
-4. **Explicit release**: `MemoryStager::release_staged_buffer` is invoked after MTCP send completion or upon `RDMA_READ_DONE_EX` to recycle pinned chunks.
+3. **CPU Path**: MTCP can stream CPU tensors without staging, while RDMA stages CPU slices through `HostPinnedCpuStager` and reuses cached MRs.
+4. **Explicit release**: `MemoryStager::release_staged_buffer` is invoked after MTCP send completion or upon `RDMA_READ_DONE_EX` to recycle staging chunks (host-pinned or VRAM).
 5. **Concurrency guard**: Set `stager.expected_gpu_channels` when sizing the pinned pool so `Communicator::init()` validates capacity up front; at runtime the communicator rejects MTCP GPU channels once this limit is reached instead of blocking on staging buffers indefinitely.
 
 ### 3.8 RDMA
@@ -392,7 +450,7 @@ Location: `transport/rdma_transport.{h,cc}` (QP, posting logic) and the RDMA pat
 Key behaviors:
 - `Channel::RdmaEndpoint` tracks each `<local_dev>|<peer_dev>` pair and governs the handshake lifecycle: `Idle → ConnectRequested → Ready → Failed`. Reads arriving while the endpoint is not `Ready` are enqueued with a generation token and drained only after the handshake succeeds.
 - When an endpoint sits in `Failed` backoff, new RDMA responses queue their reads and a dedicated retry worker schedules the next handshake exactly at `next_retry_at`, so queued requests resume automatically once the backoff expires (no additional control traffic is required to nudge the handshake).
-- `Communicator` stages every RDMA response into pinned buffers (`hdr->staged = 1`) and inserts each segment as a `StageLease` in the per-channel `StageLeaseRegistry`; `MrCache` reuses registrations per protection domain.
+- `Communicator` stages every RDMA response into the configured staging backend (`hdr->staged = 1`) and inserts each segment as a `StageLease` in the per-channel `StageLeaseRegistry`; `MrCache` reuses registrations per protection domain.
 - `on_receive_response()` only invokes `rdma_transport->read_multi()` after the endpoint transitions to `Ready`; handshake failures (connect response errors or explicit `ENGINE_OP_RDMA_CONNECT_FAILED`) flush the pending queue with an `absl::Status` that maps to `REMOTE_RDMA_CONNECT_FAILED` and schedule exponential backoff before retrying. When a fresh handshake attempt begins (`Idle` or `Failed` → `ConnectRequested`), the communicator now resets the failure counter so exponential backoff restarts from the minimum interval instead of inheriting the previous attempt's penalty.
 - `rdma_transport::read_multi()` now rejects calls while `ready()` is `false`; QP transitions are solely driven by `connect()` so callers cannot post READ WRs against an uninitialised queue pair.
 - Clients send `RDMA_READ_DONE_EX` after all segments complete. The server looks up the lease, deregisters when required, returns the buffer to the originating stager, and credits the `FlowCreditLedger`.
@@ -492,7 +550,7 @@ sequenceDiagram
   participant App
   participant Engine
   participant ReqThread as Request Thread
-  participant SrcStager as Source GpuNetStager
+  participant SrcStager as Source HostPinnedGpuStager
   participant Network as MTCP Network
   participant TgtBuffer as Target StreamingBuffer
   participant GPU as Target GPU
@@ -519,7 +577,7 @@ sequenceDiagram
 ```
 
 This flow demonstrates:
-- GPU tensors stage through `GpuNetStager` when `needs_staging` is set.
+- GPU tensors stage through `HostPinnedGpuStager` when `needs_staging` is set (MTCP). RDMA staged fallback uses the configured `rdma.staging_backend` (`STAGED_RDMA_BACKEND_HOST_PINNED` or `STAGED_RDMA_BACKEND_GPU_VRAM`).
 - Network transfer fans out across multiple MTCP sockets.
 - Streaming pinned buffers feed the final `cudaMemcpy(H2D)` on the target side.
 - MTCP completion triggers `MemoryStager::release_staged_buffer` to recycle pinned chunks.

--- a/core/communicator/README.md
+++ b/core/communicator/README.md
@@ -262,6 +262,7 @@ The communicator routes tensor payloads through `MemoryStager` implementations:
 RDMA staging backend selection is explicit:
 - `STAGED_RDMA_BACKEND_HOST_PINNED` (default) uses host-pinned stagers for both CPU and GPU tensors.
 - `STAGED_RDMA_BACKEND_GPU_VRAM` uses `GpuVramRdmaStager` for GPU tensors and keeps `HostPinnedCpuStager` for CPU tensors. `StageLease::exposed_ptr()` may therefore reference host or device memory depending on backend.
+  - If a request references a GPU `device_id` without a configured VRAM staging pool, the communicator logs a warning and falls back to host-pinned staging for that request (avoids null stagers and keeps the RDMA pipeline alive).
 
 #### GPU staging (HostPinnedGpuStager)
 

--- a/core/communicator/docs/comm-read-tensor.md
+++ b/core/communicator/docs/comm-read-tensor.md
@@ -21,11 +21,12 @@
    b) 选用传输方式：
       • RDMA 打开且对端请求 RDMA → 走 RDMA。
       • 其余情况走 MTCP (TCP)。
-   c) **RDMA 路径**：打包 `ProtoReadResponse`，返回 raddr/rkey，随后目标侧直接 RDMA READ。
+      c) **RDMA 路径**：打包 `ProtoReadResponse`，返回 raddr/rkey，随后目标侧直接 RDMA READ。
+         • GPU staging backend 由 `communicator.rdma.staging_backend` 决定（`STAGED_RDMA_BACKEND_HOST_PINNED` 或 `STAGED_RDMA_BACKEND_GPU_VRAM`）。
    d) **TCP 路径**：
       i. 若 tensor 在 CPU → 直接把 *(addr+offset)* 切块塞入 MTcpTransport::send_queue_。
       ii. 若 tensor 在 GPU 且 `needs_staging()` →
-          1. 调用 `GpuNetStager::stage()`，把 (offset,bytes) GPU→Pinned CPU。
+          1. 调用 `HostPinnedGpuStager::stage()`，把 (offset,bytes) GPU→Pinned CPU。
           2. 取得 ScopedStagedBuffer，放入 MTcpTransport 作为待发送 chunk；
              buffer 在 send 完成（future get）后自动归还。
           3. 循环直到本次 ReadRequest 所需字节全部发送。
@@ -61,7 +62,7 @@ flowchart LR
     RT["request_thread_\n(do_read_request_loop)"]
     CH_T["Channel (TCP/RDMA)"]
     MTCP_T["MTcpTransport (recv)"]
-    STAGER_T["GpuNetStager (optional H2D)"]
+    STAGER_T["HostPinnedGpuStager (optional H2D)"]
     MM_T["ReplicaLoadController"]
   end
 
@@ -74,7 +75,7 @@ flowchart LR
     CE_S["Communicator (source)"]
     CH_S["Channel (TCP/RDMA)"]
     MTCP_S["MTcpTransport (send)"]
-    STAGER_S["GpuNetStager (optional D2H)"]
+    STAGER_S["HostPinnedGpuStager (optional D2H)"]
     STORE["PartitionTensorStore"]
     Tensor[("Tensor (CPU/GPU)")]
   end
@@ -117,7 +118,7 @@ flowchart LR
    • 大量并发 reader 时 host-mem 竞争加剧，延迟抖动 ↑。
 
 4. **CUDA event / stream 数量不足**
-   • GpuNetStager 每个 chunk只分配一个 cudaEvent；并发 > num_chunks 时等待事件可形成隐形瓶颈。
+   • HostPinnedGpuStager 每个 chunk只分配一个 cudaEvent；并发 > num_chunks 时等待事件可形成隐形瓶颈。
 
 5. **Channel 发起/GC 频繁**
    • 在压力测试里每个 reader 创建独立 Communicator→Channel；hand-shake (listen + connect) & 2 秒 GC 周期会插入额外 RTT。

--- a/core/communicator/engine/engine.cc
+++ b/core/communicator/engine/engine.cc
@@ -137,6 +137,8 @@ const char* StagedBackendToString(v1::RdmaConfig::StagedRdmaBackend backend) {
 void record_staged_backend_metrics(v1::RdmaConfig::StagedRdmaBackend backend, bool tensor_on_cpu, uint64_t bytes);
 void record_mr_register_metrics(const char* location, const char* reason, bool success);
 
+} // namespace
+
 StagingWindow::StageFn MakeStageFunction(
     const std::shared_ptr<PartitionTensor>& tensor,
     FlowCreditLedger* ledger,
@@ -170,6 +172,13 @@ StagingWindow::StageFn MakeStageFunction(
           direct_mr,
           /*deregister_mr=*/false,
           metadata);
+    };
+  }
+
+  if (!stager) {
+    return [tensor_key = std::move(tensor_key)](
+               uint64_t /*offset*/, uint32_t /*bytes*/, uint32_t /*segment_idx*/) -> absl::StatusOr<StageLease> {
+      return absl::FailedPreconditionError(absl::StrCat("no staging backend available for tensor=", tensor_key));
     };
   }
 
@@ -230,6 +239,8 @@ StagingWindow::StageFn MakeStageFunction(
     return StageLease(fallback_stager, ledger, exposed_ptr, bytes, staged_mr, deregister_mr, metadata);
   };
 }
+
+namespace {
 
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Meter> g_comm_meter;
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_rdma_direct_segments_total;
@@ -1387,20 +1398,31 @@ absl::Status Communicator::handle_rdma_read_request(
   }
 
   const bool tensor_on_cpu = tensor->get_mem_type() == COMMUNICATE_ENGINE_DEV_CPU;
+  const int device_id = tensor->get_device_id();
 
   std::shared_ptr<MemoryStager> stager;
   if (tensor_on_cpu) {
     stager = get_cpu_stager_for_nic(dev->get_name());
   } else if (use_gpu_vram_staging_) {
-    stager = get_gpu_vram_stager_for_id(tensor->get_device_id());
+    stager = get_gpu_vram_stager_for_id(device_id);
   } else {
-    stager = get_gpu_mem_stager_for_id(tensor->get_device_id());
+    stager = get_gpu_mem_stager_for_id(device_id);
   }
 
   if (!stager) {
     if (tensor_on_cpu) {
       stager = memory_stager_;
-    } else if (!use_gpu_vram_staging_) {
+    } else if (use_gpu_vram_staging_) {
+      // VRAM staging is RDMA-only and depends on a per-GPU pool. If the tensor reports an
+      // unexpected device id, fall back to host-pinned GPU staging so we never end up with
+      // a nullptr stager later in the RDMA staging path.
+      LOG_FIRST_N(WARNING, 1) << "GPU VRAM staging enabled but no VRAM stager for device_id=" << device_id
+                              << "; falling back to host-pinned staging";
+      stager = get_gpu_mem_stager_for_id(device_id);
+      if (!stager) {
+        stager = gpu_memory_stager_;
+      }
+    } else {
       stager = gpu_memory_stager_;
     }
   }
@@ -1451,10 +1473,11 @@ absl::Status Communicator::handle_rdma_read_request(
       ? (direct_rdma_chunk_bytes_ > 0 ? direct_rdma_chunk_bytes_ : request.bytes)
       : (stager && stager->get_chunk_size() > 0 ? stager->get_chunk_size() : request.bytes);
 
-  const v1::RdmaConfig::StagedRdmaBackend staged_backend = tensor_on_cpu
-      ? v1::RdmaConfig::STAGED_RDMA_BACKEND_HOST_PINNED
-      : (use_gpu_vram_staging_ ? v1::RdmaConfig::STAGED_RDMA_BACKEND_GPU_VRAM
-                               : v1::RdmaConfig::STAGED_RDMA_BACKEND_HOST_PINNED);
+  const bool using_gpu_vram_stager =
+      !tensor_on_cpu && use_gpu_vram_staging_ && stager && stager == get_gpu_vram_stager_for_id(device_id);
+  const v1::RdmaConfig::StagedRdmaBackend staged_backend = using_gpu_vram_stager
+      ? v1::RdmaConfig::STAGED_RDMA_BACKEND_GPU_VRAM
+      : v1::RdmaConfig::STAGED_RDMA_BACKEND_HOST_PINNED;
 
   auto stage_fn = MakeStageFunction(
       tensor, ledger_ptr, stager, dev, mr_cache_ptr, tensor_key, staged_backend, use_direct, direct_mr);

--- a/core/communicator/engine/engine.cc
+++ b/core/communicator/engine/engine.cc
@@ -21,11 +21,13 @@
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 
+#include "core/common/cuda_api.h"
 #include "core/common/system_capabilities.h"
 #include "core/communicator/engine/channel.h"
-#include "core/communicator/engine/dram_stager.h"
 #include "core/communicator/engine/engine.h"
-#include "core/communicator/engine/gpu_net_stager.h"
+#include "core/communicator/engine/gpu_vram_rdma_stager.h"
+#include "core/communicator/engine/host_pinned_cpu_stager.h"
+#include "core/communicator/engine/host_pinned_gpu_stager.h"
 #include "core/communicator/engine/message.h"
 #include "core/communicator/engine/protocol.h"
 #include "core/communicator/engine/staging_flow_controller.h"
@@ -110,6 +112,31 @@ const char* DirectFallbackReasonToString(DirectFallbackReason reason) {
   return "unknown";
 }
 
+v1::RdmaConfig::StagedRdmaBackend NormalizeStagedBackend(const v1::CommunicatorConfig& config) {
+  auto backend = config.rdma().staging_backend();
+  if (backend == v1::RdmaConfig::STAGED_RDMA_BACKEND_UNSPECIFIED) {
+    return v1::RdmaConfig::STAGED_RDMA_BACKEND_HOST_PINNED;
+  }
+  return backend;
+}
+
+const char* StagedBackendToString(v1::RdmaConfig::StagedRdmaBackend backend) {
+  switch (backend) {
+    case v1::RdmaConfig::STAGED_RDMA_BACKEND_HOST_PINNED:
+      return "host_pinned";
+    case v1::RdmaConfig::STAGED_RDMA_BACKEND_GPU_VRAM:
+      return "gpu_vram";
+    case v1::RdmaConfig::STAGED_RDMA_BACKEND_UNSPECIFIED:
+    case v1::RdmaConfig_StagedRdmaBackend_RdmaConfig_StagedRdmaBackend_INT_MIN_SENTINEL_DO_NOT_USE_:
+    case v1::RdmaConfig_StagedRdmaBackend_RdmaConfig_StagedRdmaBackend_INT_MAX_SENTINEL_DO_NOT_USE_:
+      break;
+  }
+  return "host_pinned";
+}
+
+void record_staged_backend_metrics(v1::RdmaConfig::StagedRdmaBackend backend, bool tensor_on_cpu, uint64_t bytes);
+void record_mr_register_metrics(const char* location, const char* reason, bool success);
+
 StagingWindow::StageFn MakeStageFunction(
     const std::shared_ptr<PartitionTensor>& tensor,
     FlowCreditLedger* ledger,
@@ -117,6 +144,7 @@ StagingWindow::StageFn MakeStageFunction(
     const net_dev_t& dev,
     MrCache* mr_cache,
     std::string tensor_key,
+    v1::RdmaConfig::StagedRdmaBackend staged_backend,
     bool use_direct,
     ibv_mr* direct_mr) {
   if (use_direct) {
@@ -146,46 +174,51 @@ StagingWindow::StageFn MakeStageFunction(
   }
 
   auto fallback_stager = stager;
-  return [fallback_stager, tensor, dev, ledger, mr_cache, tensor_key = std::move(tensor_key)](
+  return [fallback_stager, tensor, dev, ledger, mr_cache, tensor_key = std::move(tensor_key), staged_backend](
              uint64_t offset, uint32_t bytes, uint32_t /*segment_idx*/) -> absl::StatusOr<StageLease> {
     constexpr int kAccess = IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_RELAXED_ORDERING;
     auto staged_or = fallback_stager->stage(tensor, offset, bytes, MemoryStager::StageMode::kTry);
     if (!staged_or.ok()) {
       return staged_or.status();
     }
-    void* host_ptr = *staged_or;
+    void* exposed_ptr = *staged_or;
     ibv_mr* staged_mr = nullptr;
     bool deregister_mr = false;
 
-    gsl::not_null<void*> host_ptr_nn{host_ptr};
+    gsl::not_null<void*> exposed_ptr_nn{exposed_ptr};
+    const char* mr_location = StagedBackendToString(staged_backend);
     if (mr_cache) {
-      gsl::not_null<void*> mr_base = host_ptr_nn;
-      size_t mr_bytes = bytes;
-      if (auto dram = std::dynamic_pointer_cast<DRAMStager>(fallback_stager)) {
-        if (auto slab = dram->pinned_pool()->slab_for_ptr(host_ptr_nn); slab.has_value()) {
-          mr_base = slab->base.get();
-          mr_bytes = slab->bytes;
-        }
-      }
+      const auto slab = NormalizeMrRegion(*fallback_stager, exposed_ptr_nn, bytes);
+      gsl::not_null<void*> mr_base = slab.base;
+      size_t mr_bytes = slab.bytes;
 
-      staged_mr = mr_cache->get_or_register(dev->get_pd(), mr_base, mr_bytes, kAccess);
+      auto mr_result = mr_cache->get_or_register(dev->get_pd(), mr_base, mr_bytes, kAccess);
+      staged_mr = mr_result.mr;
       if (staged_mr == nullptr) {
-        auto release_status = fallback_stager->release_staged_buffer(host_ptr_nn);
+        record_mr_register_metrics(mr_location, "cache_register_failed", false);
+        auto release_status = fallback_stager->release_staged_buffer(exposed_ptr_nn);
         if (!release_status.ok()) {
           LOG(WARNING) << "Failed to release staged buffer after MR cache failure: " << release_status;
         }
         return absl::InternalError("failed to register MR via cache");
       }
+      if (mr_result.registered) {
+        record_mr_register_metrics(mr_location, nullptr, true);
+      }
     } else {
-      if (dev->reg_mr(&staged_mr, host_ptr, bytes, kAccess) != SUCCESS) {
-        auto release_status = fallback_stager->release_staged_buffer(host_ptr_nn);
+      if (dev->reg_mr(&staged_mr, exposed_ptr, bytes, kAccess) != SUCCESS) {
+        record_mr_register_metrics(mr_location, "direct_register_failed", false);
+        auto release_status = fallback_stager->release_staged_buffer(exposed_ptr_nn);
         if (!release_status.ok()) {
           LOG(WARNING) << "Failed to release staged buffer after MR registration failure: " << release_status;
         }
         return absl::InternalError("failed to register staged MR");
       }
+      record_mr_register_metrics(mr_location, nullptr, true);
       deregister_mr = true;
     }
+
+    record_staged_backend_metrics(staged_backend, tensor->get_mem_type() == COMMUNICATE_ENGINE_DEV_CPU, bytes);
 
     StageLease::Metadata metadata;
     metadata.transport = StageTransport::kRdma;
@@ -194,7 +227,7 @@ StagingWindow::StageFn MakeStageFunction(
     metadata.bytes = bytes;
     metadata.zero_copy = false;
 
-    return StageLease(fallback_stager, ledger, host_ptr, bytes, staged_mr, deregister_mr, metadata);
+    return StageLease(fallback_stager, ledger, exposed_ptr, bytes, staged_mr, deregister_mr, metadata);
   };
 }
 
@@ -203,15 +236,26 @@ opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_rdma
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_rdma_direct_bytes_total;
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_rdma_direct_fallback_total;
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>> g_rdma_direct_window_bytes_hist;
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_rdma_staged_backend_total;
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_rdma_staged_bytes_total;
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_rdma_mr_register_total;
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_rdma_mr_register_failures_total;
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_pinned_rdma_prereg_failures_total;
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>> g_pinned_rdma_prereg_latency_ms_hist;
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> g_pinned_rdma_prereg_bytes_gauge;
 std::atomic<double> g_pinned_rdma_prereg_bytes_last{0.0};
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> g_vram_rdma_prereg_failures_total;
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>> g_vram_rdma_prereg_latency_ms_hist;
+opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> g_vram_rdma_prereg_bytes_gauge;
+std::atomic<double> g_vram_rdma_prereg_bytes_last{0.0};
 
 absl::once_flag g_comm_meter_once;
 absl::once_flag g_rdma_direct_window_metrics_once;
 absl::once_flag g_rdma_direct_fallback_metric_once;
+absl::once_flag g_rdma_staged_metrics_once;
+absl::once_flag g_rdma_mr_register_metrics_once;
 absl::once_flag g_pinned_rdma_prereg_metrics_once;
+absl::once_flag g_vram_rdma_prereg_metrics_once;
 
 inline void ensure_communicator_meter() {
   absl::call_once(g_comm_meter_once, []() {
@@ -235,6 +279,22 @@ inline void ensure_rdma_direct_fallback_metric() {
   });
 }
 
+inline void ensure_rdma_staged_metrics() {
+  ensure_communicator_meter();
+  absl::call_once(g_rdma_staged_metrics_once, []() {
+    g_rdma_staged_backend_total = g_comm_meter->CreateDoubleCounter("tc_rdma_staged_backend_total");
+    g_rdma_staged_bytes_total = g_comm_meter->CreateDoubleCounter("tc_rdma_staged_bytes_total");
+  });
+}
+
+inline void ensure_rdma_mr_register_metrics() {
+  ensure_communicator_meter();
+  absl::call_once(g_rdma_mr_register_metrics_once, []() {
+    g_rdma_mr_register_total = g_comm_meter->CreateDoubleCounter("tc_rdma_mr_register_total");
+    g_rdma_mr_register_failures_total = g_comm_meter->CreateDoubleCounter("tc_rdma_mr_register_failures_total");
+  });
+}
+
 void pinned_rdma_prereg_bytes_callback(opentelemetry::metrics::ObserverResult result, void* /*state*/) noexcept {
   auto obs =
       opentelemetry::nostd::get<opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<double>>>(
@@ -255,6 +315,26 @@ inline void ensure_pinned_rdma_prereg_metrics() {
   });
 }
 
+void vram_rdma_prereg_bytes_callback(opentelemetry::metrics::ObserverResult result, void* /*state*/) noexcept {
+  auto obs =
+      opentelemetry::nostd::get<opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<double>>>(
+          result);
+  if (!obs) {
+    return;
+  }
+  obs->Observe(g_vram_rdma_prereg_bytes_last.load());
+}
+
+inline void ensure_vram_rdma_prereg_metrics() {
+  ensure_communicator_meter();
+  absl::call_once(g_vram_rdma_prereg_metrics_once, []() {
+    g_vram_rdma_prereg_failures_total = g_comm_meter->CreateDoubleCounter("tc_vram_rdma_prereg_failures_total");
+    g_vram_rdma_prereg_latency_ms_hist = g_comm_meter->CreateDoubleHistogram("tc_vram_rdma_prereg_latency_ms");
+    g_vram_rdma_prereg_bytes_gauge = g_comm_meter->CreateDoubleObservableGauge("tc_vram_rdma_prereg_bytes");
+    g_vram_rdma_prereg_bytes_gauge->AddCallback(&vram_rdma_prereg_bytes_callback, nullptr);
+  });
+}
+
 void record_direct_window_metrics(int device_id, uint64_t segments, uint64_t bytes) {
   if (segments == 0 && bytes == 0) {
     return;
@@ -272,6 +352,41 @@ void record_direct_window_metrics(int device_id, uint64_t segments, uint64_t byt
     g_rdma_direct_bytes_total->Add(bytes_double, attr_view, ctx);
     g_rdma_direct_window_bytes_hist->Record(bytes_double, attr_view, ctx);
   }
+}
+
+void record_staged_backend_metrics(v1::RdmaConfig::StagedRdmaBackend backend, bool tensor_on_cpu, uint64_t bytes) {
+  ensure_rdma_staged_metrics();
+  if (!g_rdma_staged_backend_total || !g_rdma_staged_bytes_total) {
+    return;
+  }
+  const char* backend_label = StagedBackendToString(backend);
+  const char* mem_label = tensor_on_cpu ? "cpu" : "gpu";
+  std::map<std::string, opentelemetry::common::AttributeValue> attrs;
+  attrs.emplace("backend", backend_label);
+  attrs.emplace("mem", mem_label);
+  auto attr_view = opentelemetry::common::KeyValueIterableView(attrs);
+  g_rdma_staged_backend_total->Add(1.0, attr_view, opentelemetry::context::Context{});
+  g_rdma_staged_bytes_total->Add(static_cast<double>(bytes), attr_view, opentelemetry::context::Context{});
+}
+
+void record_mr_register_metrics(const char* location, const char* reason, bool success) {
+  ensure_rdma_mr_register_metrics();
+  if (!g_rdma_mr_register_total || !g_rdma_mr_register_failures_total) {
+    return;
+  }
+  if (success) {
+    std::map<std::string, opentelemetry::common::AttributeValue> attrs;
+    attrs.emplace("method", "ibv_reg_mr");
+    attrs.emplace("location", location);
+    auto attr_view = opentelemetry::common::KeyValueIterableView(attrs);
+    g_rdma_mr_register_total->Add(1.0, attr_view, opentelemetry::context::Context{});
+    return;
+  }
+  std::map<std::string, opentelemetry::common::AttributeValue> attrs;
+  attrs.emplace("method", "ibv_reg_mr");
+  attrs.emplace("reason", reason);
+  auto attr_view = opentelemetry::common::KeyValueIterableView(attrs);
+  g_rdma_mr_register_failures_total->Add(1.0, attr_view, opentelemetry::context::Context{});
 }
 
 void record_direct_fallback_metric(DirectFallbackReason reason) {
@@ -349,7 +464,7 @@ RdmaDriveResult DriveRdmaSession(Channel::FlowState& flow_state, RdmaReadSession
       auto* seg_pl = reinterpret_cast<ProtoReadResponseExSeg*>(
           reinterpret_cast<uint8_t*>(hdr) + sizeof(ProtoReadResponseExHeader) + i * sizeof(ProtoReadResponseExSeg));
 
-      seg_pl->addr = reinterpret_cast<uint64_t>(segment.lease.host_ptr());
+      seg_pl->addr = reinterpret_cast<uint64_t>(segment.lease.exposed_ptr());
       seg_pl->offset = segment.offset;
       seg_pl->bytes = segment.bytes;
       seg_pl->rkey = segment.lease.mr() ? segment.lease.mr()->rkey : 0;
@@ -505,6 +620,37 @@ Communicator::Communicator(const v1::CommunicatorConfig& config, PinnedStagingPo
     LOG(WARNING) << "Communicator staging_wait_timeout is <= 0; defaulting to 30s";
     staging_wait_timeout_ = absl::Seconds(30);
   }
+  const auto staging_backend = NormalizeStagedBackend(config_);
+  if (staging_backend == v1::RdmaConfig::STAGED_RDMA_BACKEND_GPU_VRAM && !enable_rdma_) {
+    LOG(FATAL) << "rdma.staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM requires enable_rdma=true";
+  }
+  use_gpu_vram_staging_ = enable_rdma_ && staging_backend == v1::RdmaConfig::STAGED_RDMA_BACKEND_GPU_VRAM;
+  if (use_gpu_vram_staging_) {
+    const uint64_t pool_bytes = config_.rdma().vram_pool_bytes_per_gpu();
+    const uint64_t slice_bytes = config_.rdma().vram_slice_bytes();
+    if (pool_bytes == 0 || slice_bytes == 0) {
+      LOG(FATAL) << "rdma.vram_pool_bytes_per_gpu and rdma.vram_slice_bytes must be > 0 when "
+                    "STAGED_RDMA_BACKEND_GPU_VRAM staging is set";
+    }
+    int device_count = 0;
+    auto count_status = cuda::get_device_count(&device_count);
+    if (!count_status.ok()) {
+      LOG(FATAL) << "Failed to query CUDA device count for GPU VRAM staging: " << count_status;
+    }
+    if (device_count <= 0) {
+      LOG(FATAL) << "GPU VRAM staging requires at least one CUDA device";
+    }
+    for (int device_id = 0; device_id < device_count; ++device_id) {
+      auto pool = std::make_shared<GpuVramStagingPool>(
+          device_id, static_cast<size_t>(pool_bytes), static_cast<size_t>(slice_bytes));
+      auto init_status = pool->initialize();
+      if (!init_status.ok()) {
+        LOG(FATAL) << "Failed to initialize GPU VRAM staging pool for device=" << device_id << ": " << init_status;
+      }
+      gpu_vram_pools_[device_id] = pool;
+      gpu_vram_stagers_[device_id] = std::make_shared<GpuVramRdmaStager>(pool);
+    }
+  }
 
   if (config_.stager().buffers_per_flow() <= 0) {
     LOG(FATAL) << "stager.buffers_per_flow must be > 0";
@@ -548,7 +694,7 @@ Communicator::Communicator(const v1::CommunicatorConfig& config, PinnedStagingPo
                << " (buffers_per_flow=" << num_buffers << " tcp_conn_count=" << config_.transport().tcp_conn_count()
                << ")";
   }
-  gpu_memory_stager_ = std::make_shared<GpuNetStager>(gpu_chunk_size, num_buffers, gpu_memory_pool_);
+  gpu_memory_stager_ = std::make_shared<HostPinnedGpuStager>(gpu_chunk_size, num_buffers, gpu_memory_pool_);
 
   const size_t total_gpu_slices = capacity_gpu_slices;
   if (total_gpu_slices == 0) {
@@ -597,10 +743,10 @@ Communicator::Communicator(const v1::CommunicatorConfig& config, PinnedStagingPo
     }
   }
   auto dram_pool = cpu_memory_pool_ ? cpu_memory_pool_ : gpu_memory_pool_;
-  memory_stager_ = std::make_shared<DRAMStager>(
+  memory_stager_ = std::make_shared<HostPinnedCpuStager>(
       gsl::not_null<std::shared_ptr<common::memory::PinnedBufferPool>>{dram_pool}, /*num_buffers_hint=*/num_buffers);
-  if (auto ds = std::dynamic_pointer_cast<DRAMStager>(memory_stager_)) {
-    ds->set_lease_provider(DRAMStager::make_noop_lease_provider());
+  if (auto ds = std::dynamic_pointer_cast<HostPinnedCpuStager>(memory_stager_)) {
+    ds->set_lease_provider(HostPinnedCpuStager::make_noop_lease_provider());
   }
 
   if (enable_rdma_) {
@@ -609,16 +755,17 @@ Communicator::Communicator(const v1::CommunicatorConfig& config, PinnedStagingPo
     // Apply typed RDMA QP tuning
     rdma_context_->set_qp_params(
         config_.rdma().traffic_class(), config_.rdma().qp_timeout(), config_.rdma().qp_retry());
+    int access = IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_RELAXED_ORDERING;
 
     if (config_.simple_numa().enable()) {
       for (const auto& node : config_.simple_numa().nodes()) {
-        auto cpu_stager = std::make_shared<DRAMStager>(
+        auto cpu_stager = std::make_shared<HostPinnedCpuStager>(
             gsl::not_null<std::shared_ptr<common::memory::PinnedBufferPool>>{dram_pool},
             /*num_buffers_hint=*/num_buffers);
-        if (auto ds = std::dynamic_pointer_cast<DRAMStager>(cpu_stager)) {
-          ds->set_lease_provider(DRAMStager::make_noop_lease_provider());
+        if (auto ds = std::dynamic_pointer_cast<HostPinnedCpuStager>(cpu_stager)) {
+          ds->set_lease_provider(HostPinnedCpuStager::make_noop_lease_provider());
         }
-        auto gpu_mem_stager = std::make_shared<GpuNetStager>(gpu_chunk_size, num_buffers, gpu_memory_pool_);
+        auto gpu_mem_stager = std::make_shared<HostPinnedGpuStager>(gpu_chunk_size, num_buffers, gpu_memory_pool_);
         // Map GPU ids
         for (int gid : node.gpus()) {
           gpu_mem_stagers_[gid] = gpu_mem_stager;
@@ -630,10 +777,60 @@ Communicator::Communicator(const v1::CommunicatorConfig& config, PinnedStagingPo
       }
     }
 
+    if (use_gpu_vram_staging_) {
+      ensure_vram_rdma_prereg_metrics();
+      const auto prereg_start = std::chrono::steady_clock::now();
+      uint64_t prereg_bytes = 0;
+      for (const auto& entry : gpu_vram_pools_) {
+        prereg_bytes += entry.second->pool_bytes();
+      }
+      g_vram_rdma_prereg_bytes_last.store(static_cast<double>(prereg_bytes));
+
+      uint64_t failures = 0;
+      for (const auto& dev : rdma_context_->list_devs()) {
+        for (const auto& entry : gpu_vram_pools_) {
+          auto slab = entry.second->mr_slab();
+          if (!slab.has_value()) {
+            ++failures;
+            LOG(WARNING) << "Failed to preregister VRAM MR for device=" << entry.first << ": missing slab";
+            record_mr_register_metrics("gpu_vram", "preregister_failed", false);
+            continue;
+          }
+          auto result = meta_mr_cache_->get_or_register(dev->get_pd(), slab->base, slab->bytes, access);
+          if (result.mr == nullptr) {
+            ++failures;
+            LOG(WARNING) << "Failed to preregister VRAM MR for slab " << static_cast<void*>(slab->base.get())
+                         << " bytes=" << slab->bytes << " on PD";
+            record_mr_register_metrics("gpu_vram", "preregister_failed", false);
+            continue;
+          }
+          if (result.registered) {
+            record_mr_register_metrics("gpu_vram", nullptr, true);
+          }
+        }
+      }
+      const auto prereg_end = std::chrono::steady_clock::now();
+      const double prereg_ms =
+          std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(prereg_end - prereg_start).count();
+      if (g_vram_rdma_prereg_latency_ms_hist) {
+        std::map<std::string, opentelemetry::common::AttributeValue> attrs;
+        auto attr_view = opentelemetry::common::KeyValueIterableView(attrs);
+        g_vram_rdma_prereg_latency_ms_hist->Record(prereg_ms, attr_view, opentelemetry::context::Context{});
+      }
+      if (failures > 0 && g_vram_rdma_prereg_failures_total) {
+        std::map<std::string, opentelemetry::common::AttributeValue> attrs;
+        auto attr_view = opentelemetry::common::KeyValueIterableView(attrs);
+        g_vram_rdma_prereg_failures_total->Add(
+            static_cast<double>(failures), attr_view, opentelemetry::context::Context{});
+      }
+      if (failures > 0) {
+        LOG(FATAL) << "GPU VRAM staging preregistration failed for " << failures << " slabs";
+      }
+    }
+
     // Preregister MRs for selected pools (slab-level).
     ensure_pinned_rdma_prereg_metrics();
     const auto prereg_start = std::chrono::steady_clock::now();
-    int access = IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_RELAXED_ORDERING;
     std::vector<std::shared_ptr<common::memory::PinnedBufferPool>> pools;
     if (preregister_gpu_pool_) {
       pools.push_back(gpu_memory_pool_);
@@ -653,11 +850,14 @@ Communicator::Communicator(const v1::CommunicatorConfig& config, PinnedStagingPo
     for (const auto& dev : rdma_context_->list_devs()) {
       for (auto& pool : pools) {
         for (const auto& slab : pool->list_slabs()) {
-          auto* mr = meta_mr_cache_->get_or_register(dev->get_pd(), slab.base.get(), slab.bytes, access);
-          if (mr == nullptr) {
+          auto result = meta_mr_cache_->get_or_register(dev->get_pd(), slab.base.get(), slab.bytes, access);
+          if (result.mr == nullptr) {
             ++failures;
             LOG(WARNING) << "Failed to preregister MR for slab " << static_cast<void*>(slab.base.get())
                          << " bytes=" << slab.bytes << " on PD";
+            record_mr_register_metrics("host_pinned", "preregister_failed", false);
+          } else if (result.registered) {
+            record_mr_register_metrics("host_pinned", nullptr, true);
           }
         }
       }
@@ -849,7 +1049,7 @@ void Communicator::process_mtcp_read_task(MtcpReadTask task) {
     if (!staged_or.ok()) {
       return staged_or.status();
     }
-    void* host_ptr = *staged_or;
+    void* exposed_ptr = *staged_or;
 
     StageLease::Metadata metadata;
     metadata.transport = StageTransport::kMtcp;
@@ -858,7 +1058,14 @@ void Communicator::process_mtcp_read_task(MtcpReadTask task) {
     metadata.bytes = bytes;
     metadata.segment_idx = segment_idx;
 
-    return StageLease(stager, &flow_state->ledger, host_ptr, bytes, /*mr=*/nullptr, /*deregister_mr=*/false, metadata);
+    return StageLease(
+        stager,
+        &flow_state->ledger,
+        exposed_ptr,
+        bytes,
+        /*mr=*/nullptr,
+        /*deregister_mr=*/false,
+        metadata);
   };
 
   StagingWindow window(
@@ -944,7 +1151,7 @@ void Communicator::process_mtcp_read_task(MtcpReadTask task) {
       flow_state->registry.put(key, lease);
 
       transport::MTcpTransport::StageSendSegment send_segment;
-      send_segment.data = lease.host_ptr();
+      send_segment.data = lease.exposed_ptr();
       send_segment.bytes = metadata.bytes;
       send_segment.metadata = metadata;
 
@@ -982,15 +1189,15 @@ void Communicator::process_mtcp_read_task(MtcpReadTask task) {
   }
 }
 
-void Communicator::set_dram_lease_provider(const std::shared_ptr<DRAMStager::LeaseProvider>& provider) {
+void Communicator::set_dram_lease_provider(const std::shared_ptr<HostPinnedCpuStager::LeaseProvider>& provider) {
   if (!memory_stager_)
     return;
-  if (auto ds = std::dynamic_pointer_cast<DRAMStager>(memory_stager_)) {
+  if (auto ds = std::dynamic_pointer_cast<HostPinnedCpuStager>(memory_stager_)) {
     ds->set_lease_provider(provider);
   }
   // Also propagate to NUMA CPU stagers if present
   for (auto& kv : nic_cpu_stagers_) {
-    if (auto ds2 = std::dynamic_pointer_cast<DRAMStager>(kv.second)) {
+    if (auto ds2 = std::dynamic_pointer_cast<HostPinnedCpuStager>(kv.second)) {
       ds2->set_lease_provider(provider);
     }
   }
@@ -1184,13 +1391,18 @@ absl::Status Communicator::handle_rdma_read_request(
   std::shared_ptr<MemoryStager> stager;
   if (tensor_on_cpu) {
     stager = get_cpu_stager_for_nic(dev->get_name());
+  } else if (use_gpu_vram_staging_) {
+    stager = get_gpu_vram_stager_for_id(tensor->get_device_id());
   } else {
-    // TODO: need to check
     stager = get_gpu_mem_stager_for_id(tensor->get_device_id());
   }
 
   if (!stager) {
-    stager = tensor_on_cpu ? memory_stager_ : gpu_memory_stager_;
+    if (tensor_on_cpu) {
+      stager = memory_stager_;
+    } else if (!use_gpu_vram_staging_) {
+      stager = gpu_memory_stager_;
+    }
   }
 
   const uint64_t total_bytes = request.bytes;
@@ -1239,7 +1451,13 @@ absl::Status Communicator::handle_rdma_read_request(
       ? (direct_rdma_chunk_bytes_ > 0 ? direct_rdma_chunk_bytes_ : request.bytes)
       : (stager && stager->get_chunk_size() > 0 ? stager->get_chunk_size() : request.bytes);
 
-  auto stage_fn = MakeStageFunction(tensor, ledger_ptr, stager, dev, mr_cache_ptr, tensor_key, use_direct, direct_mr);
+  const v1::RdmaConfig::StagedRdmaBackend staged_backend = tensor_on_cpu
+      ? v1::RdmaConfig::STAGED_RDMA_BACKEND_HOST_PINNED
+      : (use_gpu_vram_staging_ ? v1::RdmaConfig::STAGED_RDMA_BACKEND_GPU_VRAM
+                               : v1::RdmaConfig::STAGED_RDMA_BACKEND_HOST_PINNED);
+
+  auto stage_fn = MakeStageFunction(
+      tensor, ledger_ptr, stager, dev, mr_cache_ptr, tensor_key, staged_backend, use_direct, direct_mr);
 
   auto session = std::make_shared<RdmaReadSession>();
   session->request = request;
@@ -2569,6 +2787,13 @@ std::shared_ptr<MemoryStager> Communicator::get_cpu_stager_for_nic(const std::st
 std::shared_ptr<MemoryStager> Communicator::get_gpu_mem_stager_for_id(int gpu_id) const {
   auto it = gpu_mem_stagers_.find(gpu_id);
   if (it != gpu_mem_stagers_.end())
+    return it->second;
+  return nullptr;
+}
+
+std::shared_ptr<MemoryStager> Communicator::get_gpu_vram_stager_for_id(int gpu_id) const {
+  auto it = gpu_vram_stagers_.find(gpu_id);
+  if (it != gpu_vram_stagers_.end())
     return it->second;
   return nullptr;
 }

--- a/core/communicator/engine/engine.h
+++ b/core/communicator/engine/engine.h
@@ -22,7 +22,7 @@
 
 #include "core/common/memory/pinned_buffer_pool.h"
 #include "core/communicator/engine/channel.h"
-#include "core/communicator/engine/dram_stager.h"
+#include "core/communicator/engine/host_pinned_cpu_stager.h"
 #include "core/communicator/engine/memory_stager.h"
 #include "core/communicator/engine/message.h"
 #include "core/communicator/engine/mr_cache.h"
@@ -32,6 +32,7 @@
 namespace tensorcast::communicator::engine {
 
 class CommunicatorTestPeer;
+class GpuVramStagingPool;
 
 class Communicator {
  public:
@@ -129,7 +130,7 @@ class Communicator {
   absl::Status close_connection(const std::string& dst_ip, uint16_t dst_port);
 
   // Inject a UMA-backed lease provider for DRAM staging (optional).
-  void set_dram_lease_provider(const std::shared_ptr<DRAMStager::LeaseProvider>& provider);
+  void set_dram_lease_provider(const std::shared_ptr<HostPinnedCpuStager::LeaseProvider>& provider);
 
   // Lightweight UMA residency provider (reserved)
   struct ResidencyProvider {
@@ -250,8 +251,12 @@ class Communicator {
   uint32_t max_window_segments_ = 0;
   uint64_t direct_rdma_chunk_bytes_ = 0;
 
-  // GPU->CPU staging uses unified GPU MemoryStager only
+  // Host-pinned GPU staging uses unified GPU MemoryStager only.
   std::shared_ptr<engine::MemoryStager> gpu_memory_stager_;
+  // GPU VRAM staged-RDMA backend (when enabled).
+  std::unordered_map<int, std::shared_ptr<MemoryStager>> gpu_vram_stagers_;
+  std::unordered_map<int, std::shared_ptr<GpuVramStagingPool>> gpu_vram_pools_;
+  bool use_gpu_vram_staging_ = false;
 
   // Shared pinned memory pool for GPU operations
   std::shared_ptr<common::memory::PinnedBufferPool> gpu_memory_pool_;
@@ -274,12 +279,13 @@ class Communicator {
   // --- Simple NUMA mapping (Phase 3) ---
   // Mapping from NIC name -> CPU MemoryStager (pool per NUMA node)
   std::unordered_map<std::string, std::shared_ptr<MemoryStager>> nic_cpu_stagers_;
-  // Mapping from GPU id -> MemoryStager (GpuNetStager adapter per NUMA node)
+  // Mapping from GPU id -> MemoryStager (host-pinned GPU staging per NUMA node)
   std::unordered_map<int, std::shared_ptr<MemoryStager>> gpu_mem_stagers_;
 
   // Helpers to select NUMA-aware stagers
   std::shared_ptr<engine::MemoryStager> get_cpu_stager_for_nic(const std::string& nic_name) const;
   std::shared_ptr<engine::MemoryStager> get_gpu_mem_stager_for_id(int gpu_id) const;
+  std::shared_ptr<engine::MemoryStager> get_gpu_vram_stager_for_id(int gpu_id) const;
 
   absl::Mutex handshake_retry_mu_;
   absl::CondVar handshake_retry_cv_;

--- a/core/communicator/engine/gpu_vram_rdma_stager.cc
+++ b/core/communicator/engine/gpu_vram_rdma_stager.cc
@@ -1,0 +1,244 @@
+// Copyright (c) 2025-2026, TensorCast Team.
+
+#include "core/communicator/engine/gpu_vram_rdma_stager.h"
+
+#include <algorithm>
+#include <cstdint>
+
+#include "absl/log/log.h"
+#include "absl/strings/str_cat.h"
+
+namespace tensorcast::communicator::engine {
+
+GpuVramStagingPool::GpuVramStagingPool(int device_id, size_t pool_bytes, size_t slice_bytes)
+    : device_id_(device_id), pool_bytes_(pool_bytes), slice_bytes_(slice_bytes) {}
+
+GpuVramStagingPool::~GpuVramStagingPool() {
+  auto status = release_pool();
+  if (!status.ok()) {
+    LOG(WARNING) << "Failed to release VRAM staging pool: " << status;
+  }
+}
+
+absl::Status GpuVramStagingPool::initialize() {
+  if (initialized_) {
+    return absl::FailedPreconditionError("GpuVramStagingPool already initialized");
+  }
+  if (slice_bytes_ == 0) {
+    return absl::InvalidArgumentError("GpuVramStagingPool slice_bytes must be > 0");
+  }
+  if (pool_bytes_ < slice_bytes_) {
+    return absl::InvalidArgumentError("GpuVramStagingPool pool_bytes must be >= slice_bytes");
+  }
+  num_slices_ = pool_bytes_ / slice_bytes_;
+  if (num_slices_ == 0) {
+    return absl::InvalidArgumentError("GpuVramStagingPool has zero usable slices");
+  }
+  if (pool_bytes_ % slice_bytes_ != 0) {
+    LOG(WARNING) << "GpuVramStagingPool pool_bytes not aligned to slice_bytes; truncating remainder."
+                 << " pool_bytes=" << pool_bytes_ << " slice_bytes=" << slice_bytes_;
+  }
+
+  int device_id = std::max(device_id_, 0);
+  auto device_status = cuda::set_device(device_id);
+  if (!device_status.ok()) {
+    return device_status;
+  }
+
+  auto alloc_status = cuda::malloc(&base_ptr_, pool_bytes_);
+  if (!alloc_status.ok()) {
+    return alloc_status;
+  }
+
+  {
+    absl::MutexLock lock(&mu_);
+    free_indices_.reserve(num_slices_);
+    in_use_.assign(num_slices_, false);
+    for (size_t i = 0; i < num_slices_; ++i) {
+      free_indices_.push_back(static_cast<int>(i));
+    }
+    initialized_ = true;
+  }
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<GpuVramStagingPool::Slice> GpuVramStagingPool::acquire_slice() {
+  absl::MutexLock lock(&mu_);
+  if (!initialized_) {
+    return absl::FailedPreconditionError("GpuVramStagingPool not initialized");
+  }
+  if (free_indices_.empty()) {
+    return absl::ResourceExhaustedError(
+        absl::StrCat(
+            "GpuVramStagingPool exhausted: device_id=",
+            device_id_,
+            " slice_bytes=",
+            slice_bytes_,
+            " pool_bytes=",
+            pool_bytes_));
+  }
+  int index = free_indices_.back();
+  free_indices_.pop_back();
+  in_use_.at(static_cast<size_t>(index)) = true;
+  auto* base = static_cast<uint8_t*>(base_ptr_);
+  void* ptr = static_cast<void*>(base + (static_cast<size_t>(index) * slice_bytes_));
+  return Slice{.ptr = ptr, .bytes = slice_bytes_, .index = index};
+}
+
+absl::Status GpuVramStagingPool::release_slice(int index) {
+  absl::MutexLock lock(&mu_);
+  if (!initialized_) {
+    return absl::FailedPreconditionError("GpuVramStagingPool not initialized");
+  }
+  if (index < 0 || static_cast<size_t>(index) >= num_slices_) {
+    return absl::InvalidArgumentError("GpuVramStagingPool slice index out of range");
+  }
+  if (!in_use_.at(static_cast<size_t>(index))) {
+    return absl::NotFoundError("GpuVramStagingPool slice not in use");
+  }
+  in_use_.at(static_cast<size_t>(index)) = false;
+  free_indices_.push_back(index);
+  return absl::OkStatus();
+}
+
+bool GpuVramStagingPool::contains_ptr(gsl::not_null<void*> ptr) const {
+  if (base_ptr_ == nullptr || pool_bytes_ == 0) {
+    return false;
+  }
+  const auto base = reinterpret_cast<std::uintptr_t>(base_ptr_);
+  const auto end = base + pool_bytes_;
+  const auto probe = reinterpret_cast<std::uintptr_t>(ptr.get());
+  return probe >= base && probe < end;
+}
+
+std::optional<MemoryStager::MrSlab> GpuVramStagingPool::mr_slab() const {
+  if (base_ptr_ == nullptr || pool_bytes_ == 0) {
+    return std::nullopt;
+  }
+  return MemoryStager::MrSlab{gsl::not_null<void*>{base_ptr_}, pool_bytes_};
+}
+
+absl::Status GpuVramStagingPool::release_pool() {
+  if (base_ptr_ == nullptr) {
+    return absl::OkStatus();
+  }
+  int device_id = std::max(device_id_, 0);
+  auto device_status = cuda::set_device(device_id);
+  if (!device_status.ok()) {
+    return device_status;
+  }
+  auto free_status = cuda::free(base_ptr_);
+  if (!free_status.ok()) {
+    return free_status;
+  }
+  base_ptr_ = nullptr;
+  {
+    absl::MutexLock lock(&mu_);
+    free_indices_.clear();
+    in_use_.clear();
+    initialized_ = false;
+  }
+  return absl::OkStatus();
+}
+
+GpuVramRdmaStager::GpuVramRdmaStager(std::shared_ptr<GpuVramStagingPool> pool) : pool_(std::move(pool)) {
+  if (!pool_) {
+    LOG(FATAL) << "GpuVramRdmaStager requires a non-null pool";
+  }
+}
+
+absl::StatusOr<void*> GpuVramRdmaStager::stage(
+    const std::shared_ptr<transport::PartitionTensor>& tensor,
+    uint64_t offset,
+    uint64_t bytes,
+    StageMode /*mode*/) {
+  if (bytes == 0 || bytes > pool_->slice_bytes()) {
+    return absl::InvalidArgumentError("GpuVramRdmaStager: bytes must be within (0, slice_bytes]");
+  }
+  if (offset + bytes > tensor->get_bytes()) {
+    return absl::InvalidArgumentError("GpuVramRdmaStager: staging beyond tensor bounds");
+  }
+  if (tensor->get_mem_type() != base::COMMUNICATE_ENGINE_DEV_GPU) {
+    return absl::InvalidArgumentError("GpuVramRdmaStager requires GPU tensors");
+  }
+
+  auto slice_or = pool_->acquire_slice();
+  if (!slice_or.ok()) {
+    return slice_or.status();
+  }
+  auto slice = slice_or.value();
+
+  const int tensor_device_id = tensor->get_device_id();
+  const int pool_device_id = pool_->device_id();
+  if (tensor_device_id >= 0 && pool_device_id >= 0 && tensor_device_id != pool_device_id) {
+    auto release_status = pool_->release_slice(slice.index);
+    if (!release_status.ok()) {
+      LOG(WARNING) << "GpuVramRdmaStager failed to release slice after device mismatch: " << release_status;
+    }
+    return absl::InvalidArgumentError(
+        absl::StrCat(
+            "GpuVramRdmaStager tensor device id ",
+            tensor_device_id,
+            " does not match pool device id ",
+            pool_device_id));
+  }
+  int device_id = tensor_device_id >= 0 ? tensor_device_id : pool_device_id;
+  device_id = std::max(device_id, 0);
+  auto guard = cuda::set_device(device_id);
+  if (!guard.ok()) {
+    auto release_status = pool_->release_slice(slice.index);
+    if (!release_status.ok()) {
+      LOG(WARNING) << "GpuVramRdmaStager failed to release slice after device error: " << release_status;
+    }
+    return guard;
+  }
+
+  void* src = reinterpret_cast<void*>(tensor->get_uint64_addr() + offset);
+  auto copy_status = cuda::memcpy(slice.ptr, src, bytes, cudaMemcpyDeviceToDevice);
+  if (!copy_status.ok()) {
+    auto release_status = pool_->release_slice(slice.index);
+    if (!release_status.ok()) {
+      LOG(WARNING) << "GpuVramRdmaStager failed to release slice after copy error: " << release_status;
+    }
+    return copy_status;
+  }
+
+  {
+    absl::MutexLock lock(&mu_);
+    staged_slices_[slice.ptr] = slice.index;
+  }
+
+  return slice.ptr;
+}
+
+absl::Status GpuVramRdmaStager::release_staged_buffer(gsl::not_null<void*> exposed_ptr) {
+  int index = -1;
+  {
+    absl::MutexLock lock(&mu_);
+    auto it = staged_slices_.find(exposed_ptr.get());
+    if (it == staged_slices_.end()) {
+      return absl::NotFoundError("GpuVramRdmaStager: exposed ptr not found");
+    }
+    index = it->second;
+    staged_slices_.erase(it);
+  }
+  return pool_->release_slice(index);
+}
+
+size_t GpuVramRdmaStager::get_chunk_size() const {
+  return pool_->slice_bytes();
+}
+
+size_t GpuVramRdmaStager::get_num_buffers() const {
+  return pool_->num_slices();
+}
+
+std::optional<MemoryStager::MrSlab> GpuVramRdmaStager::mr_slab_for_ptr(gsl::not_null<void*> exposed_ptr) const {
+  if (!pool_->contains_ptr(exposed_ptr)) {
+    return std::nullopt;
+  }
+  return pool_->mr_slab();
+}
+
+} // namespace tensorcast::communicator::engine

--- a/core/communicator/engine/gpu_vram_rdma_stager.h
+++ b/core/communicator/engine/gpu_vram_rdma_stager.h
@@ -1,0 +1,110 @@
+// Copyright (c) 2025-2026, TensorCast Team.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "gsl/pointers"
+
+#include "core/common/cuda_api.h"
+#include "core/communicator/base/constants.h"
+#include "core/communicator/engine/memory_stager.h"
+#include "core/communicator/transport/partition_tensor.h"
+
+namespace tensorcast::communicator::engine {
+
+class GpuVramStagingPool {
+ public:
+  struct Slice {
+    void* ptr = nullptr;
+    size_t bytes = 0;
+    int index = -1;
+  };
+
+  GpuVramStagingPool(int device_id, size_t pool_bytes, size_t slice_bytes);
+  ~GpuVramStagingPool();
+
+  GpuVramStagingPool(const GpuVramStagingPool&) = delete;
+  GpuVramStagingPool& operator=(const GpuVramStagingPool&) = delete;
+
+  absl::Status initialize();
+
+  absl::StatusOr<Slice> acquire_slice();
+  absl::Status release_slice(int index);
+
+  [[nodiscard]] int device_id() const {
+    return device_id_;
+  }
+
+  [[nodiscard]] size_t pool_bytes() const {
+    return pool_bytes_;
+  }
+
+  [[nodiscard]] size_t slice_bytes() const {
+    return slice_bytes_;
+  }
+
+  [[nodiscard]] size_t num_slices() const {
+    return num_slices_;
+  }
+
+  [[nodiscard]] void* base_ptr() const {
+    return base_ptr_;
+  }
+
+  [[nodiscard]] bool contains_ptr(gsl::not_null<void*> ptr) const;
+  [[nodiscard]] std::optional<MemoryStager::MrSlab> mr_slab() const;
+
+ private:
+  absl::Status release_pool();
+
+  int device_id_ = -1;
+  size_t pool_bytes_ = 0;
+  size_t slice_bytes_ = 0;
+  size_t num_slices_ = 0;
+  void* base_ptr_ = nullptr;
+
+  mutable absl::Mutex mu_;
+  std::vector<int> free_indices_ ABSL_GUARDED_BY(mu_);
+  std::vector<bool> in_use_ ABSL_GUARDED_BY(mu_);
+  bool initialized_ = false;
+};
+
+class GpuVramRdmaStager : public MemoryStager {
+ public:
+  explicit GpuVramRdmaStager(std::shared_ptr<GpuVramStagingPool> pool);
+  ~GpuVramRdmaStager() override = default;
+
+  absl::StatusOr<void*> stage(
+      const std::shared_ptr<transport::PartitionTensor>& tensor,
+      uint64_t offset,
+      uint64_t bytes,
+      StageMode mode = StageMode::kBlocking) override;
+
+  absl::Status release_staged_buffer(gsl::not_null<void*> exposed_ptr) override;
+
+  [[nodiscard]] size_t get_chunk_size() const override;
+  [[nodiscard]] size_t get_num_buffers() const override;
+
+  std::optional<MrSlab> mr_slab_for_ptr(gsl::not_null<void*> exposed_ptr) const override;
+
+  std::shared_ptr<GpuVramStagingPool> pool() const {
+    return pool_;
+  }
+
+ private:
+  std::shared_ptr<GpuVramStagingPool> pool_;
+
+  mutable absl::Mutex mu_;
+  std::unordered_map<void*, int> staged_slices_ ABSL_GUARDED_BY(mu_);
+};
+
+} // namespace tensorcast::communicator::engine

--- a/core/communicator/engine/gpu_vram_rdma_stager_test.cc
+++ b/core/communicator/engine/gpu_vram_rdma_stager_test.cc
@@ -1,0 +1,40 @@
+// Copyright (c) 2025-2026, TensorCast Team.
+
+#include "core/communicator/engine/gpu_vram_rdma_stager.h"
+
+#include "catch2/catch_test_macros.hpp"
+
+#include "core/common/cuda_api.h"
+#include "core/communicator/base/constants.h"
+#include "core/communicator/transport/partition_tensor.h"
+
+namespace tensorcast::communicator::engine {
+
+TEST_CASE("GpuVramRdmaStager stages and releases slices") {
+  constexpr size_t kSliceBytes = 4096;
+  constexpr size_t kPoolBytes = kSliceBytes * 2;
+
+  auto pool = std::make_shared<GpuVramStagingPool>(/*device_id=*/0, kPoolBytes, kSliceBytes);
+  REQUIRE(pool->initialize().ok());
+  GpuVramRdmaStager stager(pool);
+
+  void* gpu_ptr = nullptr;
+  REQUIRE(cuda::malloc(&gpu_ptr, kSliceBytes).ok());
+  auto tensor = std::make_shared<transport::PartitionTensor>(
+      "gpu_tensor", reinterpret_cast<uint64_t>(gpu_ptr), kSliceBytes, base::COMMUNICATE_ENGINE_DEV_GPU, nullptr);
+  tensor->set_device_id(0);
+
+  auto staged_or = stager.stage(tensor, /*offset=*/0, /*bytes=*/kSliceBytes, MemoryStager::StageMode::kTry);
+  REQUIRE(staged_or.ok());
+  void* staged_ptr = *staged_or;
+
+  auto slab = stager.mr_slab_for_ptr(gsl::not_null<void*>{staged_ptr});
+  REQUIRE(slab.has_value());
+  CHECK(slab->base.get() == pool->base_ptr());
+  CHECK(slab->bytes == pool->pool_bytes());
+
+  REQUIRE(stager.release_staged_buffer(gsl::not_null<void*>{staged_ptr}).ok());
+  REQUIRE(cuda::free(gpu_ptr).ok());
+}
+
+} // namespace tensorcast::communicator::engine

--- a/core/communicator/engine/host_pinned_cpu_stager.cc
+++ b/core/communicator/engine/host_pinned_cpu_stager.cc
@@ -1,6 +1,6 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
-#include "core/communicator/engine/dram_stager.h"
+#include "core/communicator/engine/host_pinned_cpu_stager.h"
 
 #include <cstring>
 
@@ -10,11 +10,11 @@
 namespace tensorcast::communicator::engine {
 
 namespace {
-class NoOpLeaseHandle : public DRAMStager::LeaseHandle {};
+class NoOpLeaseHandle : public HostPinnedCpuStager::LeaseHandle {};
 
-class NoOpLeaseProvider : public DRAMStager::LeaseProvider {
+class NoOpLeaseProvider : public HostPinnedCpuStager::LeaseProvider {
  public:
-  std::unique_ptr<DRAMStager::LeaseHandle> acquire(
+  std::unique_ptr<HostPinnedCpuStager::LeaseHandle> acquire(
       const std::string& /*tensor_key*/,
       uint64_t /*offset*/,
       uint64_t /*bytes*/) override {
@@ -23,15 +23,17 @@ class NoOpLeaseProvider : public DRAMStager::LeaseProvider {
 };
 } // namespace
 
-std::shared_ptr<DRAMStager::LeaseProvider> DRAMStager::make_noop_lease_provider() {
+std::shared_ptr<HostPinnedCpuStager::LeaseProvider> HostPinnedCpuStager::make_noop_lease_provider() {
   static auto provider = std::make_shared<NoOpLeaseProvider>();
   return provider;
 }
 
-DRAMStager::DRAMStager(gsl::not_null<std::shared_ptr<common::memory::PinnedBufferPool>> pool, size_t num_buffers_hint)
+HostPinnedCpuStager::HostPinnedCpuStager(
+    gsl::not_null<std::shared_ptr<common::memory::PinnedBufferPool>> pool,
+    size_t num_buffers_hint)
     : pool_(std::move(pool)), chunk_size_(pool_->slice_bytes()), num_buffers_hint_(num_buffers_hint) {}
 
-absl::StatusOr<void*> DRAMStager::stage(
+absl::StatusOr<void*> HostPinnedCpuStager::stage(
     const std::shared_ptr<communicator::transport::PartitionTensor>& tensor,
     uint64_t offset,
     uint64_t bytes,
@@ -55,14 +57,14 @@ absl::StatusOr<void*> DRAMStager::stage(
     return absl::ResourceExhaustedError("PinnedBufferPool out of buffers for staging");
   }
 
-  void* host_ptr = bufs[0];
+  void* exposed_ptr = bufs[0];
   // memcpy from source VA
   std::unique_ptr<LeaseHandle> lease;
   if (lease_provider_) {
     lease = lease_provider_->acquire(tensor->get_key(), offset, bytes);
   }
   auto* src = tensor->get_addr<uint8_t>() + offset;
-  std::memcpy(host_ptr, src, static_cast<size_t>(bytes));
+  std::memcpy(exposed_ptr, src, static_cast<size_t>(bytes));
 
   {
     absl::MutexLock lock(&mu_);
@@ -70,19 +72,19 @@ absl::StatusOr<void*> DRAMStager::stage(
     wrapped.reserve(bufs.size());
     for (auto* p : bufs)
       wrapped.emplace_back(gsl::not_null<char*>{p});
-    allocations_[host_ptr] = std::move(wrapped);
+    allocations_[exposed_ptr] = std::move(wrapped);
   }
-  return host_ptr;
+  return exposed_ptr;
 }
 
-absl::Status DRAMStager::release_staged_buffer(gsl::not_null<void*> host_ptr) {
+absl::Status HostPinnedCpuStager::release_staged_buffer(gsl::not_null<void*> exposed_ptr) {
   // pool_ is guaranteed non-null
   std::vector<char*> bufs;
   {
     absl::MutexLock lock(&mu_);
-    auto it = allocations_.find(host_ptr.get());
+    auto it = allocations_.find(exposed_ptr.get());
     if (it == allocations_.end()) {
-      return absl::InvalidArgumentError("Unknown host_ptr for DRAMStager::release_staged_buffer");
+      return absl::InvalidArgumentError("Unknown exposed_ptr for HostPinnedCpuStager::release_staged_buffer");
     }
     bufs.reserve(it->second.size());
     for (auto p : it->second)

--- a/core/communicator/engine/host_pinned_cpu_stager.h
+++ b/core/communicator/engine/host_pinned_cpu_stager.h
@@ -18,16 +18,16 @@
 
 namespace tensorcast::communicator::engine {
 
-// DRAM (CPU) stager: memcpy from source VA into host-pinned pool buffer.
+// Host-pinned CPU stager: memcpy from source VA into host-pinned pool buffer.
 // Supports UMA-backed short pin leases via an optional LeaseProvider injected
 // by the StoreEngine. When set, stage() acquires a short lease for the
 // [offset, bytes] region and releases it after memcpy completes.
-class DRAMStager : public MemoryStager {
+class HostPinnedCpuStager : public MemoryStager {
  public:
-  explicit DRAMStager(
+  explicit HostPinnedCpuStager(
       gsl::not_null<std::shared_ptr<common::memory::PinnedBufferPool>> pool,
       size_t num_buffers_hint = 4);
-  ~DRAMStager() override = default;
+  ~HostPinnedCpuStager() override = default;
 
   // UMA pin-lease provider interface (optional). If set, stage() will
   // acquire a lease for the [offset, bytes] region and release it immediately
@@ -53,7 +53,15 @@ class DRAMStager : public MemoryStager {
       uint64_t bytes,
       StageMode mode = StageMode::kBlocking) override;
 
-  absl::Status release_staged_buffer(gsl::not_null<void*> host_ptr) override;
+  absl::Status release_staged_buffer(gsl::not_null<void*> exposed_ptr) override;
+
+  std::optional<MrSlab> mr_slab_for_ptr(gsl::not_null<void*> exposed_ptr) const override {
+    auto slab = pool_->slab_for_ptr(exposed_ptr);
+    if (!slab.has_value()) {
+      return std::nullopt;
+    }
+    return MrSlab{slab->base.get(), slab->bytes};
+  }
 
   size_t get_chunk_size() const override {
     return chunk_size_;

--- a/core/communicator/engine/host_pinned_gpu_stager.h
+++ b/core/communicator/engine/host_pinned_gpu_stager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #pragma once
 
@@ -22,19 +22,19 @@
 
 namespace tensorcast::communicator::engine {
 
-// GPU MemoryStager implementation using a StreamingPinnedBuffer for D2H staging.
-class GpuNetStager : public MemoryStager {
+// Host-pinned GPU stager using a StreamingPinnedBuffer for D2H staging.
+class HostPinnedGpuStager : public MemoryStager {
  public:
-  GpuNetStager(size_t chunk_size, size_t num_buffers, std::shared_ptr<common::memory::PinnedBufferPool> pool)
+  HostPinnedGpuStager(size_t chunk_size, size_t num_buffers, std::shared_ptr<common::memory::PinnedBufferPool> pool)
       : chunk_size_(chunk_size), num_buffers_(num_buffers), pool_(std::move(pool)) {
     if (chunk_size_ == 0) {
-      LOG(FATAL) << "GpuNetStager chunk_size must be > 0";
+      LOG(FATAL) << "HostPinnedGpuStager chunk_size must be > 0";
     }
     if (num_buffers_ == 0) {
-      LOG(FATAL) << "GpuNetStager num_buffers must be > 0";
+      LOG(FATAL) << "HostPinnedGpuStager num_buffers must be > 0";
     }
     if (!pool_) {
-      LOG(FATAL) << "GpuNetStager pool must not be null";
+      LOG(FATAL) << "HostPinnedGpuStager pool must not be null";
     }
   }
 
@@ -44,14 +44,14 @@ class GpuNetStager : public MemoryStager {
       uint64_t bytes,
       StageMode mode) override {
     if (bytes == 0 || bytes > chunk_size_) {
-      return absl::InvalidArgumentError("GpuNetStager: bytes must be within (0, chunk_size]");
+      return absl::InvalidArgumentError("HostPinnedGpuStager: bytes must be within (0, chunk_size]");
     }
     if (offset + bytes > tensor->get_bytes()) {
-      return absl::InvalidArgumentError("GpuNetStager: staging beyond tensor bounds");
+      return absl::InvalidArgumentError("HostPinnedGpuStager: staging beyond tensor bounds");
     }
     if (!streaming_) {
       if (!pool_)
-        return absl::FailedPreconditionError("GpuNetStager: no pinned pool");
+        return absl::FailedPreconditionError("HostPinnedGpuStager: no pinned pool");
       streaming_ = std::make_unique<common::memory::StreamingPinnedBuffer>(num_buffers_, chunk_size_, pool_);
       auto st = streaming_->initialize();
       if (!st.ok())
@@ -85,31 +85,39 @@ class GpuNetStager : public MemoryStager {
     }
     const int promoted_slot = slot_guard.release_for_async();
 
-    void* host_ptr = static_cast<void*>(dst);
+    void* exposed_ptr = static_cast<void*>(dst);
     {
       absl::MutexLock lk(&mu_);
-      staged_slots_[host_ptr] = SlotMetadata{
+      staged_slots_[exposed_ptr] = SlotMetadata{
           .slot_id = promoted_slot,
           .bytes_in_chunk = static_cast<size_t>(bytes),
           .tensor_offset = offset,
           .chunk_index = chunk_index,
       };
     }
-    return host_ptr;
+    return exposed_ptr;
   }
 
-  absl::Status release_staged_buffer(gsl::not_null<void*> host_ptr) override {
+  absl::Status release_staged_buffer(gsl::not_null<void*> exposed_ptr) override {
     SlotMetadata metadata;
     {
       absl::MutexLock lk(&mu_);
-      auto it = staged_slots_.find(host_ptr.get());
+      auto it = staged_slots_.find(exposed_ptr.get());
       if (it == staged_slots_.end()) {
-        return absl::NotFoundError("GpuNetStager: host ptr not found");
+        return absl::NotFoundError("HostPinnedGpuStager: exposed ptr not found");
       }
       metadata = it->second;
       staged_slots_.erase(it);
     }
     return streaming_->return_chunk(metadata.slot_id);
+  }
+
+  std::optional<MrSlab> mr_slab_for_ptr(gsl::not_null<void*> exposed_ptr) const override {
+    auto slab = pool_->slab_for_ptr(exposed_ptr);
+    if (!slab.has_value()) {
+      return std::nullopt;
+    }
+    return MrSlab{slab->base.get(), slab->bytes};
   }
 
   size_t get_chunk_size() const override {

--- a/core/communicator/engine/memory_stager.h
+++ b/core/communicator/engine/memory_stager.h
@@ -1,10 +1,11 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #pragma once
 
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -13,9 +14,9 @@
 
 namespace tensorcast::communicator::engine {
 
-// Unified interface for staging memory into host-pinned buffers suitable
-// for network transport. Implementations may perform memcpy (CPU) or
-// cudaMemcpyAsync (GPU) and must provide a way to release buffers.
+// Unified interface for staging memory into RDMA/MTCP-exposed buffers.
+// Implementations may return host-pinned or device pointers; callers must
+// treat the returned pointer as an exposed address for transport.
 class MemoryStager {
  public:
   virtual ~MemoryStager() = default;
@@ -26,7 +27,7 @@ class MemoryStager {
   };
 
   // Stage a view from the given tensor starting at offset for bytes.
-  // Returns a host pointer valid until release_staged_buffer() is called.
+  // Returns an exposed pointer valid until release_staged_buffer() is called.
   // Implementations must ensure bytes <= get_chunk_size().
   virtual absl::StatusOr<void*> stage(
       const std::shared_ptr<transport::PartitionTensor>& tensor,
@@ -35,7 +36,18 @@ class MemoryStager {
       StageMode mode = StageMode::kBlocking) = 0;
 
   // Release a previously staged buffer. Must be called once per stage().
-  virtual absl::Status release_staged_buffer(gsl::not_null<void*> host_ptr) = 0;
+  virtual absl::Status release_staged_buffer(gsl::not_null<void*> exposed_ptr) = 0;
+
+  struct MrSlab {
+    gsl::not_null<void*> base;
+    size_t bytes = 0;
+  };
+
+  // Optional MR slab lookup for preregistered staging pools. When present,
+  // callers may normalize MR registrations to the slab base.
+  virtual std::optional<MrSlab> mr_slab_for_ptr(gsl::not_null<void*> /*exposed_ptr*/) const {
+    return std::nullopt;
+  }
 
   // Size of a single staging chunk (bytes). Callers should not request
   // more than this in a single stage() call.
@@ -44,5 +56,15 @@ class MemoryStager {
   // Hint for how many buffers are available for pipelining per flow.
   [[nodiscard]] virtual size_t get_num_buffers() const = 0;
 };
+
+inline MemoryStager::MrSlab NormalizeMrRegion(
+    const MemoryStager& stager,
+    gsl::not_null<void*> exposed_ptr,
+    size_t bytes) {
+  if (auto slab = stager.mr_slab_for_ptr(exposed_ptr); slab.has_value()) {
+    return *slab;
+  }
+  return MemoryStager::MrSlab{exposed_ptr, bytes};
+}
 
 } // namespace tensorcast::communicator::engine

--- a/core/communicator/engine/mr_cache.cc
+++ b/core/communicator/engine/mr_cache.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "core/communicator/engine/mr_cache.h"
 
@@ -7,37 +7,83 @@
 
 namespace tensorcast::communicator::engine {
 
+namespace {
+MrCache::RegisterFn DefaultRegisterFn() {
+  return [](ibv_pd* pd, void* addr, size_t bytes, int access) -> ibv_mr* {
+    struct ibv_mr* mr = nullptr;
+    int rc = misc::wrap_ibv_reg_mr(&mr, pd, addr, bytes, access);
+    if (rc != misc::SUCCESS) {
+      return nullptr;
+    }
+    return mr;
+  };
+}
+
+MrCache::DeregisterFn DefaultDeregisterFn() {
+  return [](ibv_mr* mr) -> absl::Status {
+    if (mr == nullptr) {
+      return absl::OkStatus();
+    }
+    auto rc = misc::wrap_ibv_dereg_mr(mr);
+    if (rc != misc::SUCCESS) {
+      return absl::InternalError("Failed to dereg MR");
+    }
+    return absl::OkStatus();
+  };
+}
+} // namespace
+
+MrCache::MrCache(Options options) : options_(std::move(options)) {
+  if (!options_.register_fn) {
+    options_.register_fn = DefaultRegisterFn();
+  }
+  if (!options_.deregister_fn) {
+    options_.deregister_fn = DefaultDeregisterFn();
+  }
+}
+
 MrCache::~MrCache() {
   absl::MutexLock lk(&mu_);
   for (auto& kv : cache_) {
-    if (kv.second) {
-      auto rc = misc::wrap_ibv_dereg_mr(kv.second);
-      if (rc != misc::SUCCESS) {
-        LOG(WARNING) << "Failed to dereg MR in MrCache dtor";
-      }
+    if (!kv.second) {
+      continue;
+    }
+    auto status = options_.deregister_fn(kv.second);
+    if (!status.ok()) {
+      LOG(WARNING) << "Failed to dereg MR in MrCache dtor: " << status;
     }
   }
   cache_.clear();
 }
 
-struct ibv_mr* MrCache::get_or_register(ibv_pd* pd, gsl::not_null<void*> ptr, size_t bytes, int access) {
+MrCache::Result MrCache::get_or_register(ibv_pd* pd, gsl::not_null<void*> ptr, size_t bytes, int access) {
   Key key{.pd = pd, .ptr = ptr};
   {
     absl::MutexLock lk(&mu_);
     auto it = cache_.find(key);
     if (it != cache_.end()) {
-      return it->second;
+      return Result{.mr = it->second, .registered = false};
     }
   }
   // Not found; register
-  struct ibv_mr* mr = nullptr;
-  int rc = misc::wrap_ibv_reg_mr(&mr, pd, ptr.get(), bytes, access);
-  if (rc != misc::SUCCESS) {
-    return nullptr;
+  struct ibv_mr* mr = options_.register_fn(pd, ptr.get(), bytes, access);
+  if (mr == nullptr) {
+    return Result{.mr = nullptr, .registered = false};
   }
   absl::MutexLock lk(&mu_);
   cache_.emplace(key, mr);
-  return mr;
+  return Result{.mr = mr, .registered = true};
+}
+
+bool MrCache::contains(gsl::not_null<ibv_pd*> pd, gsl::not_null<void*> ptr) const {
+  Key key{.pd = pd, .ptr = ptr};
+  absl::MutexLock lk(&mu_);
+  return cache_.find(key) != cache_.end();
+}
+
+size_t MrCache::size() const {
+  absl::MutexLock lk(&mu_);
+  return cache_.size();
 }
 
 } // namespace tensorcast::communicator::engine

--- a/core/communicator/engine/mr_cache.h
+++ b/core/communicator/engine/mr_cache.h
@@ -1,11 +1,13 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <unordered_map>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
 #include "core/communicator/misc/ibv_wrap.h"
 #include "gsl/pointers"
@@ -16,37 +18,56 @@ namespace tensorcast::communicator::engine {
 // Registers an MR once for a given (pd, ptr, length) and reuses it.
 class MrCache {
  public:
-  MrCache() = default;
+  struct Result {
+    ibv_mr* mr = nullptr;
+    bool registered = false;
+  };
+
+  using RegisterFn = std::function<ibv_mr*(ibv_pd* pd, void* addr, size_t bytes, int access)>;
+  using DeregisterFn = std::function<absl::Status(ibv_mr* mr)>;
+
+  struct Options {
+    RegisterFn register_fn;
+    DeregisterFn deregister_fn;
+  };
+
+  explicit MrCache(Options options = {});
   ~MrCache();
 
   // Returns a cached or newly-registered MR for (pd, ptr, bytes).
   // If a cached MR exists with matching base ptr, returns it regardless
   // of requested bytes, assuming the cached MR length covers the staging chunk.
   // Access flags must be consistent for a given (pd, ptr) registration.
-  struct ibv_mr* get_or_register(ibv_pd* pd, gsl::not_null<void*> ptr, size_t bytes, int access)
-      ABSL_LOCKS_EXCLUDED(mu_);
+  Result get_or_register(ibv_pd* pd, gsl::not_null<void*> ptr, size_t bytes, int access) ABSL_LOCKS_EXCLUDED(mu_);
+
   // Preferred overload using not_null for pd.
-  struct ibv_mr* get_or_register(gsl::not_null<ibv_pd*> pd, gsl::not_null<void*> ptr, size_t bytes, int access)
+  Result get_or_register(gsl::not_null<ibv_pd*> pd, gsl::not_null<void*> ptr, size_t bytes, int access)
       ABSL_LOCKS_EXCLUDED(mu_) {
     return get_or_register(pd.get(), ptr, bytes, access);
   }
+
+  [[nodiscard]] bool contains(gsl::not_null<ibv_pd*> pd, gsl::not_null<void*> ptr) const ABSL_LOCKS_EXCLUDED(mu_);
+  [[nodiscard]] size_t size() const ABSL_LOCKS_EXCLUDED(mu_);
 
  private:
   struct Key {
     gsl::not_null<ibv_pd*> pd;
     gsl::not_null<void*> ptr;
+
     bool operator==(const Key& o) const {
       return pd.get() == o.pd.get() && ptr.get() == o.ptr.get();
     }
   };
+
   struct KeyHash {
     size_t operator()(const Key& k) const {
       return std::hash<void*>{}(k.pd.get()) ^ (std::hash<void*>{}(k.ptr.get()) << 1);
     }
   };
 
-  absl::Mutex mu_;
+  mutable absl::Mutex mu_;
   std::unordered_map<Key, gsl::owner<ibv_mr*>, KeyHash> cache_ ABSL_GUARDED_BY(mu_);
+  Options options_;
 };
 
 } // namespace tensorcast::communicator::engine

--- a/core/communicator/engine/protocol.h
+++ b/core/communicator/engine/protocol.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #ifndef CORE_COMMUNICATOR_ENGINE_PROTOCOL_H_
 #define CORE_COMMUNICATOR_ENGINE_PROTOCOL_H_
@@ -94,7 +94,7 @@ struct ProtoReadRequest {
 struct ProtoReadResponseExHeader {
   char tensor_key[kMaxTensorNameLen];
   uint8_t transport_type;
-  uint8_t staged; // 1 if segments are staged on server
+  uint8_t staged; // 1 if segments require RDMA_READ_DONE_EX to release staging credit
   char nic_name[kMaxDevName];
   uint32_t num_segments;
   uint32_t window_seq;

--- a/core/communicator/engine/rdma_stage_fn_test.cc
+++ b/core/communicator/engine/rdma_stage_fn_test.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2025-2026, TensorCast Team.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <string>
+
+#include "absl/status/status.h"
+#include "core/communicator/engine/mr_cache.h"
+#include "core/communicator/engine/staging_flow_controller.h"
+#include "core/communicator/transport/net_dev.h"
+#include "core/communicator/transport/partition_tensor.h"
+#include "tensorcast/communicator/v1/communicator_config.pb.h"
+
+struct ibv_mr;
+
+namespace tensorcast::communicator::engine {
+
+StagingWindow::StageFn MakeStageFunction(
+    const std::shared_ptr<transport::PartitionTensor>& tensor,
+    FlowCreditLedger* ledger,
+    const std::shared_ptr<MemoryStager>& stager,
+    const transport::net_dev_t& dev,
+    MrCache* mr_cache,
+    std::string tensor_key,
+    v1::RdmaConfig::StagedRdmaBackend staged_backend,
+    bool use_direct,
+    ::ibv_mr* direct_mr);
+
+TEST_CASE("MakeStageFunction guards null stager", "[communicator][rdma]") {
+  transport::net_dev_t dev = nullptr;
+
+  auto stage_fn = MakeStageFunction(
+      /*tensor=*/nullptr,
+      /*ledger=*/nullptr,
+      /*stager=*/nullptr,
+      dev,
+      /*mr_cache=*/nullptr,
+      /*tensor_key=*/"missing_stager",
+      /*staged_backend=*/v1::RdmaConfig::STAGED_RDMA_BACKEND_HOST_PINNED,
+      /*use_direct=*/false,
+      /*direct_mr=*/nullptr);
+
+  auto lease_or = stage_fn(/*offset=*/0, /*bytes=*/1, /*segment_idx=*/0);
+  REQUIRE_FALSE(lease_or.ok());
+  REQUIRE(lease_or.status().code() == absl::StatusCode::kFailedPrecondition);
+  REQUIRE(lease_or.status().message().find("missing_stager") != std::string::npos);
+}
+
+} // namespace tensorcast::communicator::engine

--- a/core/communicator/engine/stager_mr_normalization_test.cc
+++ b/core/communicator/engine/stager_mr_normalization_test.cc
@@ -1,0 +1,66 @@
+// Copyright (c) 2025-2026, TensorCast Team.
+
+#include "core/communicator/engine/host_pinned_cpu_stager.h"
+#include "core/communicator/engine/host_pinned_gpu_stager.h"
+#include "core/communicator/engine/memory_stager.h"
+
+#include <vector>
+
+#include "catch2/catch_test_macros.hpp"
+
+#include "core/common/cuda_api.h"
+#include "core/common/memory/pinned_buffer_pool.h"
+#include "core/communicator/base/constants.h"
+#include "core/communicator/transport/partition_tensor.h"
+
+namespace tensorcast::communicator::engine {
+
+TEST_CASE("NormalizeMrRegion uses slab base for host-pinned CPU staging") {
+  constexpr size_t kSliceBytes = 4096;
+  auto pool = std::make_shared<common::memory::PinnedBufferPool>(kSliceBytes * 2, kSliceBytes);
+  HostPinnedCpuStager stager(
+      gsl::not_null<std::shared_ptr<common::memory::PinnedBufferPool>>{pool}, /*num_buffers_hint=*/2);
+
+  std::vector<uint8_t> src(kSliceBytes, 0xAB);
+  auto tensor = std::make_shared<transport::PartitionTensor>(
+      "cpu_tensor", reinterpret_cast<uint64_t>(src.data()), kSliceBytes, base::COMMUNICATE_ENGINE_DEV_CPU, nullptr);
+
+  auto staged_or = stager.stage(tensor, /*offset=*/0, /*bytes=*/kSliceBytes, MemoryStager::StageMode::kBlocking);
+  REQUIRE(staged_or.ok());
+  void* staged_ptr = *staged_or;
+
+  auto slab = NormalizeMrRegion(stager, gsl::not_null<void*>{staged_ptr}, kSliceBytes);
+  auto slabs = pool->list_slabs();
+  REQUIRE(!slabs.empty());
+  CHECK(slab.base.get() == slabs.front().base.get());
+  CHECK(slab.bytes == slabs.front().bytes);
+
+  REQUIRE(stager.release_staged_buffer(gsl::not_null<void*>{staged_ptr}).ok());
+}
+
+TEST_CASE("NormalizeMrRegion uses slab base for host-pinned GPU staging") {
+  constexpr size_t kSliceBytes = 4096;
+  auto pool = std::make_shared<common::memory::PinnedBufferPool>(kSliceBytes * 2, kSliceBytes);
+  HostPinnedGpuStager stager(kSliceBytes, /*num_buffers=*/2, pool);
+
+  void* gpu_ptr = nullptr;
+  REQUIRE(cuda::malloc(&gpu_ptr, kSliceBytes).ok());
+  auto tensor = std::make_shared<transport::PartitionTensor>(
+      "gpu_tensor", reinterpret_cast<uint64_t>(gpu_ptr), kSliceBytes, base::COMMUNICATE_ENGINE_DEV_GPU, nullptr);
+  tensor->set_device_id(0);
+
+  auto staged_or = stager.stage(tensor, /*offset=*/0, /*bytes=*/kSliceBytes, MemoryStager::StageMode::kTry);
+  REQUIRE(staged_or.ok());
+  void* staged_ptr = *staged_or;
+
+  auto slab = NormalizeMrRegion(stager, gsl::not_null<void*>{staged_ptr}, kSliceBytes);
+  auto slabs = pool->list_slabs();
+  REQUIRE(!slabs.empty());
+  CHECK(slab.base.get() == slabs.front().base.get());
+  CHECK(slab.bytes == slabs.front().bytes);
+
+  REQUIRE(stager.release_staged_buffer(gsl::not_null<void*>{staged_ptr}).ok());
+  REQUIRE(cuda::free(gpu_ptr).ok());
+}
+
+} // namespace tensorcast::communicator::engine

--- a/core/communicator/engine/staging_flow_controller.cc
+++ b/core/communicator/engine/staging_flow_controller.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "core/communicator/engine/staging_flow_controller.h"
 
@@ -190,7 +190,7 @@ void FlowCreditLedger::wake_waiters_locked() {
 StageLease::State::State(
     std::shared_ptr<MemoryStager> stager,
     FlowCreditLedger* ledger,
-    void* host_ptr,
+    void* exposed_ptr,
     size_t bytes,
     ibv_mr* mr,
     bool deregister_mr,
@@ -198,7 +198,7 @@ StageLease::State::State(
     std::function<void()> extra_release_hook)
     : stager(std::move(stager)),
       ledger(ledger),
-      host_ptr(host_ptr),
+      exposed_ptr(exposed_ptr),
       bytes(bytes),
       mr(mr),
       deregister_mr(deregister_mr),
@@ -213,8 +213,8 @@ void StageLease::State::do_release() {
   if (mr != nullptr && deregister_mr) {
     DeregisterMr(mr);
   }
-  if (stager != nullptr && host_ptr != nullptr) {
-    auto status = stager->release_staged_buffer(gsl::not_null<void*>{host_ptr});
+  if (stager != nullptr && exposed_ptr != nullptr) {
+    auto status = stager->release_staged_buffer(gsl::not_null<void*>{exposed_ptr});
     if (!status.ok()) {
       LOG(WARNING) << "Failed to release staged buffer: " << status;
     }
@@ -227,7 +227,7 @@ void StageLease::State::do_release() {
 StageLease::StageLease(
     std::shared_ptr<MemoryStager> stager,
     FlowCreditLedger* ledger,
-    void* host_ptr,
+    void* exposed_ptr,
     size_t bytes,
     ibv_mr* mr,
     bool deregister_mr,
@@ -237,7 +237,7 @@ StageLease::StageLease(
           std::make_shared<State>(
               std::move(stager),
               ledger,
-              host_ptr,
+              exposed_ptr,
               bytes,
               mr,
               deregister_mr,
@@ -269,8 +269,8 @@ void StageLease::release() {
   }
 }
 
-void* StageLease::host_ptr() const {
-  return state_ ? state_->host_ptr : nullptr;
+void* StageLease::exposed_ptr() const {
+  return state_ ? state_->exposed_ptr : nullptr;
 }
 
 size_t StageLease::bytes() const {

--- a/core/communicator/engine/staging_flow_controller.h
+++ b/core/communicator/engine/staging_flow_controller.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #pragma once
 
@@ -130,7 +130,7 @@ class StageLease {
   StageLease(
       std::shared_ptr<MemoryStager> stager,
       FlowCreditLedger* ledger,
-      void* host_ptr,
+      void* exposed_ptr,
       size_t bytes,
       ibv_mr* mr,
       bool deregister_mr,
@@ -149,7 +149,7 @@ class StageLease {
   [[nodiscard]] bool released() const;
   void release();
 
-  [[nodiscard]] void* host_ptr() const;
+  [[nodiscard]] void* exposed_ptr() const;
   [[nodiscard]] size_t bytes() const;
   [[nodiscard]] ibv_mr* mr() const;
   [[nodiscard]] const Metadata& metadata() const;
@@ -161,7 +161,7 @@ class StageLease {
     State(
         std::shared_ptr<MemoryStager> stager,
         FlowCreditLedger* ledger,
-        void* host_ptr,
+        void* exposed_ptr,
         size_t bytes,
         ibv_mr* mr,
         bool deregister_mr,
@@ -172,7 +172,7 @@ class StageLease {
 
     std::shared_ptr<MemoryStager> stager;
     FlowCreditLedger* ledger;
-    void* host_ptr;
+    void* exposed_ptr;
     size_t bytes;
     ibv_mr* mr;
     bool deregister_mr;

--- a/core/communicator/engine/staging_flow_controller_test.cc
+++ b/core/communicator/engine/staging_flow_controller_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "core/communicator/engine/staging_flow_controller.h"
 
@@ -25,8 +25,8 @@ class DummyStager : public MemoryStager {
     return absl::UnimplementedError("DummyStager stage not used");
   }
 
-  absl::Status release_staged_buffer(gsl::not_null<void*> host_ptr) override {
-    released_ptrs_.push_back(host_ptr);
+  absl::Status release_staged_buffer(gsl::not_null<void*> exposed_ptr) override {
+    released_ptrs_.push_back(exposed_ptr);
     return absl::OkStatus();
   }
 

--- a/core/communicator/engine/tcp_error_handling_test.cc
+++ b/core/communicator/engine/tcp_error_handling_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include <atomic>
 #include <chrono>
@@ -9,7 +9,7 @@
 #include "catch2/catch_test_macros.hpp"
 
 #include "core/communicator/engine/engine.h"
-#include "core/communicator/engine/gpu_net_stager.h"
+#include "core/communicator/engine/host_pinned_gpu_stager.h"
 #include "core/communicator/transport/partition_tensor.h"
 #include "core/testing/test_helpers.h"
 
@@ -50,7 +50,7 @@ TEST_CASE("TCP Mode GPU Error Handling", "[communicator][tcp][gpu][error]") {
   SECTION("Staging buffer exhaustion recovery") {
     // Create a GPU stager with very limited buffers
     auto pool = std::make_shared<tensorcast::common::memory::PinnedBufferPool>(2 * 1024 * 1024, 1024 * 1024);
-    tensorcast::communicator::engine::GpuNetStager stager(1024 * 1024, 1, pool);
+    tensorcast::communicator::engine::HostPinnedGpuStager stager(1024 * 1024, 1, pool);
 
     // Allocate GPU memory
     void* gpu_ptr;
@@ -134,7 +134,7 @@ TEST_CASE("TCP Mode GPU Error Handling", "[communicator][tcp][gpu][error]") {
 
   SECTION("Out of bounds staging") {
     auto pool = std::make_shared<tensorcast::common::memory::PinnedBufferPool>(2 * 1024 * 1024, 1024 * 1024);
-    tensorcast::communicator::engine::GpuNetStager stager(1024 * 1024, 2, pool);
+    tensorcast::communicator::engine::HostPinnedGpuStager stager(1024 * 1024, 2, pool);
 
     void* gpu_ptr;
     const std::size_t tensor_size = 1024 * 1024;

--- a/core/store/materialization/runtime/pipeline/allocation_stage.cc
+++ b/core/store/materialization/runtime/pipeline/allocation_stage.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "core/store/materialization/runtime/pipeline/allocation_stage.h"
 
@@ -28,6 +28,9 @@ absl::StatusOr<replica::ReplicaConfig> build_replica_config(IngestionContext& ct
   config.pinned_memory_timeout =
       ctx.hints.pinned_timeout.count() > 0 ? ctx.hints.pinned_timeout : ctx.pinned_memory_timeout;
   config.max_buffer_bytes = ctx.hints.max_buffer_bytes;
+  if (ctx.options != nullptr) {
+    config.streaming_buffer_chunks = std::max<size_t>(1, ctx.options->streaming_buffer_chunks);
+  }
   config.view_id = ctx.hints.variant ? ctx.hints.variant->view_id : std::nullopt;
   config.view_plan = ctx.resolved_view_plan;
   config.transform_placement = ctx.hints.variant ? ctx.hints.variant->placement : loading::TransformPlacement::kServer;

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -97,7 +97,7 @@ Contract highlights:
 - Observability is best-effort and never changes control flow; high-cardinality fields are gated. Background HA counters (heartbeat/sync) tolerate missing meters so registration and sync continue even when telemetry providers are unavailable.
 - Idempotent unload and lock cleanup; expired tokens are unlocked automatically.
 - Lease-in-place commits rebuild the canonical tensor index from the fed `storage_entries` and `tensor_aliases`, emitting `tc_register_storage_count` / `tc_register_tensor_count` metrics so rollouts can confirm dedupe efficacy.
-- LIP segment alignment checks apply to logical segment base offsets and destinations; region-backed `region_base_offset` is only bounds-validated and does not need chunk alignment.
+- LIP segment alignment checks apply to logical artifact offsets (`LeasedSegment.artifact_offset`) and segment lengths; physical offsets (`StorageEntry.mapping_base_offset` / `LeasedSegment.storage_offset`) are only bounds-validated and may be unaligned (e.g., PyTorch sub-allocations).
 
 ## Directory Layout (What lives here)
 

--- a/daemon/grpc_service_impl_lease_copy_test.cc
+++ b/daemon/grpc_service_impl_lease_copy_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "daemon/grpc_service_impl.h"
 
@@ -49,7 +49,7 @@ TEST_CASE("Lease commit places segments by dst_offset and zeros PAD", "[daemon][
   breq.mutable_tensor_index_data()->set_data(index_bytes);
   breq.mutable_tensor_index_data()->set_schema_version("v3");
   breq.mutable_tensor_index_data()->set_encoding("json");
-  (void)breq.mutable_lease();
+  breq.mutable_lease()->set_in_place(true);
 
   grpc::ServerContext ctx;
   tensorcast::daemon::v1::BeginRegisterArtifactResponse bresp;
@@ -73,19 +73,48 @@ TEST_CASE("Lease commit places segments by dst_offset and zeros PAD", "[daemon][
   // Feed in reverse order to validate order independence; include explicit dst_offset
   tensorcast::daemon::v1::FeedRegisterArtifactStreamRequest freq;
   freq.set_registration_id(bresp.registration_id());
+  // Storage metadata (deduplicated table).
+  auto* storage2 = freq.add_storage_entries();
+  storage2->set_storage_id("s2");
+  storage2->set_device_id(0);
+  storage2->set_storage_length(16);
+  storage2->set_cuda_ipc_handle(std::string(reinterpret_cast<const char*>(&h2), sizeof(cudaIpcMemHandle_t)));
+  storage2->set_mapping_base_offset(0);
+  auto* storage1 = freq.add_storage_entries();
+  storage1->set_storage_id("s1");
+  storage1->set_device_id(0);
+  storage1->set_storage_length(16);
+  storage1->set_cuda_ipc_handle(std::string(reinterpret_cast<const char*>(&h1), sizeof(cudaIpcMemHandle_t)));
+  storage1->set_mapping_base_offset(0);
+  // Tensor alias metadata (required for LIP commits).
+  auto* a = freq.add_tensor_aliases();
+  a->set_name("a");
+  a->set_storage_id("s1");
+  a->set_storage_offset(0);
+  a->set_logical_length(16);
+  a->add_shape(16);
+  a->add_stride(1);
+  a->set_dtype("torch.uint8");
+  auto* b = freq.add_tensor_aliases();
+  b->set_name("b");
+  b->set_storage_id("s2");
+  b->set_storage_offset(0);
+  b->set_logical_length(16);
+  b->add_shape(16);
+  b->add_stride(1);
+  b->set_dtype("torch.uint8");
+
   auto* ls = freq.mutable_lease_segments();
   auto* s2 = ls->add_segments();
-  s2->set_device_id(0);
+  s2->set_storage_id("s2");
+  s2->set_storage_offset(0);
   s2->set_length(16);
-  s2->set_base_addr(0);
-  s2->set_cuda_ipc_handle(std::string(reinterpret_cast<const char*>(&h2), sizeof(cudaIpcMemHandle_t)));
-  s2->set_dst_offset(32);
+  s2->set_artifact_offset(32);
   auto* s1 = ls->add_segments();
-  s1->set_device_id(0);
+  s1->set_storage_id("s1");
+  s1->set_storage_offset(0);
   s1->set_length(16);
-  s1->set_base_addr(0);
-  s1->set_cuda_ipc_handle(std::string(reinterpret_cast<const char*>(&h1), sizeof(cudaIpcMemHandle_t)));
-  s1->set_dst_offset(0);
+  s1->set_artifact_offset(0);
 
   // Use helper to feed streaming vector without spinning up gRPC server
   std::vector<tensorcast::daemon::v1::FeedRegisterArtifactStreamRequest> reqs;

--- a/daemon/grpc_service_impl_lip_same_device_denial_test.cc
+++ b/daemon/grpc_service_impl_lip_same_device_denial_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "daemon/grpc_service_impl.h"
 
@@ -61,11 +61,24 @@ TEST_CASE("LIP same-device denial in MaterializeReplica", "[daemon][lip][fakecud
   freq.set_registration_id(bresp.registration_id());
   auto* ls = freq.mutable_lease_segments();
   auto* s = ls->add_segments();
-  s->set_device_id(0);
+  auto* storage = freq.add_storage_entries();
+  storage->set_storage_id("s0");
+  storage->set_device_id(0);
+  storage->set_storage_length(1 * 1024 * 1024);
+  storage->set_cuda_ipc_handle(std::string(reinterpret_cast<const char*>(&h), sizeof(h)));
+  storage->set_mapping_base_offset(0);
+  auto* alias = freq.add_tensor_aliases();
+  alias->set_name("tensor");
+  alias->set_storage_id("s0");
+  alias->set_storage_offset(0);
+  alias->set_logical_length(1 * 1024 * 1024);
+  alias->add_shape(1 * 1024 * 1024);
+  alias->add_stride(1);
+  alias->set_dtype("torch.uint8");
+  s->set_storage_id("s0");
+  s->set_storage_offset(0);
   s->set_length(1 * 1024 * 1024);
-  s->set_base_addr(0);
-  s->set_dst_offset(0);
-  s->set_cuda_ipc_handle(std::string(reinterpret_cast<const char*>(&h), sizeof(h)));
+  s->set_artifact_offset(0);
   st = svc.feed_register_artifact_stream_vector({freq});
   REQUIRE(st.ok());
 

--- a/daemon/grpc_service_impl_lip_ttl_expiry_test.cc
+++ b/daemon/grpc_service_impl_lip_ttl_expiry_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "daemon/grpc_service_impl.h"
 
@@ -65,11 +65,24 @@ TEST_CASE("LIP TTL expiry gates P2P source selection", "[daemon][lip][ttl][fakec
   freq.set_registration_id(bresp.registration_id());
   auto* ls = freq.mutable_lease_segments();
   auto* s = ls->add_segments();
-  s->set_device_id(0);
+  auto* storage = freq.add_storage_entries();
+  storage->set_storage_id("s0");
+  storage->set_device_id(0);
+  storage->set_storage_length(1 * 1024 * 1024);
+  storage->set_cuda_ipc_handle(std::string(reinterpret_cast<const char*>(&h), sizeof(h)));
+  storage->set_mapping_base_offset(0);
+  auto* alias = freq.add_tensor_aliases();
+  alias->set_name("tensor");
+  alias->set_storage_id("s0");
+  alias->set_storage_offset(0);
+  alias->set_logical_length(1 * 1024 * 1024);
+  alias->add_shape(1 * 1024 * 1024);
+  alias->add_stride(1);
+  alias->set_dtype("torch.uint8");
+  s->set_storage_id("s0");
+  s->set_storage_offset(0);
   s->set_length(1 * 1024 * 1024);
-  s->set_base_addr(0);
-  s->set_dst_offset(0);
-  s->set_cuda_ipc_handle(std::string(reinterpret_cast<const char*>(&h), sizeof(h)));
+  s->set_artifact_offset(0);
   st = svc.feed_register_artifact_stream_vector({freq});
   REQUIRE(st.ok());
 

--- a/daemon/lip_manager.cc
+++ b/daemon/lip_manager.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "daemon/lip_manager.h"
 
@@ -66,7 +66,9 @@ absl::StatusOr<CudaIpcMapping*> GetOrOpenMappingForStorage(
     RegionAcquireGuard& guard,
     IpcRegionRegistry* registry,
     int owner_pid) {
-  auto it = cache.find(storage.storage_id);
+  const std::string cache_key =
+      storage.has_handle() ? absl::StrCat("h:", storage.handle_bytes) : absl::StrCat("r:", storage.region_id);
+  auto it = cache.find(cache_key);
   if (it != cache.end()) {
     return it->second.get();
   }
@@ -95,7 +97,7 @@ absl::StatusOr<CudaIpcMapping*> GetOrOpenMappingForStorage(
     return absl::InvalidArgumentError("storage entry missing source handle or region");
   }
 
-  auto [insert_it, _] = cache.emplace(storage.storage_id, std::move(mapping));
+  auto [insert_it, _] = cache.emplace(cache_key, std::move(mapping));
   return insert_it->second.get();
 }
 
@@ -113,29 +115,15 @@ absl::StatusOr<std::vector<uint8_t>> LipManager::copy_to_new_coalesced(
   }
   absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_id;
   storage_by_id.reserve(storages.size());
-  absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_handle;
-  storage_by_handle.reserve(storages.size());
   for (const auto& storage : storages) {
     storage_by_id.emplace(storage.storage_id, &storage);
-    if (storage.has_handle()) {
-      storage_by_handle.emplace(storage.handle_bytes, &storage);
-    }
   }
   for (const auto& seg : segments) {
-    const RegisterStorageMeta* storage = nullptr;
-    if (!seg.storage_id.empty()) {
-      auto it = storage_by_id.find(seg.storage_id);
-      if (it == storage_by_id.end()) {
-        return absl::InvalidArgumentError("segment references unknown storage_id");
-      }
-      storage = it->second;
-    } else {
-      auto it = storage_by_handle.find(seg.handle_bytes);
-      if (it == storage_by_handle.end()) {
-        return absl::InvalidArgumentError("segment handle missing matching RegisterStorage entry");
-      }
-      storage = it->second;
+    auto it = storage_by_id.find(seg.storage_id);
+    if (it == storage_by_id.end()) {
+      return absl::InvalidArgumentError("segment references unknown storage_id");
     }
+    const RegisterStorageMeta* storage = it->second;
     if (seg.length != storage->storage_length) {
       return absl::InvalidArgumentError(
           absl::StrFormat(
@@ -143,6 +131,9 @@ absl::StatusOr<std::vector<uint8_t>> LipManager::copy_to_new_coalesced(
               static_cast<uint64_t>(seg.length),
               static_cast<uint64_t>(storage->storage_length),
               storage->storage_id));
+    }
+    if (seg.storage_offset != 0) {
+      return absl::InvalidArgumentError("segment storage_offset must be 0 for full-storage registrations");
     }
   }
 
@@ -210,39 +201,28 @@ absl::StatusOr<std::vector<uint8_t>> LipManager::copy_to_new_coalesced(
     uint64_t base;
     uint64_t len;
     uint64_t dst;
-    uint64_t segment_base;
   };
 
   std::vector<Opened> opened;
   opened.reserve(segments.size());
   for (const auto& seg : segments) {
-    const RegisterStorageMeta* storage = nullptr;
-    if (!seg.storage_id.empty()) {
-      auto it = storage_by_id.find(seg.storage_id);
-      if (it == storage_by_id.end()) {
-        return absl::InvalidArgumentError("segment references unknown storage_id");
-      }
-      storage = it->second;
-    } else {
-      auto it = storage_by_handle.find(seg.handle_bytes);
-      if (it == storage_by_handle.end()) {
-        return absl::InvalidArgumentError("segment handle missing matching RegisterStorage entry");
-      }
-      storage = it->second;
+    auto it = storage_by_id.find(seg.storage_id);
+    if (it == storage_by_id.end()) {
+      return absl::InvalidArgumentError("segment references unknown storage_id");
     }
+    const RegisterStorageMeta* storage = it->second;
     auto map_or = GetOrOpenMappingForStorage(*storage, mapping_cache, region_guard, region_registry_, owner_pid);
     if (!map_or.ok()) {
       return map_or.status();
     }
-    const uint64_t source_base = seg.base_offset + (storage->has_region() ? storage->region_base_offset : 0);
+    const uint64_t source_base = storage->mapping_base_offset + seg.storage_offset;
     opened.push_back(
         Opened{
-            .device_id = seg.device_id,
+            .device_id = storage->device_id,
             .map = *map_or,
             .base = source_base,
             .len = seg.length,
-            .dst = seg.dst_offset,
-            .segment_base = seg.base_offset});
+            .dst = seg.artifact_offset});
   }
   const size_t chunk_size = engine_->get_artifact_chunk_bytes();
   if (chunk_size == 0) {
@@ -251,12 +231,10 @@ absl::StatusOr<std::vector<uint8_t>> LipManager::copy_to_new_coalesced(
   auto is_aligned = [&](uint64_t v) { return (v % chunk_size) == 0; };
   for (const auto& o : opened) {
     const bool is_tail = (o.dst + o.len == total_size);
-    if (!is_aligned(o.dst) || !is_aligned(o.segment_base) || (!is_aligned(o.len) && !is_tail)) {
+    if (!is_aligned(o.dst) || (!is_aligned(o.len) && !is_tail)) {
       return absl::FailedPreconditionError(
           absl::StrCat(
-              "LIP segment not aligned to artifact_chunk_bytes: base_offset=",
-              o.segment_base,
-              ", dst_offset=",
+              "LIP segment not aligned to artifact_chunk_bytes: artifact_offset=",
               o.dst,
               ", length=",
               o.len,
@@ -311,131 +289,77 @@ absl::StatusOr<std::string> LipManager::create_staged_export(
     return absl::FailedPreconditionError("invalid chunk_size (0)");
   }
 
-  if (!lip.storages.empty()) {
-    absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_id;
-    absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_handle;
-    storage_by_id.reserve(lip.storages.size());
-    storage_by_handle.reserve(lip.storages.size());
-    for (const auto& storage : lip.storages) {
-      storage_by_id.emplace(storage.storage_id, &storage);
-      if (storage.has_handle()) {
-        storage_by_handle.emplace(storage.handle_bytes, &storage);
-      }
-    }
-    for (const auto& seg : lip.segments) {
-      const RegisterStorageMeta* storage = nullptr;
-      if (!seg.storage_id.empty()) {
-        auto it = storage_by_id.find(seg.storage_id);
-        if (it == storage_by_id.end()) {
-          return absl::InvalidArgumentError("staged export missing storage metadata for segment storage_id");
-        }
-        storage = it->second;
-      } else if (!seg.handle_bytes.empty()) {
-        auto it = storage_by_handle.find(seg.handle_bytes);
-        if (it == storage_by_handle.end()) {
-          return absl::InvalidArgumentError("staged export missing storage metadata for segment handle");
-        }
-        storage = it->second;
-      } else {
-        return absl::InvalidArgumentError("staged export segment missing storage reference");
-      }
-      if (seg.length != storage->storage_length) {
-        return absl::InvalidArgumentError(
-            absl::StrFormat(
-                "segment length (%llu) does not match storage_length (%llu) for storage_id=%s",
-                static_cast<uint64_t>(seg.length),
-                static_cast<uint64_t>(storage->storage_length),
-                storage->storage_id));
-      }
-    }
+  if (lip.storages.empty()) {
+    return absl::FailedPreconditionError("staged export requires storage metadata");
   }
 
   struct OpenedSeg {
     int device_id;
-    CudaIpcMapping* map; // non-owning; lifetime held by owned_maps or mapping_cache/export record
+    CudaIpcMapping* map; // non-owning; lifetime held by mapping_cache/export record
     uint64_t base;
     uint64_t len;
     uint64_t dst;
-    uint64_t segment_base;
   };
 
   std::vector<OpenedSeg> opened;
   opened.reserve(lip.segments.size());
   // When storage metadata is present, prefer region-backed or cached mappings via registry.
   absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_id;
-  absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_handle;
   storage_by_id.reserve(lip.storages.size());
-  storage_by_handle.reserve(lip.storages.size());
   for (const auto& s : lip.storages) {
     storage_by_id.emplace(s.storage_id, &s);
-    if (s.has_handle()) {
-      storage_by_handle.emplace(s.handle_bytes, &s);
-    }
   }
   RegionAcquireGuard region_guard(region_registry_);
   absl::flat_hash_map<std::string, std::unique_ptr<CudaIpcMapping>> mapping_cache;
-  std::vector<std::unique_ptr<CudaIpcMapping>> owned_maps;
   absl::flat_hash_map<std::string, uint32_t> region_hold_counts; // region_id -> refcount to hold beyond this scope
   mapping_cache.reserve(lip.storages.size());
   for (const auto& seg : lip.segments) {
-    std::optional<OpenedSeg> opened_seg;
-    if (!lip.storages.empty()) {
-      const RegisterStorageMeta* storage = nullptr;
-      if (!seg.storage_id.empty()) {
-        auto it = storage_by_id.find(seg.storage_id);
-        if (it == storage_by_id.end())
-          return absl::InvalidArgumentError("staged export: unknown storage_id in segment");
-        storage = it->second;
-      } else if (!seg.handle_bytes.empty()) {
-        auto it = storage_by_handle.find(seg.handle_bytes);
-        if (it == storage_by_handle.end())
-          return absl::InvalidArgumentError("staged export: segment handle missing matching storage entry");
-        storage = it->second;
+    auto it = storage_by_id.find(seg.storage_id);
+    if (it == storage_by_id.end()) {
+      return absl::InvalidArgumentError("staged export: unknown storage_id in segment");
+    }
+    const RegisterStorageMeta* storage = it->second;
+    if (seg.length != storage->storage_length) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat(
+              "segment length (%llu) does not match storage_length (%llu) for storage_id=%s",
+              static_cast<uint64_t>(seg.length),
+              static_cast<uint64_t>(storage->storage_length),
+              storage->storage_id));
+    }
+    if (seg.storage_offset != 0) {
+      return absl::InvalidArgumentError("segment storage_offset must be 0 for full-storage registrations");
+    }
+    // Track first-time region-backed mapping per storage to hold registry refs.
+    if (storage->has_region()) {
+      const std::string region_key = absl::StrCat("r:", storage->region_id);
+      if (mapping_cache.find(region_key) == mapping_cache.end()) {
+        // Hold exactly one ref per region used by this export.
+        ++region_hold_counts[storage->region_id];
       }
-      if (storage != nullptr) {
-        // Track first-time region-backed mapping per storage to hold registry refs
-        if (storage->has_region() && mapping_cache.find(storage->storage_id) == mapping_cache.end()) {
-          ++region_hold_counts[storage->region_id];
-        }
-        auto map_or =
-            GetOrOpenMappingForStorage(*storage, mapping_cache, region_guard, region_registry_, lip.owner_pid);
-        if (!map_or.ok())
-          return map_or.status();
-        const uint64_t source_base = seg.base_offset + (storage->has_region() ? storage->region_base_offset : 0);
-        opened_seg = OpenedSeg{
-            .device_id = seg.device_id,
+    }
+    auto map_or = GetOrOpenMappingForStorage(*storage, mapping_cache, region_guard, region_registry_, lip.owner_pid);
+    if (!map_or.ok()) {
+      return map_or.status();
+    }
+    const uint64_t source_base = storage->mapping_base_offset + seg.storage_offset;
+    opened.push_back(
+        OpenedSeg{
+            .device_id = storage->device_id,
             .map = *map_or,
             .base = source_base,
             .len = seg.length,
-            .dst = seg.dst_offset,
-            .segment_base = seg.base_offset};
-      }
-    }
-    if (!opened_seg.has_value()) {
-      auto map_or = CudaIpcMapping::open(seg.handle_bytes, cudaIpcMemLazyEnablePeerAccess);
-      if (!map_or.ok())
-        return map_or.status();
-      owned_maps.push_back(std::make_unique<CudaIpcMapping>(std::move(*map_or)));
-      opened_seg = OpenedSeg{
-          .device_id = seg.device_id,
-          .map = owned_maps.back().get(),
-          .base = seg.base_offset,
-          .len = seg.length,
-          .dst = seg.dst_offset,
-          .segment_base = seg.base_offset};
-    }
-    opened.push_back(std::move(*opened_seg));
+            .dst = seg.artifact_offset,
+        });
   }
   // Enforce alignment of LIP segments to artifact_chunk_bytes
   auto is_aligned = [&](uint64_t v) { return (v % chunk_size) == 0; };
   for (const auto& s : opened) {
     const bool is_tail = (s.dst + s.len == lip.total_size);
-    if (!is_aligned(s.dst) || !is_aligned(s.segment_base) || (!is_aligned(s.len) && !is_tail)) {
+    if (!is_aligned(s.dst) || (!is_aligned(s.len) && !is_tail)) {
       return absl::FailedPreconditionError(
           absl::StrCat(
-              "LIP segment not aligned to artifact_chunk_bytes: base_offset=",
-              s.segment_base,
-              ", dst_offset=",
+              "LIP segment not aligned to artifact_chunk_bytes: artifact_offset=",
               s.dst,
               ", length=",
               s.len,
@@ -524,11 +448,6 @@ absl::StatusOr<std::string> LipManager::create_staged_export(
     rec.device_id = lip.device_id;
     rec.region_registry = region_registry_;
     rec.held_region_refs = std::move(region_hold_counts);
-    // Transfer ownership of new opens
-    for (auto& up : owned_maps) {
-      rec.opened_maps.push_back(std::move(*up));
-    }
-    owned_maps.clear();
     // Transfer ownership of cached mappings so they outlive this function
     for (auto& kv : mapping_cache) {
       rec.opened_maps.push_back(std::move(*kv.second));
@@ -790,82 +709,54 @@ absl::StatusOr<CommitLeaseResult> LipManager::commit_lease_in_place(
   // Build seekable source over LIP segments using RAII CUDA IPC mappings.
   struct OpenedSeg {
     int device_id;
-    CudaIpcMapping* map; // non-owning; lifetime held by mapping_cache or owned_maps
+    CudaIpcMapping* map; // non-owning; lifetime held by mapping_cache
     uint64_t base;
     uint64_t len;
     uint64_t dst;
   };
 
   absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_id;
-  absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_handle;
   storage_by_id.reserve(storages.size());
-  storage_by_handle.reserve(storages.size());
   for (const auto& s : storages) {
     storage_by_id.emplace(s.storage_id, &s);
-    if (s.has_handle()) {
-      storage_by_handle.emplace(s.handle_bytes, &s);
-    }
   }
 
   RegionAcquireGuard region_guard(region_registry_);
   absl::flat_hash_map<std::string, std::unique_ptr<CudaIpcMapping>> mapping_cache;
-  std::vector<std::unique_ptr<CudaIpcMapping>> owned_maps;
   mapping_cache.reserve(storages.size());
 
   std::vector<OpenedSeg> opened;
   opened.reserve(segments.size());
   for (const auto& seg : segments) {
-    std::optional<OpenedSeg> opened_seg;
-    if (!storages.empty()) {
-      const RegisterStorageMeta* storage = nullptr;
-      if (!seg.storage_id.empty()) {
-        auto it = storage_by_id.find(seg.storage_id);
-        if (it == storage_by_id.end()) {
-          return absl::InvalidArgumentError("segment references unknown storage_id");
-        }
-        storage = it->second;
-      } else if (!seg.handle_bytes.empty()) {
-        auto it = storage_by_handle.find(seg.handle_bytes);
-        if (it == storage_by_handle.end()) {
-          return absl::InvalidArgumentError("segment handle missing matching RegisterStorage entry");
-        }
-        storage = it->second;
-      }
-      if (storage != nullptr) {
-        if (seg.length != storage->storage_length) {
-          return absl::InvalidArgumentError(
-              absl::StrFormat(
-                  "segment length (%llu) does not match storage_length (%llu) for storage_id=%s",
-                  static_cast<uint64_t>(seg.length),
-                  static_cast<uint64_t>(storage->storage_length),
-                  storage->storage_id));
-        }
-        auto map_or = GetOrOpenMappingForStorage(*storage, mapping_cache, region_guard, region_registry_, owner_pid);
-        if (!map_or.ok()) {
-          return map_or.status();
-        }
-        const uint64_t source_base = seg.base_offset + (storage->has_region() ? storage->region_base_offset : 0);
-        opened_seg = OpenedSeg{
-            .device_id = seg.device_id, .map = *map_or, .base = source_base, .len = seg.length, .dst = seg.dst_offset};
-      }
+    auto it = storage_by_id.find(seg.storage_id);
+    if (it == storage_by_id.end()) {
+      return absl::InvalidArgumentError("segment references unknown storage_id");
     }
-    if (!opened_seg.has_value()) {
-      if (seg.handle_bytes.empty()) {
-        return absl::InvalidArgumentError("lease segment missing cuda_ipc_handle bytes");
-      }
-      auto map_or = CudaIpcMapping::open(seg.handle_bytes, cudaIpcMemLazyEnablePeerAccess);
-      if (!map_or.ok()) {
-        return map_or.status();
-      }
-      owned_maps.push_back(std::make_unique<CudaIpcMapping>(std::move(*map_or)));
-      opened_seg = OpenedSeg{
-          .device_id = seg.device_id,
-          .map = owned_maps.back().get(),
-          .base = seg.base_offset,
-          .len = seg.length,
-          .dst = seg.dst_offset};
+    const RegisterStorageMeta* storage = it->second;
+    if (seg.length != storage->storage_length) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat(
+              "segment length (%llu) does not match storage_length (%llu) for storage_id=%s",
+              static_cast<uint64_t>(seg.length),
+              static_cast<uint64_t>(storage->storage_length),
+              storage->storage_id));
     }
-    opened.push_back(std::move(*opened_seg));
+    if (seg.storage_offset != 0) {
+      return absl::InvalidArgumentError("segment storage_offset must be 0 for full-storage registrations");
+    }
+    auto map_or = GetOrOpenMappingForStorage(*storage, mapping_cache, region_guard, region_registry_, owner_pid);
+    if (!map_or.ok()) {
+      return map_or.status();
+    }
+    const uint64_t source_base = storage->mapping_base_offset + seg.storage_offset;
+    opened.push_back(
+        OpenedSeg{
+            .device_id = storage->device_id,
+            .map = *map_or,
+            .base = source_base,
+            .len = seg.length,
+            .dst = seg.artifact_offset,
+        });
   }
 
   class LipSeekableSource final : public store::loader::SeekableSource {

--- a/daemon/lip_metadata_utils.cc
+++ b/daemon/lip_metadata_utils.cc
@@ -24,25 +24,10 @@ absl::StatusOr<std::string> build_canonical_index_from_metadata(
 
   absl::flat_hash_map<std::string, uint64_t> storage_to_dst;
   storage_to_dst.reserve(segments.size());
-  absl::flat_hash_map<std::string, uint64_t> handle_to_dst;
-  handle_to_dst.reserve(segments.size());
   for (const auto& seg : segments) {
-    if (!seg.storage_id.empty()) {
-      auto [it, inserted] = storage_to_dst.emplace(seg.storage_id, seg.dst_offset);
-      if (!inserted && it->second != seg.dst_offset) {
-        return absl::InvalidArgumentError(absl::StrCat("conflicting dst_offset for storage_id=", seg.storage_id));
-      }
-    }
-    // Handle-only mapping is only meaningful when the segment does not carry a
-    // storage_id reference. In unified flows, multiple storage entries can
-    // legitimately share the same CUDA IPC handle bytes (e.g., allocator
-    // sub-allocations) while mapping to different dst offsets; do not treat
-    // that as an error.
-    if (seg.storage_id.empty() && !seg.handle_bytes.empty()) {
-      auto [it, inserted] = handle_to_dst.emplace(seg.handle_bytes, seg.dst_offset);
-      if (!inserted && it->second != seg.dst_offset) {
-        return absl::InvalidArgumentError("conflicting dst_offset for handle_bytes segment");
-      }
+    auto [it, inserted] = storage_to_dst.emplace(seg.storage_id, seg.artifact_offset);
+    if (!inserted && it->second != seg.artifact_offset) {
+      return absl::InvalidArgumentError(absl::StrCat("conflicting artifact_offset for storage_id=", seg.storage_id));
     }
   }
 
@@ -79,10 +64,6 @@ absl::StatusOr<std::string> build_canonical_index_from_metadata(
     std::optional<uint64_t> base_dst;
     if (auto dst_it = storage_to_dst.find(alias.storage_id); dst_it != storage_to_dst.end()) {
       base_dst = dst_it->second;
-    } else if (storage_meta->has_handle()) {
-      if (auto dst_it = handle_to_dst.find(storage_meta->handle_bytes); dst_it != handle_to_dst.end()) {
-        base_dst = dst_it->second;
-      }
     }
     if (!base_dst.has_value()) {
       return absl::InvalidArgumentError(absl::StrCat("missing segment entry for storage_id=", alias.storage_id));

--- a/daemon/lip_metadata_utils.cc
+++ b/daemon/lip_metadata_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "daemon/lip_metadata_utils.h"
 
@@ -33,7 +33,12 @@ absl::StatusOr<std::string> build_canonical_index_from_metadata(
         return absl::InvalidArgumentError(absl::StrCat("conflicting dst_offset for storage_id=", seg.storage_id));
       }
     }
-    if (!seg.handle_bytes.empty()) {
+    // Handle-only mapping is only meaningful when the segment does not carry a
+    // storage_id reference. In unified flows, multiple storage entries can
+    // legitimately share the same CUDA IPC handle bytes (e.g., allocator
+    // sub-allocations) while mapping to different dst offsets; do not treat
+    // that as an error.
+    if (seg.storage_id.empty() && !seg.handle_bytes.empty()) {
       auto [it, inserted] = handle_to_dst.emplace(seg.handle_bytes, seg.dst_offset);
       if (!inserted && it->second != seg.dst_offset) {
         return absl::InvalidArgumentError("conflicting dst_offset for handle_bytes segment");

--- a/daemon/lip_metadata_utils_test.cc
+++ b/daemon/lip_metadata_utils_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "daemon/lip_metadata_utils.h"
 
@@ -11,10 +11,16 @@ using tensorcast::daemon::RegisterTensorAliasMeta;
 
 TEST_CASE("BuildCanonicalIndexFromMetadata generates stable JSON", "[daemon][lip]") {
   std::vector<LeaseSegMeta> segments = {
-      LeaseSegMeta{.device_id = 0, .handle_bytes = "handle-a", .base_offset = 0, .length = 1024, .dst_offset = 0},
+      LeaseSegMeta{.storage_id = "s0", .storage_offset = 0, .artifact_offset = 0, .length = 1024},
   };
   std::vector<RegisterStorageMeta> storages = {
-      RegisterStorageMeta{.storage_id = "s0", .device_id = 0, .handle_bytes = "handle-a", .storage_length = 1024},
+      RegisterStorageMeta{
+          .storage_id = "s0",
+          .device_id = 0,
+          .handle_bytes = "handle-a",
+          .storage_length = 1024,
+          .mapping_base_offset = 0,
+      },
   };
   std::vector<RegisterTensorAliasMeta> aliases;
   RegisterTensorAliasMeta a;
@@ -47,12 +53,24 @@ TEST_CASE("BuildCanonicalIndexFromMetadata generates stable JSON", "[daemon][lip
 
 TEST_CASE("BuildCanonicalIndexFromMetadata handles multiple storages and views", "[daemon][lip]") {
   std::vector<LeaseSegMeta> segments = {
-      LeaseSegMeta{.device_id = 0, .handle_bytes = "handle-a", .base_offset = 0, .length = 1024, .dst_offset = 0},
-      LeaseSegMeta{.device_id = 0, .handle_bytes = "handle-b", .base_offset = 0, .length = 2048, .dst_offset = 4096},
+      LeaseSegMeta{.storage_id = "s0", .storage_offset = 0, .artifact_offset = 0, .length = 1024},
+      LeaseSegMeta{.storage_id = "s1", .storage_offset = 0, .artifact_offset = 4096, .length = 2048},
   };
   std::vector<RegisterStorageMeta> storages = {
-      RegisterStorageMeta{.storage_id = "s0", .device_id = 0, .handle_bytes = "handle-a", .storage_length = 1024},
-      RegisterStorageMeta{.storage_id = "s1", .device_id = 0, .handle_bytes = "handle-b", .storage_length = 2048},
+      RegisterStorageMeta{
+          .storage_id = "s0",
+          .device_id = 0,
+          .handle_bytes = "handle-a",
+          .storage_length = 1024,
+          .mapping_base_offset = 0,
+      },
+      RegisterStorageMeta{
+          .storage_id = "s1",
+          .device_id = 0,
+          .handle_bytes = "handle-b",
+          .storage_length = 2048,
+          .mapping_base_offset = 0,
+      },
   };
 
   std::vector<RegisterTensorAliasMeta> aliases;
@@ -105,10 +123,16 @@ TEST_CASE("BuildCanonicalIndexFromMetadata handles multiple storages and views",
 
 TEST_CASE("BuildCanonicalIndexFromMetadata detects mismatched storage", "[daemon][lip]") {
   std::vector<LeaseSegMeta> segments = {
-      LeaseSegMeta{.device_id = 0, .handle_bytes = "seg", .base_offset = 0, .length = 256, .dst_offset = 0},
+      LeaseSegMeta{.storage_id = "s1", .storage_offset = 0, .artifact_offset = 0, .length = 256},
   };
   std::vector<RegisterStorageMeta> storages = {
-      RegisterStorageMeta{.storage_id = "s0", .device_id = 0, .handle_bytes = "other", .storage_length = 256},
+      RegisterStorageMeta{
+          .storage_id = "s0",
+          .device_id = 0,
+          .handle_bytes = "other",
+          .storage_length = 256,
+          .mapping_base_offset = 0,
+      },
   };
   std::vector<RegisterTensorAliasMeta> aliases = {
       RegisterTensorAliasMeta{

--- a/daemon/service/controllers/materialization_controller.cc
+++ b/daemon/service/controllers/materialization_controller.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "daemon/service/controllers/materialization_controller.h"
 
@@ -1306,11 +1306,6 @@ grpc::Status MaterializationController::materialize_into_target(
         "error", "storage_not_region", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
     return {StatusCode::INVALID_ARGUMENT, "Target storage must reference a vram_region_id"};
   }
-  if (!storage.has_region_base_offset()) {
-    record_materialize_into_target(
-        "error", "region_base_offset_missing", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
-    return {StatusCode::INVALID_ARGUMENT, "region_base_offset is required for region-backed targets"};
-  }
 
   const auto device = d_.devices.From(v1::DeviceType::DEVICE_TYPE_GPU, req.device_uuid(), std::nullopt);
   if (storage.device_id() != device.ordinal) {
@@ -1402,7 +1397,7 @@ grpc::Status MaterializationController::materialize_into_target(
     d_.regions.release(storage.vram_region_id()).IgnoreError();
     return {StatusCode::FAILED_PRECONDITION, "region device does not match storage device"};
   }
-  const uint64_t region_end = storage.region_base_offset() + storage.storage_length();
+  const uint64_t region_end = storage.mapping_base_offset() + storage.storage_length();
   if (region_end > region_desc.size_bytes) {
     record_materialize_into_target("error", "bounds", v1::MaterializationSource::MATERIALIZATION_SOURCE_UNSPECIFIED);
     d_.regions.release(storage.vram_region_id()).IgnoreError();
@@ -1451,7 +1446,7 @@ grpc::Status MaterializationController::materialize_into_target(
 
   record_materialize_into_target_verification_skipped();
 
-  void* region_base_ptr = static_cast<uint8_t*>(map_or->get()) + static_cast<uint64_t>(storage.region_base_offset());
+  void* region_base_ptr = static_cast<uint8_t*>(map_or->get()) + static_cast<uint64_t>(storage.mapping_base_offset());
   const uint64_t generation = compute_generation_from_index(*canonical_json_or);
   auto result_or = d_.engine.materialize_into_target(
       device, gsl::not_null<void*>{region_base_ptr}, logical_total_size, *canonical_json_or, generation, hints);

--- a/daemon/service/controllers/registration_controller.cc
+++ b/daemon/service/controllers/registration_controller.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 // Implementation of RegistrationController
 
@@ -288,7 +288,9 @@ absl::StatusOr<CudaIpcMapping*> get_or_open_mapping_for_storage(
     RegionPinGuard& region_pin,
     IpcRegionRegistry& regions,
     int owner_pid) {
-  auto it = cache.find(storage.storage_id);
+  const std::string cache_key =
+      storage.has_handle() ? absl::StrCat("h:", storage.handle_bytes) : absl::StrCat("r:", storage.region_id);
+  auto it = cache.find(cache_key);
   if (it != cache.end()) {
     return it->second.get();
   }
@@ -319,7 +321,7 @@ absl::StatusOr<CudaIpcMapping*> get_or_open_mapping_for_storage(
     return absl::InvalidArgumentError("storage entry missing source handle or region");
   }
 
-  auto [insert_it, _] = cache.emplace(storage.storage_id, std::move(mapping));
+  auto [insert_it, _] = cache.emplace(cache_key, std::move(mapping));
   return insert_it->second.get();
 }
 
@@ -340,14 +342,9 @@ absl::Status copy_to_staging_from_lip_sources(
   }
 
   absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_id;
-  absl::flat_hash_map<std::string, const RegisterStorageMeta*> storage_by_handle;
   storage_by_id.reserve(storages.size());
-  storage_by_handle.reserve(storages.size());
   for (const auto& s : storages) {
     storage_by_id.emplace(s.storage_id, &s);
-    if (s.has_handle()) {
-      storage_by_handle.emplace(s.handle_bytes, &s);
-    }
   }
 
   struct OpenedSeg {
@@ -360,62 +357,38 @@ absl::Status copy_to_staging_from_lip_sources(
 
   RegionPinGuard pin_guard(regions);
   absl::flat_hash_map<std::string, std::unique_ptr<CudaIpcMapping>> mapping_cache;
-  std::vector<std::unique_ptr<CudaIpcMapping>> owned_maps;
   mapping_cache.reserve(storages.size());
 
   std::vector<OpenedSeg> opened;
   opened.reserve(segments.size());
   for (const auto& seg : segments) {
-    std::optional<OpenedSeg> opened_seg;
-    if (!storages.empty()) {
-      const RegisterStorageMeta* storage = nullptr;
-      if (!seg.storage_id.empty()) {
-        auto it = storage_by_id.find(seg.storage_id);
-        if (it == storage_by_id.end()) {
-          return absl::InvalidArgumentError("segment references unknown storage_id");
-        }
-        storage = it->second;
-      } else if (!seg.handle_bytes.empty()) {
-        auto it = storage_by_handle.find(seg.handle_bytes);
-        if (it == storage_by_handle.end()) {
-          return absl::InvalidArgumentError("segment handle missing matching RegisterStorage entry");
-        }
-        storage = it->second;
-      }
-      if (storage != nullptr) {
-        if (seg.length != storage->storage_length) {
-          return absl::InvalidArgumentError(
-              absl::StrCat("segment length does not match storage_length for storage_id=", storage->storage_id));
-        }
-        auto map_or = get_or_open_mapping_for_storage(*storage, mapping_cache, pin_guard, regions, owner_pid);
-        if (!map_or.ok()) {
-          return map_or.status();
-        }
-        const uint64_t source_base = seg.base_offset + (storage->has_region() ? storage->region_base_offset : 0);
-        opened_seg = OpenedSeg{
-            .device_id = seg.device_id, .map = *map_or, .base = source_base, .len = seg.length, .dst = seg.dst_offset};
-      }
+    auto it = storage_by_id.find(seg.storage_id);
+    if (it == storage_by_id.end()) {
+      return absl::InvalidArgumentError("segment references unknown storage_id");
     }
-    if (!opened_seg.has_value()) {
-      if (seg.handle_bytes.empty()) {
-        return absl::InvalidArgumentError("lease segment missing cuda_ipc_handle bytes");
-      }
-      auto map_or = CudaIpcMapping::open(seg.handle_bytes, cudaIpcMemLazyEnablePeerAccess);
-      if (!map_or.ok()) {
-        return map_or.status();
-      }
-      owned_maps.push_back(std::make_unique<CudaIpcMapping>(std::move(*map_or)));
-      opened_seg = OpenedSeg{
-          .device_id = seg.device_id,
-          .map = owned_maps.back().get(),
-          .base = seg.base_offset,
-          .len = seg.length,
-          .dst = seg.dst_offset};
+    const RegisterStorageMeta* storage = it->second;
+    if (seg.length != storage->storage_length) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("segment length does not match storage_length for storage_id=", storage->storage_id));
     }
-    if (opened_seg->device_id != device_id) {
+    if (seg.storage_offset != 0) {
+      return absl::InvalidArgumentError("segment storage_offset must be 0 for full-storage registrations");
+    }
+    auto map_or = get_or_open_mapping_for_storage(*storage, mapping_cache, pin_guard, regions, owner_pid);
+    if (!map_or.ok()) {
+      return map_or.status();
+    }
+    OpenedSeg opened_seg{
+        .device_id = storage->device_id,
+        .map = *map_or,
+        .base = storage->mapping_base_offset + seg.storage_offset,
+        .len = seg.length,
+        .dst = seg.artifact_offset,
+    };
+    if (opened_seg.device_id != device_id) {
       return absl::UnimplementedError("multi-device lease sources are not supported for local stable materialization");
     }
-    opened.push_back(*opened_seg);
+    opened.push_back(opened_seg);
   }
   std::sort(opened.begin(), opened.end(), [](const OpenedSeg& a, const OpenedSeg& b) { return a.dst < b.dst; });
 
@@ -915,17 +888,12 @@ grpc::Status RegistrationController::feed_stream(
       to_add.reserve(req.lease_segments().segments_size());
       for (const auto& s : req.lease_segments().segments()) {
         LeaseSegMeta m;
-        m.device_id = s.device_id();
-        if (!s.cuda_ipc_handle().empty()) {
-          m.handle_bytes = s.cuda_ipc_handle();
-        }
-        m.base_offset = s.base_addr();
+        m.storage_id = s.storage_id();
+        m.storage_offset = s.storage_offset();
+        m.artifact_offset = s.artifact_offset();
         m.length = s.length();
-        m.dst_offset = s.dst_offset();
-        if (!s.storage_id().empty())
-          m.storage_id = s.storage_id();
-        if (m.handle_bytes.empty() && m.storage_id.empty()) {
-          return {StatusCode::INVALID_ARGUMENT, "lease segment missing storage reference"};
+        if (m.storage_id.empty()) {
+          return {StatusCode::INVALID_ARGUMENT, "lease segment missing storage_id"};
         }
         to_add.push_back(std::move(m));
       }
@@ -969,14 +937,9 @@ grpc::Status RegistrationController::feed_stream(
         const bool has_region = !entry.vram_region_id().empty();
         if (has_region)
           meta.region_id = entry.vram_region_id();
-        const bool has_region_offset = entry.has_region_base_offset();
-        if (has_region_offset)
-          meta.region_base_offset = entry.region_base_offset();
+        meta.mapping_base_offset = entry.mapping_base_offset();
         if (meta.handle_bytes.empty() == meta.region_id.empty()) {
           return {StatusCode::INVALID_ARGUMENT, "storage entry must specify exactly one source"};
-        }
-        if (has_region && !has_region_offset) {
-          return {StatusCode::INVALID_ARGUMENT, "region-backed storage requires region_base_offset"};
         }
         if (has_region) {
           // Validate using describe() first to avoid leaking a ref on failure
@@ -988,7 +951,7 @@ grpc::Status RegistrationController::feed_stream(
           if (desc.device_id != meta.device_id) {
             return {StatusCode::FAILED_PRECONDITION, "region device does not match storage device"};
           }
-          const uint64_t offset = meta.region_base_offset;
+          const uint64_t offset = meta.mapping_base_offset;
           const uint64_t length = meta.storage_length;
           if (length > desc.size_bytes || offset > (desc.size_bytes - length)) {
             return {StatusCode::FAILED_PRECONDITION, "region-backed storage exceeds region bounds"};
@@ -1089,16 +1052,12 @@ grpc::Status RegistrationController::feed_vector(const std::vector<v1::FeedRegis
       to_add.reserve(req.lease_segments().segments_size());
       for (const auto& s : req.lease_segments().segments()) {
         LeaseSegMeta m;
-        m.device_id = s.device_id();
-        if (!s.cuda_ipc_handle().empty())
-          m.handle_bytes = s.cuda_ipc_handle();
-        m.base_offset = s.base_addr();
+        m.storage_id = s.storage_id();
+        m.storage_offset = s.storage_offset();
+        m.artifact_offset = s.artifact_offset();
         m.length = s.length();
-        m.dst_offset = s.dst_offset();
-        if (!s.storage_id().empty())
-          m.storage_id = s.storage_id();
-        if (m.handle_bytes.empty() && m.storage_id.empty()) {
-          return {StatusCode::INVALID_ARGUMENT, "lease segment missing storage reference"};
+        if (m.storage_id.empty()) {
+          return {StatusCode::INVALID_ARGUMENT, "lease segment missing storage_id"};
         }
         to_add.push_back(std::move(m));
       }
@@ -1142,14 +1101,9 @@ grpc::Status RegistrationController::feed_vector(const std::vector<v1::FeedRegis
         const bool has_region = !entry.vram_region_id().empty();
         if (has_region)
           meta.region_id = entry.vram_region_id();
-        const bool has_region_offset = entry.has_region_base_offset();
-        if (has_region_offset)
-          meta.region_base_offset = entry.region_base_offset();
+        meta.mapping_base_offset = entry.mapping_base_offset();
         if (meta.handle_bytes.empty() == meta.region_id.empty()) {
           return {StatusCode::INVALID_ARGUMENT, "storage entry must specify exactly one source"};
-        }
-        if (has_region && !has_region_offset) {
-          return {StatusCode::INVALID_ARGUMENT, "region-backed storage requires region_base_offset"};
         }
         if (has_region) {
           // Validate using describe() first to avoid leaking a ref on failure
@@ -1161,7 +1115,7 @@ grpc::Status RegistrationController::feed_vector(const std::vector<v1::FeedRegis
           if (desc.device_id != meta.device_id) {
             return {StatusCode::FAILED_PRECONDITION, "region device does not match storage device"};
           }
-          const uint64_t offset = meta.region_base_offset;
+          const uint64_t offset = meta.mapping_base_offset;
           const uint64_t length = meta.storage_length;
           if (length > desc.size_bytes || offset > (desc.size_bytes - length)) {
             return {StatusCode::FAILED_PRECONDITION, "region-backed storage exceeds region bounds"};

--- a/daemon/types.h
+++ b/daemon/types.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 // Shared daemon-local strong types and hashing helpers
 
@@ -29,12 +29,13 @@ H AbslHashValue(H h, const ArtifactDeviceKey& k) {
 
 // Lease segment metadata used for LIP registration/commit
 struct LeaseSegMeta {
-  int device_id{0};
-  std::string handle_bytes; // raw cudaIpcMemHandle_t bytes
-  uint64_t base_offset{0}; // offset within mapped handle
+  // Physical storage backing this segment (must match RegisterStorageMeta.storage_id).
+  std::string storage_id;
+  // Byte offset within the referenced storage window where this segment begins.
+  uint64_t storage_offset{0};
+  // Logical byte offset within the artifact where this segment begins.
+  uint64_t artifact_offset{0};
   uint64_t length{0};
-  uint64_t dst_offset{0}; // destination offset in coalesced buffer
-  std::string storage_id; // optional ref to RegisterStorageMeta
 };
 
 struct RegisterStorageMeta {
@@ -43,7 +44,9 @@ struct RegisterStorageMeta {
   std::string handle_bytes;
   uint64_t storage_length{0};
   std::string region_id;
-  uint64_t region_base_offset{0};
+  // Byte offset from the mapped base pointer (allocation base for handle_bytes, region base for region_id)
+  // to the start of this storage window.
+  uint64_t mapping_base_offset{0};
 
   [[nodiscard]] bool has_region() const {
     return !region_id.empty();

--- a/docs/architecture/api/region-backed.md
+++ b/docs/architecture/api/region-backed.md
@@ -86,7 +86,7 @@ When LIP registration sees a storage fully covered by a registered region, the
 SDK emits:
 
 - `StorageEntry.vram_region_id`
-- `StorageEntry.region_base_offset`
+- `StorageEntry.mapping_base_offset`
 
 The lease segments then reference the storage id without attaching a per-storage
 CUDA IPC handle. The daemon resolves region handles and holds refs for the

--- a/docs/architecture/api/registration-flow.md
+++ b/docs/architecture/api/registration-flow.md
@@ -94,9 +94,9 @@ Proto: [proto/tensorcast/daemon/v1/store_daemon.proto](../../../proto/tensorcast
 | `storage_id` | Client-chosen identifier used for deduplication. | Must be unique within the registration stream. |
 | `device_id` | GPU ordinal that owns this storage. | Used for validation and handle resolution. |
 | `cuda_ipc_handle` | Inline CUDA IPC handle for the storage. | Mutually exclusive with `vram_region_id`. |
-| `vram_region_id` | Reference to a previously registered VRAM region. | Used with `region_base_offset`. |
+| `vram_region_id` | Reference to a previously registered VRAM region. | Used with `mapping_base_offset`. |
 | `storage_length` | Length in bytes of the storage. | Bounds checks for aliases/segments. |
-| `region_base_offset` | Base offset into the referenced region (bytes). | Defaults to `0` when unset. |
+| `mapping_base_offset` | Base offset from the mapped handle to the start of this storage window (bytes). | For `cuda_ipc_handle`, this is the CUDA allocation offset (sub-allocation safe). For `vram_region_id`, this is the offset into the region mapping. |
 
 `TensorAlias` maps logical tensors to storages and offsets:
 
@@ -114,11 +114,10 @@ Proto: [proto/tensorcast/daemon/v1/store_daemon.proto](../../../proto/tensorcast
 
 | Field | What it means | Why it exists |
 |---|---|---|
-| `device_id` | GPU ordinal for the segment handle. | Validation; multi-device correctness. |
-| `cuda_ipc_handle` | CUDA IPC handle bytes for this segment. | Legacy/inline mode when not using `storage_id`. |
-| `base_addr`, `length` | Segment base address and length (bytes). | Defines the source range. |
-| `dst_offset` | Destination offset in the canonical coalesced buffer. | Defines where the bytes land in the artifact. |
-| `storage_id` | Optional reference to a `StorageEntry`. | Preferred: reuses storage metadata instead of inline handles. |
+| `storage_id` | Reference to a `StorageEntry`. | Required: segments never inline CUDA IPC handles. |
+| `storage_offset` | Offset into the referenced storage window (bytes). | Allows slicing a storage window (usually `0`). |
+| `artifact_offset` | Destination offset in the canonical artifact layout (bytes). | Defines where the bytes land in the artifact. |
+| `length` | Segment length (bytes). | Must match the referenced storage length for full-storage registrations. |
 
 ### CommitRegisteredArtifactResponse (caller-visible outcomes)
 
@@ -140,7 +139,7 @@ segments.
 - Lease segments reference storage entries and specify destination offsets.
 
 Region-backed LIP is preferred when a storage is fully covered by a registered
-VRAM region. The SDK emits `vram_region_id` and `region_base_offset` in
+VRAM region. The SDK emits `vram_region_id` and `mapping_base_offset` in
 `StorageEntry` and does not send per-storage CUDA handles in that case.
 
 ### Region Referenced LIP Storage

--- a/docs/designs/0003-unified-memory-registration-avbs-lip.md
+++ b/docs/designs/0003-unified-memory-registration-avbs-lip.md
@@ -94,7 +94,7 @@ The daemon exposes one RPC family shared across plans:
 
 Key fields and behaviors
 - Begin validates device/size/index and emits plan‑specific handshakes (e.g., IPC mapping for coalesced VRAM).
-- Feed for Lease provides `lease_segments(dst_offset,len,...)` covering DATA ranges; PAD is implicit and zero‑filled by the daemon.
+- Feed for Lease provides `storage_entries` (CUDA IPC handles or region references) plus `lease_segments(storage_id,artifact_offset,length,...)` covering DATA ranges; PAD is implicit and zero‑filled by the daemon.
 - KeepAlive requires `owner_pid` matching Begin; extends registration or LIP lease.
 - Commit computes `mi2:` over AVBS with PAD=0 and registers the replica type.
 - Feed now includes deduplicated storage descriptors plus tensor alias metadata, mirroring the disk pipeline so the daemon can rebuild the canonical index without inferring alias groups from raw segments.

--- a/docs/designs/0006-unified-memory-stager-and-staged-p2p.md
+++ b/docs/designs/0006-unified-memory-stager-and-staged-p2p.md
@@ -4,8 +4,8 @@ title: Unified Memory Stager and Staged P2P (Design)
 related_code:
   - core/communicator/engine/engine.*
   - core/communicator/engine/memory_stager.*
-  - core/communicator/engine/dram_stager.*
-  - core/communicator/engine/gpu_net_stager.*
+  - core/communicator/engine/host_pinned_cpu_stager.*
+  - core/communicator/engine/host_pinned_gpu_stager.*
   - core/common/memory/pinned_buffer_pool.h (alias of pinned_buffer_pool.*)
   - core/communicator/transport/mtcp_transport.*
   - core/store/replica/chunk_export_service.*
@@ -36,9 +36,9 @@ Non‑Goals
 ## Concepts
 
 - MemoryStager: component that produces host‑pinned slices suitable for transport from either VS (CPU) or VRAM (GPU) sources.
-- StageToken: scoped handle carrying `host_ptr`, `bytes`, and optional `RdmaMr`, plus `complete()` to return resources.
-- DRAMStager: VS VA → host‑pinned copy; holds a VS lease only for the duration of memcpy and then releases it.
-- GpuNetStager: VRAM → host‑pinned D2H via `cudaMemcpyAsync`; emits token upon completion.
+- StageToken: scoped handle carrying `exposed_ptr`, `bytes`, and optional `RdmaMr`, plus `complete()` to return resources.
+- HostPinnedCpuStager: VS VA → host‑pinned copy; holds a VS lease only for the duration of memcpy and then releases it.
+- HostPinnedGpuStager: VRAM → host‑pinned D2H via `cudaMemcpyAsync`; emits token upon completion.
 - PinnedBufferPool: per‑NUMA pools of pinned buffers; each buffer is permanently registered per RNIC PD with cached `ibv_mr`.
 
 ## Class model (Mermaid)
@@ -49,15 +49,15 @@ class MemoryStager {
   +StageToken stage(uint64_t va_offset, size_t bytes)
 }
 class StageToken {
-  +void* host_ptr
+  +void* exposed_ptr
   +size_t bytes
   +optional RdmaMr mr
   +void complete()
 }
-class DRAMStager
-class GpuNetStager
-MemoryStager <|.. DRAMStager
-MemoryStager <|.. GpuNetStager
+class HostPinnedCpuStager
+class HostPinnedGpuStager
+MemoryStager <|.. HostPinnedCpuStager
+MemoryStager <|.. HostPinnedGpuStager
 ```
 
 ## Transport semantics
@@ -103,7 +103,7 @@ Selection rules
 # Invariants & Error Model
 
 Invariants
-- VS leases are held only during memcpy in DRAMStager; leases are released before tokens are returned to callers.
+- VS leases are held only during memcpy in HostPinnedCpuStager; leases are released before tokens are returned to callers.
 - MR registration never occurs over VS VA or producer VRAM; only over pool buffers.
 - StageToken must be completed exactly once. RDMA tokens require ACK; MTCP tokens are completed upon send completion.
 - Staged‑only across machines: PAD bytes are never transmitted and are zero‑filled by receivers.
@@ -145,7 +145,7 @@ Risks and mitigations
 ```cpp
 // memory_stager.h
 struct StageToken {
-  void* host_ptr;
+  void* exposed_ptr;
   size_t bytes;
   struct ibv_mr* mr; // optional
   std::function<void()> complete; // RAII/explicit
@@ -176,14 +176,14 @@ sequenceDiagram
 
   Sv->>ST: stage(offset,len)
   alt RDMA
-    ST-->>Sv: StageToken{host_ptr,len,mr}
+    ST-->>Sv: StageToken{exposed_ptr,len,mr}
     Sv-->>CL: READ_RESPONSE_EX{segments: [(addr,rkey,bytes),...]}
     CL->>TX: post RDMA READs
     CL->>Sv: RDMA_READ_DONE_EX(offsets)
     Sv->>ST: token.complete()
   else MTCP
-    ST-->>Sv: StageToken{host_ptr,len}
-    Sv->>TX: send(host_ptr,len, token)
+    ST-->>Sv: StageToken{exposed_ptr,len}
+    Sv->>TX: send(exposed_ptr,len, token)
     TX-->>ST: send_done → token.complete()
   end
 ```

--- a/docs/designs/0013-unified-staging-flow-control.md
+++ b/docs/designs/0013-unified-staging-flow-control.md
@@ -5,7 +5,7 @@ related_code:
   - core/communicator/engine/engine.cc
   - core/communicator/engine/engine.h
   - core/communicator/engine/channel.h
-  - core/communicator/engine/gpu_net_stager.h
+  - core/communicator/engine/host_pinned_gpu_stager.h
   - core/common/memory/streaming_pinned_buffer.*
   - core/communicator/transport/rdma_transport.cc
   - core/communicator/transport/mtcp_transport.cc
@@ -18,7 +18,7 @@ links:
 
 # Summary
 
-The Communicator dedicates a shared staging infrastructure (`GpuNetStager`, `DRAMStager`, `StreamingPinnedBuffer`) to serve both RDMA and MTCP transfers. Today, RDMA responses require pre-staging every segment before the server emits a single `READ_RESPONSE_EX`; if a request spans more bytes than the pool capacity (`buffers_per_flow * chunk_size`), the server blocks inside `GpuNetStager::stage()`, preventing the control channel from responding and the client from issuing reads—deadlocking the transfer. MTCP avoids this deadlock only because its send path streams staged buffers as soon as they are available, but RDMA and MTCP compete for the same pool without explicit arbitration, so one flow can starve the other under heavy load.
+The Communicator dedicates a shared staging infrastructure (`HostPinnedGpuStager`, `HostPinnedCpuStager`, `StreamingPinnedBuffer`) to serve both RDMA and MTCP transfers. Today, RDMA responses require pre-staging every segment before the server emits a single `READ_RESPONSE_EX`; if a request spans more bytes than the pool capacity (`buffers_per_flow * chunk_size`), the server blocks inside `HostPinnedGpuStager::stage()`, preventing the control channel from responding and the client from issuing reads—deadlocking the transfer. MTCP avoids this deadlock only because its send path streams staged buffers as soon as they are available, but RDMA and MTCP compete for the same pool without explicit arbitration, so one flow can starve the other under heavy load.
 
 This design introduces a **unified staging flow controller** that manages credit across transports, slices responses into windows bounded by available credit, and continuously refills both RDMA and MTCP pipelines as acknowledgements (RDMA) or send completions (MTCP) arrive. The approach aligns with the Communicator architecture in `core/communicator/README.md`, preserves staged-only RDMA semantics, improves fairness across concurrent flows, and adds observability and configuration validation for staging pressure. We assume a simultaneous rollout of all daemons/clients, so no backward-compatibility shims are required.
 
@@ -63,7 +63,7 @@ We retain these invariants while adding transport-agnostic flow credit and windo
 - Keeps waitlists for requests that cannot obtain credit immediately.
 
 ### StageLease
-- Wraps a staged buffer (host pointer, bytes, staging metadata) and remembers the owning FlowCredit lease.
+- Wraps a staged buffer (exposed pointer, bytes, staging metadata) and remembers the owning FlowCredit lease.
 - Carries RDMA registration state: `{ibv_mr*, bool deregister_on_release}` so the unified controller—not ad hoc maps—owns MR lifecycle.
 - Provides `void release()` which invokes the stored `release_fn` (stager release + optional MR deregistration) and returns the credit back to `FlowCreditLedger`.
 - Uniform across RDMA and MTCP: RDMA returns the lease when ACK arrives; MTCP returns it on send completion.
@@ -137,7 +137,7 @@ sequenceDiagram
 
 ### Non-blocking Staging
 
-- `GpuNetStager::stage()` gains a `StageMode` enum:
+- `HostPinnedGpuStager::stage()` gains a `StageMode` enum:
   ```cpp
   enum class StageMode { kBlocking, kTry };
   absl::StatusOr<StageLease> stage(..., StageMode mode);

--- a/docs/designs/0022-zero-copy-region-rdma.md
+++ b/docs/designs/0022-zero-copy-region-rdma.md
@@ -65,7 +65,7 @@ sequenceDiagram
 ## Stage Function Variants
 
 - Introduce helper `MakeStageFunction(const std::shared_ptr<PartitionTensor>& tensor, FlowCreditLedger* ledger)`.
-  - **Direct path:** returns a lambda that creates `StageLease{stager=nullptr, ledger, host_ptr=tensor_base+offset, mr=tensor->get_mr(), deregister_mr=false}`.
+  - **Direct path:** returns a lambda that creates `StageLease{stager=nullptr, ledger, exposed_ptr=tensor_base+offset, mr=tensor->get_mr(), deregister_mr=false}`.
   - **Fallback path:** retains current staging lambda using `MemoryStager::stage`.
 - `StagingWindow` continues to drive chunking. Add configuration knob `stager().direct_chunk_mb` (defaults to `stage_chunk_mb_gpu`) to tune zero-copy window size without affecting staging chunking.
 

--- a/docs/designs/0042-region-backed-tensor-dict-into.md
+++ b/docs/designs/0042-region-backed-tensor-dict-into.md
@@ -91,14 +91,14 @@ Region-backed `tensor_dict_into` needs a compact description of where each tenso
 **StorageEntry** (existing, v1)
 - `storage_id`, `device_id`, `storage_length`
 - `vram_region_id` (required for region-backed target)
-- `region_base_offset` (required)
+- `mapping_base_offset` (required)
 
 **TensorAlias** (existing, v1)
 - `name`, `storage_id`, `storage_offset`, `logical_length`
 - `shape`, `stride`, `dtype`
 
 The **offset table** maps each tensor's logical offset to a region offset:
-`logical_offset (canonical or view) -> region_id + region_base_offset + storage_offset`.
+`logical_offset (canonical or view) -> region_id + mapping_base_offset + storage_offset`.
 
 ### Layout Compaction
 - `TENSOR_SPEC_KIND_OFFSETS` sends only `TargetTensorOffset` entries; dtype/shape/stride come
@@ -110,7 +110,7 @@ The **offset table** maps each tensor's logical offset to a region offset:
 `logical_layout_hash` is a SHA-256 digest over the logical byte space only:
 - Derive it from canonical (or view) index bytes plus `index_kind`; prefer `index_multihash`
   when present to avoid re-hashing large indices.
-- Exclude physical binding fields (`storage_id`, `vram_region_id`, `region_base_offset`,
+- Exclude physical binding fields (`storage_id`, `vram_region_id`, `mapping_base_offset`,
   `storage_offset`) so the hash stays stable across region bindings.
 - In Phase 1 the on-wire field is optional and diagnostic; SegmentPlan caching should
   key on `index_multihash` (or a locally computed `logical_layout_hash`) plus
@@ -141,7 +141,7 @@ does not implement this logic.
 ### Layout Modes
 1. **COALESCED**: the target region is arranged in logical order (canonical or view).
    The daemon verifies `storage_offset == logical_offset` for each tensor, and a single
-   storage entry spans the logical space (`storage_length == logical_total_size`). The `region_base_offset` acts as the base of
+   storage entry spans the logical space (`storage_length == logical_total_size`). The `mapping_base_offset` acts as the base of
    the coalesced buffer slice in the region. This lets the pipeline stream ranges
    without extra scatter logic and reuse `pump_ranges`.
    COALESCED implies the storage covers the full logical space and includes every tensor
@@ -178,8 +178,8 @@ daemon-side write. It builds a `TargetLayout` only when all of the following are
    and `view_subset_hash` must be empty for Phase 1.
 5. Group target tensors by storage; assign deterministic `storage_id` (e.g., hash of base
    pointer + size).
-6. For each storage, find the covering region and compute `region_base_offset`.
-7. Emit `StorageEntry` records with `vram_region_id`, `region_base_offset`, and
+6. For each storage, find the covering region and compute `mapping_base_offset`.
+7. Emit `StorageEntry` records with `vram_region_id`, `mapping_base_offset`, and
    `storage_length == logical_total_size`.
 8. Emit `TargetTensorOffset` records for each tensor with `storage_offset` and
    `logical_length` (use `TensorAlias` only when `tensor_spec_kind=ALIAS`).
@@ -307,7 +307,7 @@ target_layout {
     storage_id: "s0"
     device_id: 0
     vram_region_id: "region:0001"
-    region_base_offset: 0
+    mapping_base_offset: 0
     storage_length: 3072
   }
   offsets: [
@@ -353,7 +353,7 @@ target_layout {
     storage_id: "s0"
     device_id: 0
     vram_region_id: "region:0002"
-    region_base_offset: 0
+    mapping_base_offset: 0
     storage_length: 8192
   }
   offsets: [
@@ -402,7 +402,7 @@ so the data-path stays in core and shares scheduling, buffer pools, and loaders.
 - `device_uuid` is present and resolves to a device; each storage entry `device_id`
   matches the resolved UUID (device_id is not authoritative across processes).
 - `layout_kind == COALESCED` and `len(storages) == 1`.
-- `region_base_offset + storage_length <= region.size_bytes`.
+- `mapping_base_offset + storage_length <= region.size_bytes`.
 - `owner_pid` matches the session (via `IpcRegionRegistry::acquire`).
 - Region is not poisoned (fail fast if the registry marks the region as invalid).
 - `TensorAlias` or `TargetTensorOffset` matches canonical entry (length, name).
@@ -423,7 +423,7 @@ For COALESCED layouts, the logical offsets match the destination offsets. The da
 ### External GPU Target
 Introduce an external GPU target in the materialization pipeline:
 - Bypass `AllocationStage` and `HandleStage`; no daemon-owned replica or IPC export.
-- Open the single region IPC handle and pass `gpu_base_ptr = region_base + region_base_offset`
+- Open the single region IPC handle and pass `gpu_base_ptr = region_base + mapping_base_offset`
   into `GpuMemorySink`, with `total_size = logical_total_size` to enforce a full copy.
 - Acquire the region via `IpcRegionRegistry::acquire` to extend TTL and enforce ownership,
   then release on completion to decrement the refcount.
@@ -566,7 +566,7 @@ updates are acceptable in this pre-launch phase.
 Proposed API and type names follow repository conventions:
 - **Proto messages**: `TargetLayout`, `TargetTensorOffset` (PascalCase)
 - **Proto messages**: `MaterializeIntoTargetRequest`, `MaterializeIntoTargetResponse` (PascalCase)
-- **Proto fields**: `target_layout`, `layout_kind`, `region_base_offset` (snake_case)
+- **Proto fields**: `target_layout`, `layout_kind`, `mapping_base_offset` (snake_case)
 - **RPCs**: `MaterializeIntoTarget` (PascalCase)
 - **C++ functions**: `materialize_into_target` (snake_case)
 - **Python types**: `RegionBackedMode`, `TargetLayout` (PascalCase)

--- a/docs/designs/0045-rdma-staging-vram-and-mr-prereg.md
+++ b/docs/designs/0045-rdma-staging-vram-and-mr-prereg.md
@@ -1,0 +1,382 @@
+---
+slug: rdma-staging-vram-and-mr-prereg
+title: RDMA Staging Backends (GPU VRAM) and MR Preregistration (Design)
+status: implemented
+areas: ["core", "daemon"]
+related_code:
+  - core/communicator/engine/engine.{h,cc}
+  - core/communicator/engine/host_pinned_gpu_stager.h
+  - core/communicator/engine/host_pinned_cpu_stager.{h,cc}
+  - core/communicator/engine/gpu_vram_rdma_stager.{h,cc} # new (RDMA-only GPU VRAM staging)
+  - core/common/memory/pinned_buffer_pool.{h,cc}
+  - core/communicator/engine/mr_cache.{h,cc}
+  - core/communicator/misc/ibv_wrap.{h,cc}
+  - daemon/server_main.cc
+  - proto/tensorcast/communicator/v1/communicator_config.proto
+links:
+  plan: ../plans/0045-rdma-staging-vram-and-mr-prereg.md
+  predecessors:
+    - ./0006-unified-memory-stager-and-staged-p2p.md
+    - ./0043-unified-pinned-memory-authority.md
+---
+
+# Summary
+
+Add a GPU VRAM staged-RDMA backend (bounce buffers in device memory) for non-direct workloads where RDMA is desired but staging through host-pinned memory is suboptimal. Fix and complete the existing RDMA preregistration story so `rdma_preregister` materially reduces staging overhead for both CPU and GPU host-pinned staging. Clarify and de-ambiguate the staged-RDMA “pointer” contract by using `StageLease::exposed_ptr()` (renamed from `StageLease::host_ptr()`) to reflect that it may be a host pointer (host-pinned staging) or a device pointer (direct RDMA and GPU VRAM staging).
+
+This design is explicitly compatible with TensorCast’s user-driven **direct vs non-direct** modes:
+- **Direct mode** (e.g., region-backed): prefer direct RDMA when enabled and MR is available; otherwise fall back to staged RDMA.
+- **Non-direct mode**: provide high-throughput staged RDMA, including an explicit GPU VRAM staging backend when configured.
+
+# Problem Statement
+
+TensorCast currently has:
+
+- A staged-RDMA path that stages server-side responses into **host-pinned** buffers (via `MemoryStager`) and exposes those buffers to the client for RDMA READ. This is correct and broadly compatible, but for GPU tensors it incurs **GPU→CPU** copies via `HostPinnedGpuStager` (`cudaMemcpyDeviceToHost`), which is avoidable on GPUDirect RDMA capable systems.
+- A slab-level RDMA preregistration mechanism (`PinnedBufferPool::list_slabs()` preregistered once per NIC/PD) that is intended to reduce runtime registration cost. Historically, only `HostPinnedCpuStager`-backed staging reliably exploited this because `HostPinnedGpuStager` staging did not normalize MR registrations to slab bases; this design fixes that via stager-provided slab lookup (`MemoryStager::mr_slab_for_ptr(...)`).
+- A naming/contract mismatch in the lease/pointer path: `StageLease::exposed_ptr()` (formerly `host_ptr()`) already carries a device pointer in the direct RDMA path (zero-copy). This makes it hard to safely extend staged RDMA to device memory without confusion in code and docs.
+
+We want:
+
+1. **P0**: `rdma_preregister` actually reduces staged-RDMA overhead for GPU host-pinned staging as well as CPU host-pinned staging.
+2. **P1**: a staged-RDMA backend that uses **GPU VRAM** bounce buffers (D2D) instead of host-pinned bounce buffers (D2H), selected explicitly by configuration and validated at initialization time (no runtime fallback).
+
+# Goals / Non-Goals
+
+## Goals
+
+- Preserve the existing transport protocol and credit/ACK semantics for RDMA windows (`RDMA_READ_DONE_EX` releases `StageLease`).
+- Keep MTCP/TCP semantics unchanged; any new staging backend must not regress TCP paths.
+- Make `pinned_memory.classes[comm_*].rdma_preregister` measurably effective for staged RDMA, including GPU-side staging where the underlying slices live in host-pinned slabs.
+- Add an explicit GPU VRAM staged-RDMA backend with clear prerequisites and failure behavior (init-time validation; no runtime fallback when configured).
+- De-ambiguate the lease pointer contract by renaming `StageLease::host_ptr()` to `StageLease::exposed_ptr()` and updating docs accordingly.
+- Follow unified runtime config rules: no ad-hoc env vars; configuration lives in protobuf-backed config (`DaemonConfig.communicator`).
+
+## Non-Goals
+
+- Changing the wire protocol messages or handshake machinery (no new opcodes, no new response types).
+- Forcing “direct” behavior in non-direct user scenarios; mode selection remains user-driven.
+- Introducing new global allocators/budgets outside the unified config system.
+- Making GPU VRAM staging available on systems without GPUDirect RDMA or where GPU MR registration is not supported.
+- Solving end-to-end cross-process policy (e.g., “never expose any GPU MR to peers”) beyond explicit configuration.
+- Supporting dma-buf MR registration or CUDA VMM/backed registrations in this design iteration.
+
+# Current State (Grounded in Code)
+
+## Stagers and staging buffers
+
+- `HostPinnedCpuStager` (formerly `DRAMStager`) stages CPU tensors into **host-pinned** slices allocated from `PinnedBufferPool` and uses `memcpy`:
+  - `core/communicator/engine/host_pinned_cpu_stager.cc` (`PinnedBufferPool::allocate` → `std::memcpy`)
+- `HostPinnedGpuStager` (formerly `GpuNetStager`) stages GPU tensors into **host-pinned** slices allocated from `PinnedBufferPool` and uses `cudaMemcpyDeviceToHost`:
+  - `core/communicator/engine/host_pinned_gpu_stager.h`
+- `PinnedBufferPool` allocations are host memory that is pinned via CUDA (`cudaHostRegister`) at pool construction time:
+  - `core/common/memory/pinned_buffer_pool.cc`
+
+## Staged RDMA vs direct RDMA in Communicator
+
+In `core/communicator/engine/engine.cc`, the RDMA response path uses `MakeStageFunction(...)`:
+- **Direct RDMA**: `StageLease` references the tensor’s device pointer + MR (no staging buffer). This pointer is carried via `StageLease::exposed_ptr()`.
+- **Staged RDMA**: `fallback_stager->stage(...)` yields a staged pointer and registers an MR for that region (via `MrCache`).
+
+## Preregistration
+
+On startup (when `enable_rdma=true`), the Communicator preregisters MRs for selected staging pools at slab granularity (one MR per slab per NIC/PD) and caches them in `MrCache`:
+- `core/communicator/engine/engine.cc` prereg loop over `PinnedBufferPool::list_slabs()`
+
+Staged-RDMA MR selection normalizes to slab bases via the `MemoryStager::mr_slab_for_ptr(...)` hook (implemented by `HostPinnedCpuStager` and `HostPinnedGpuStager`), so preregistered slab MRs are reused for both CPU and GPU host-pinned staging.
+
+# Terminology and Naming (Contract Clarification)
+
+This design makes the “RDMA-exposed address” explicit in naming:
+
+- **`StageLease` pointer contract**: `StageLease::exposed_ptr()` (formerly `host_ptr()`) reflects that the returned address may refer to:
+  - host-pinned memory (host-pinned staged RDMA), or
+  - device memory (direct RDMA and GPU VRAM staged RDMA).
+  - The returned value is an exposed transport address; it must not be dereferenced by the server process.
+- **`ProtoReadResponseExHeader.staged` semantics**: treat `staged=1` as “the client must ACK (`RDMA_READ_DONE_EX`) so the server can release the corresponding `StageLease` and return staging credit”, not as “host-pinned vs device staging”. (In current code, RDMA windows use `staged=1` even for direct RDMA.)
+
+We also rename staging classes to make “where the staged buffer lives” self-evident:
+
+- `HostPinnedCpuStager` (formerly `DRAMStager`)
+- `HostPinnedGpuStager` (formerly `GpuNetStager`)
+- `GpuVramRdmaStager` (RDMA-only; stages into GPU VRAM)
+
+# Architecture & Interfaces
+
+## Overview
+
+We introduce a staged-RDMA backend selection that is **explicitly** separate from user-level “direct vs non-direct” mode:
+
+- User-level mode determines whether direct writes / region-backed flows are used.
+- RDMA staging backend determines *how staged RDMA behaves when it is selected by the transport and policy*.
+
+```mermaid
+flowchart TD
+  A["Server tensor registered<br>direct_rdma_enabled flag"] --> B{"direct_rdma_enabled = true?"}
+  B -->|yes| C{"Direct MR available<br>for tensor on this NIC/PD?"}
+  C -->|yes| D["Direct RDMA<br>(zero-copy)"]
+  C -->|no| E["Staged RDMA fallback"]
+  B -->|no| E
+  E --> F{"Staged backend configured"}
+  F -->|STAGED_RDMA_BACKEND_GPU_VRAM| G["GPU VRAM staged RDMA<br>(D2D into VRAM pool)"]
+  F -->|STAGED_RDMA_BACKEND_HOST_PINNED| H["Host-pinned staged RDMA<br>(D2H/CPU memcpy into pinned pool)"]
+```
+
+## User Scenarios and Expected Behavior
+
+TensorCast exposes user-driven “direct vs non-direct” choices (for example, backed-region flows). This design makes staged-RDMA backend selection orthogonal and predictable:
+
+| User scenario | Typical data-plane behavior | Communicator policy expectation |
+| --- | --- | --- |
+| Direct (region-backed) | `pump_ranges()` uses direct write tokens (`read_into`) | Prefer direct RDMA when enabled; staged backend rarely used |
+| Non-direct (not region-backed) | source reads into caller buffers | staged RDMA is common for large reads; backend choice matters |
+
+The key invariant is that staged backend selection must never “force direct mode”; it only optimizes the staged fallback behavior within a scenario.
+
+## Error Model and Failure Mapping
+
+This design intentionally preserves existing error surfaces (including `ENGINE_OP_READ_FAILED`) while making failures more diagnosable.
+
+### Staged RDMA failures
+
+- **Host-pinned pool exhaustion / staging credit exhaustion**: return `absl::ResourceExhaustedError(...)` and map to `TENSORCAST_READ_FAILED_RESOURCE_EXHAUSTED` on the control channel when serving a request.
+- **VRAM pool exhaustion** (P1): return `absl::ResourceExhaustedError(...)` with a stable message including `device_id`, `slice_bytes`, and `pool_bytes_per_gpu`.
+- **MR registration failure**:
+  - If direct mode was requested (`direct_rdma_enabled=true`) and MR registration fails, record a “direct fallback” reason and continue via staged backend selection.
+  - If staged backend MR registration fails, surface `absl::InternalError(...)` and map to `TENSORCAST_READ_FAILED_MEM_MISMATCH` (status quo), while incrementing a dedicated `tc_rdma_mr_register_failures_total` metric.
+
+## Security and Policy Model
+
+### Threat model (scoped)
+
+- RDMA exposes memory ranges to remote peers via rkeys. Even with short lifetimes, exposing device memory MRs can be considered higher risk than exposing host-pinned staging MRs because:
+  - device memory may contain sensitive model weights/activations depending on workload;
+  - device memory access patterns can have different isolation and auditing properties than host memory.
+
+### Policy principles
+
+- Default behavior must not increase exposure surface: GPU VRAM staging is not enabled unless explicitly configured.
+- In non-direct scenarios, GPU VRAM staging must be explicitly enabled and bounded; it must not “accidentally” expose arbitrary primary pointers.
+- Observability must make exposure mode explicit (backend, method, bytes).
+
+### Policy knobs (config-level)
+
+- `rdma.staging_backend` is the explicit selector; `STAGED_RDMA_BACKEND_UNSPECIFIED` behaves as `STAGED_RDMA_BACKEND_HOST_PINNED`.
+- There is no `AUTO` mode: operators must choose `STAGED_RDMA_BACKEND_HOST_PINNED` or `STAGED_RDMA_BACKEND_GPU_VRAM` explicitly.
+- When `STAGED_RDMA_BACKEND_GPU_VRAM` is selected, the Communicator must validate support at initialization time and fail fast if unsupported. Runtime fallback is not permitted.
+
+## Integration Points (Code-Level)
+
+- `core/communicator/engine/engine.cc`
+  - P0: update staged-RDMA MR normalization inside `MakeStageFunction(...)` to consult `MemoryStager` for slab-base normalization (no type-specific `dynamic_cast`).
+  - P1: extend staged backend selection for RDMA to choose `GpuVramRdmaStager` when configured.
+  - P1: add init-time validation and preregistration for GPU VRAM pool MRs using `ibv_reg_mr` (fail-fast; no runtime fallback).
+- `core/communicator/engine/memory_stager.h`
+  - P0: add an optional “MR slab lookup” capability so `MakeStageFunction(...)` can normalize MR bases independent of concrete stager type.
+- `core/communicator/engine/host_pinned_gpu_stager.h` / `core/communicator/engine/host_pinned_cpu_stager.{h,cc}`
+  - P0: implement the slab lookup capability (host-pinned pool slab base).
+
+## P0: Make preregistration effective for GPU host-pinned staging
+
+### Change
+
+Generalize MR-base normalization for staged buffers so that staged slices map to their containing slab base for both host-pinned CPU staging and host-pinned GPU staging:
+
+- Add an optional “MR slab lookup” hook to `MemoryStager` (default: no slab).
+- Implement it in:
+  - `HostPinnedCpuStager` (formerly `DRAMStager`)
+  - `HostPinnedGpuStager` (formerly `GpuNetStager`)
+- In `MakeStageFunction` (staged path), normalize `(mr_base, mr_bytes)` using the stager-provided slab when available, so `MrCache` is keyed by slab base, not per-slice pointers.
+
+### Expected outcome
+
+When `pinned_memory.classes[name=comm_gpu].rdma_preregister=true`:
+- preregistration registers slab MRs once per NIC/PD
+- staged-RDMA uses those preregistered slab MRs (no per-slice registration churn)
+
+## P1: GPU VRAM staged-RDMA backend (bounce buffer in device memory)
+
+### Motivation
+
+For non-direct workloads where we cannot (or choose not to) expose the artifact’s primary device pointer for RDMA, staged RDMA currently requires GPU→CPU staging for GPU tensors. On GPUDirect RDMA capable systems, we can instead stage into GPU VRAM and let the NIC read the staged GPU memory directly (D2D staging).
+
+### New components (daemon / Communicator)
+
+- **GpuVramStagingPool**: per-device fixed-size pool of device allocations carved into slices of size `communicator.rdma.vram_slice_bytes`.
+  - Supports non-blocking acquire (try) and release, mirroring the “do not block inside stage” philosophy.
+  - Required preregistration of pool MRs per NIC/PD at Communicator init when `STAGED_RDMA_BACKEND_GPU_VRAM` is selected (fail-fast; no runtime fallback).
+- **GpuVramRdmaStager**: RDMA-only staging implementation that stages a `(tensor, offset, bytes)` range into a slice from `GpuVramStagingPool` via D2D copy.
+  - Produces `StageLease` objects whose `exposed_ptr()` is a **device pointer**.
+  - Uses `ibv_reg_mr` only (no dma-buf path in this iteration).
+
+### Interface choice: reuse existing staging abstractions
+
+We keep the existing `StageFn` / `StagingWindow` / `StageLease` pipeline and implement GPU VRAM staging by:
+
+- Making `StageLease`’s address contract explicit (`exposed_ptr()`).
+- Implementing an RDMA-only `MemoryStager` (`GpuVramRdmaStager`) that returns a device pointer as the exposed address.
+
+MTCP staging remains untouched because MTCP is wired to the host-pinned stagers (`HostPinnedGpuStager` / `HostPinnedCpuStager`) at transport construction time.
+
+### Invariants
+
+- GPU VRAM staging is used **only** for RDMA staged fallback, never for MTCP.
+- Credit and lifecycle remain unchanged:
+  - Each staged segment corresponds to one `StageLease` in the per-channel registry.
+  - Release still occurs on `RDMA_READ_DONE_EX` and returns credit + buffer.
+- Buffer sizing is fixed and derived from unified config; no unbounded growth.
+
+### Init-time validation (required; no runtime fallback)
+
+When `communicator.rdma.staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM`, initialization must:
+
+- allocate the configured per-GPU VRAM pool;
+- preregister the pool memory with `ibv_reg_mr` for every active NIC/PD;
+- fail fast if any required preregistration step fails (daemon startup fails; no runtime fallback).
+
+If initialization succeeds, runtime staging must not fall back to `STAGED_RDMA_BACKEND_HOST_PINNED` in response to capability or MR failures; failures are surfaced as request failures (or fatal errors if invariant-breaking).
+
+# Configuration
+
+We extend the typed communicator config (embedded under `DaemonConfig.communicator`) with an explicit staged-RDMA backend selection.
+
+Proto additions in `proto/tensorcast/communicator/v1/communicator_config.proto`:
+
+```proto
+message RdmaConfig {
+  ...
+  enum StagedRdmaBackend {
+    STAGED_RDMA_BACKEND_UNSPECIFIED = 0; // treated as STAGED_RDMA_BACKEND_HOST_PINNED (no behavior change by default)
+    STAGED_RDMA_BACKEND_HOST_PINNED = 1;                     // current behavior
+    STAGED_RDMA_BACKEND_GPU_VRAM = 2;                        // new P1 behavior (requires init-time validation)
+  }
+  StagedRdmaBackend staging_backend = 6;
+  uint64 vram_pool_bytes_per_gpu = 7; // required when staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM
+  uint64 vram_slice_bytes = 8;        // required when staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM
+}
+```
+
+Notes:
+- Host-pinned sizing remains under `DaemonConfig.pinned_memory.classes[comm_gpu/comm_cpu]`.
+- GPU VRAM staging sizing is separate because it is not pinned host memory and should not consume `pinned_memory` budget.
+
+## Configuration Examples
+
+### Keep current behavior (default)
+
+No config changes required; `STAGED_RDMA_BACKEND_UNSPECIFIED` behaves as `STAGED_RDMA_BACKEND_HOST_PINNED`.
+
+### Enable P0 preregistration for host-pinned staging (recommended with RDMA)
+
+`rdma_preregister` lives under daemon-wide pinned memory classes (not under `communicator.rdma`). When enabled and RDMA is on, the daemon preregisters pinned slabs once per NIC/PD so staged RDMA reuses slab MRs.
+
+```yaml
+communicator:
+  enable_rdma: true
+
+pinned_memory:
+  classes:
+    - name: comm_gpu
+      slice_bytes: 16MB
+      pool_bytes: 8GB
+      rdma_preregister: true
+    - name: comm_cpu
+      slice_bytes: 16MB
+      pool_bytes: 2GB
+      rdma_preregister: true
+```
+
+### Enable GPU VRAM staged RDMA (explicit)
+
+```yaml
+communicator:
+  enable_rdma: true
+  rdma:
+    staging_backend: STAGED_RDMA_BACKEND_GPU_VRAM
+    vram_pool_bytes_per_gpu: 2GB
+    vram_slice_bytes: 16MB
+
+# Still required for MTCP and host-pinned staging paths (and for CPU tensors).
+pinned_memory:
+  classes:
+    - name: comm_gpu
+      slice_bytes: 16MB
+      pool_bytes: 8GB
+      rdma_preregister: true
+    - name: comm_cpu
+      slice_bytes: 16MB
+      pool_bytes: 2GB
+      rdma_preregister: true
+```
+
+## VRAM pool semantics and constraints (forced mode)
+
+When `communicator.rdma.staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM`:
+
+- **One pool per GPU**: the daemon allocates exactly one contiguous VRAM pool per initialized CUDA device. Total reserved VRAM is approximately `vram_pool_bytes_per_gpu * num_initialized_gpus` (plus allocator overhead).
+- **MR preregistration is not “one pool per NIC”**: the same per-GPU pool is preregistered once per NIC/PD (multiple MRs referencing the same pool). This scales the *number of MRs* with NIC/PD count, but does not multiply VRAM allocation.
+- **Sizing rules**:
+  - `vram_pool_bytes_per_gpu > 0` and `vram_slice_bytes > 0` are required.
+  - `vram_pool_bytes_per_gpu >= vram_slice_bytes` is required.
+  - `vram_pool_bytes_per_gpu / vram_slice_bytes` determines the number of usable slices; if the division has a remainder, the implementation truncates the remainder and logs a warning.
+- **Segment bound**: staged RDMA segments into VRAM must satisfy `0 < bytes <= vram_slice_bytes`.
+
+# Observability
+
+Add/extend metrics (low cardinality):
+- `tc_rdma_staged_backend_total{backend="host_pinned|gpu_vram", mem="cpu|gpu"}` (segments)
+- `tc_rdma_staged_bytes_total{backend=..., mem=...}`
+- `tc_rdma_mr_register_total{method="ibv_reg_mr", location="host_pinned|gpu_vram"}`
+- `tc_rdma_mr_register_failures_total{method="ibv_reg_mr", reason=...}`
+- Keep existing `tc_pinned_rdma_prereg_*` for host-pinned pools.
+- VRAM preregistration exposes:
+  - `tc_vram_rdma_prereg_failures_total`
+  - `tc_vram_rdma_prereg_latency_ms`
+  - `tc_vram_rdma_prereg_bytes`
+
+# Naming Compliance (C++ APIs)
+
+All proposed new interfaces obey repository naming conventions:
+
+| Kind | Examples | Convention |
+| --- | --- | --- |
+| Class/struct | `GpuVramStagingPool`, `GpuVramRdmaStager`, `HostPinnedGpuStager`, `HostPinnedCpuStager` | `PascalCase` |
+| Proto msg/enum | `RdmaConfig::StagedRdmaBackend` | generated `PascalCase` |
+| Methods | `acquire_slice(...)`, `release_slice(...)`, `preregister_slabs(...)` | `snake_case` |
+| Constants/macros | `IBV_ACCESS_REMOTE_READ` (existing) | `ALL_CAPS` |
+
+# Trade-offs & Risks
+
+- **GPU VRAM staging increases GPU memory pressure**: requires careful sizing; can compete with model memory.
+- **Capability variability**: GPU device-memory MR registration support varies by driver/kernel/NIC; `STAGED_RDMA_BACKEND_GPU_VRAM` must validate at initialization and fail fast if unsupported.
+- **Non-direct semantics**: “non-direct” user scenarios may intentionally avoid exposing primary GPU pointers; GPU VRAM staging still exposes a GPU MR to peers (temporary). This must be explicitly configured and documented.
+
+## Alternatives Considered
+
+- **Keep host-pinned staged RDMA only**: simplest, but forces GPU→CPU staging (`cudaMemcpyDeviceToHost`) and higher CPU involvement in GPU workloads.
+- **Always require direct RDMA for GPU tensors**: incompatible with non-direct user scenarios where exposing primary pointers is not desired or feasible.
+- **Use a separate RDMA-only staging interface**: reduces risk of accidentally using VRAM staging for MTCP, but introduces a parallel abstraction stack. We instead keep one stack and encode “RDMA-only” explicitly via naming (`GpuVramRdmaStager`) and wiring.
+- **Rely on MTCP for GPU transfers**: avoids RDMA staging complexity, but does not meet latency/bandwidth goals in RDMA environments.
+
+# Compatibility & Acceptance Criteria
+
+- No behavior change when config remains default (STAGED_RDMA_BACKEND_HOST_PINNED, preregistration as today).
+- With `rdma_preregister=true` for `comm_gpu`:
+  - staged-RDMA for GPU tensors should reuse slab MRs rather than per-slice registrations.
+- With `communicator.rdma.staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM`:
+  - communicator initialization fails fast if GPU device-memory MR preregistration fails for any required NIC/PD.
+  - staged-RDMA for GPU tensors performs D2D staging (no D2H) and remains bounded by configured pool size.
+  - runtime does not fall back to STAGED_RDMA_BACKEND_HOST_PINNED due to capability detection (forced mode).
+
+# Protobuf and Build Hygiene
+
+- This design introduces only additive protobuf fields; it is wire/backward compatible for config parsing.
+- After modifying `proto/tensorcast/communicator/v1/communicator_config.proto`, regenerate code:
+  - `bash tools/build_proto_python.sh`
+
+# References
+
+- `core/communicator/engine/engine.cc` (RDMA stage policy and preregistration)
+- `core/communicator/engine/host_pinned_gpu_stager.h` / `core/communicator/engine/host_pinned_cpu_stager.cc` (host-pinned stagers)
+- `core/common/memory/pinned_buffer_pool.cc`
+- `core/communicator/misc/ibv_wrap.{h,cc}` (`ibv_reg_mr` wrapper)

--- a/docs/internals/model-loading.md
+++ b/docs/internals/model-loading.md
@@ -139,6 +139,7 @@ Both the fast path and the engine path increment the caller’s PID in `RefTrack
 - SDK registration flows call `tensorcast.api._tensor_graph.build_tensor_storage_graph()` before feeding lease segments.
 - The helper deduplicates `torch.Storage` objects and emits a `TensorStorageGraph` containing `StorageEntry` rows (unique storage id, device id, base pointer, storage length) plus `TensorAlias` metadata (tensor name, storage id, storage offset, logical byte length, shape, stride, dtype).
 - Clients transmit the deduplicated storage table via `storage_entries` and alias metadata via `tensor_aliases`. The daemon reconstructs canonical index JSON from these structures, producing byte-for-byte parity with disk persistence and opening each CUDA IPC handle only once per unique storage.
+- On materialization, the SDK maps the returned CUDA IPC handle once and constructs all `torch.Tensor` views from that mapping in one pass so the mapping is reference-counted across tensors and closed exactly once.
 
 Recommended: rely on `tensorcast.register(...)` (or `register_async`) with
 `RegisterArtifactOptions(lease_in_place=True)` and an explicit `ttl_ms`. The Store

--- a/docs/internals/model-loading.md
+++ b/docs/internals/model-loading.md
@@ -125,13 +125,13 @@ Both the fast path and the engine path increment the caller’s PID in `RefTrack
 
 ### LeaseSegments ↔ SegmentPlan
 
-- Robust protocol: each `LeasedSegment` now includes `dst_offset` (destination offset in the coalesced VRAM buffer). This removes any ordering assumption when sending lease segments.
+- Robust protocol: each `LeasedSegment` includes `artifact_offset` (logical byte offset in the canonical artifact layout) plus a `storage_id` reference. This removes any ordering assumption when sending lease segments.
 - Daemon behavior:
   - Builds the `SegmentPlan` from canonical index bytes.
-  - Zeros all `PAD` intervals in the destination VRAM buffer.
-  - Copies each `LeasedSegment` payload into `dst_offset .. dst_offset+length` regardless of feed order.
+  - Treats all `PAD` intervals as zero-filled for hashing and for any materialization copies.
+  - Reads `DATA` intervals from the referenced storage windows (`StorageEntry` + `mapping_base_offset` + `storage_offset`) regardless of feed order.
 - Client behavior:
-  - SDK already computes a coalesced layout and sets `dst_offset` per unique storage block.
+  - SDK computes a coalesced logical layout and sets `artifact_offset` per unique storage block.
   - Ordering no longer matters, but the SDK still sorts for stable traces.
 
 ### Shared Storage Graph Helper

--- a/docs/plans/0045-rdma-staging-vram-and-mr-prereg.md
+++ b/docs/plans/0045-rdma-staging-vram-and-mr-prereg.md
@@ -1,0 +1,150 @@
+---
+slug: rdma-staging-vram-and-mr-prereg
+title: RDMA Staging Backends (GPU VRAM) and MR Preregistration (Plan)
+areas: ["core", "daemon"]
+related_code:
+  - core/communicator/engine/engine.{h,cc}
+  - core/communicator/engine/host_pinned_gpu_stager.h
+  - core/communicator/engine/host_pinned_cpu_stager.{h,cc}
+  - core/communicator/engine/gpu_vram_rdma_stager.{h,cc} # new (RDMA-only GPU VRAM staging)
+  - core/communicator/engine/mr_cache.{h,cc}
+  - core/communicator/misc/ibv_wrap.{h,cc}
+  - core/communicator/transport/{partition_tensor,net_dev}.{h,cc}
+  - daemon/server_main.cc
+  - proto/tensorcast/communicator/v1/communicator_config.proto
+links:
+  design: ../designs/0045-rdma-staging-vram-and-mr-prereg.md
+---
+
+# Objective
+
+Land P0/P1 end-to-end:
+
+- **P0**: make `rdma_preregister` effective for GPU host-pinned staging (HostPinnedGpuStager; formerly `GpuNetStager`) by using slab-base MR normalization, and remove pointer-contract ambiguity by renaming `StageLease::host_ptr()` to `StageLease::exposed_ptr()`.
+- **P1**: add a GPU VRAM staged-RDMA backend (bounded VRAM bounce pool + D2D staging) with unified config. `STAGED_RDMA_BACKEND_GPU_VRAM` is a forced mode: initialization must fail fast if unsupported, and runtime must not fall back.
+
+# Current State & Grounding
+
+- Staged RDMA uses `MemoryStager::stage()` and registers MRs via `MrCache`:
+  - `core/communicator/engine/engine.cc`
+- `rdma_preregister` preregisters host-pinned slabs once per NIC/PD:
+  - `core/communicator/engine/engine.cc`
+- Slab-base MR reuse is now applied for both `HostPinnedCpuStager` and `HostPinnedGpuStager` via stager-provided slab lookup:
+  - `core/communicator/engine/engine.cc`
+- `HostPinnedGpuStager` stages GPU tensors via `cudaMemcpyDeviceToHost` into `PinnedBufferPool` slices:
+  - `core/communicator/engine/host_pinned_gpu_stager.h`
+- Direct RDMA already stores a device pointer in `StageLease::exposed_ptr()` (formerly `host_ptr()`). This plan renames the API to match reality and make GPU VRAM staged RDMA safe to reason about.
+
+## Constraints and assumptions
+
+- No ad-hoc env vars; config must be protobuf-backed and follow unified runtime config (`docs/designs/0004-unified-runtime-config.md`).
+- After any `.proto` edit, regenerate code via `bash tools/build_proto_python.sh`.
+- Prefer bounded waiting; do not introduce blocking waits on shared worker threads (see repository concurrency guidelines).
+
+# Configuration Compatibility Strategy
+
+- This work is additive to `tensorcast.communicator.v1.CommunicatorConfig` and does not change defaults:
+  - `rdma.staging_backend=STAGED_RDMA_BACKEND_UNSPECIFIED` behaves as STAGED_RDMA_BACKEND_HOST_PINNED.
+  - `rdma.staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM` is explicit and forced: communicator initialization fails if VRAM pool allocation or `ibv_reg_mr` preregistration fails for any required NIC/PD.
+- Existing configs continue to parse; new keys are optional.
+
+# Phases & Milestones
+
+- [x] Phase 1 (P0): Make preregistration effective + clarify naming/contracts
+  - [x] Milestone: rename stagers for clarity:
+    - `DRAMStager` → `HostPinnedCpuStager`
+    - `GpuNetStager` → `HostPinnedGpuStager`
+  - [x] Milestone: rename `StageLease::host_ptr()` → `StageLease::exposed_ptr()` and update all call sites / docs.
+  - [x] Milestone: add a stager-provided slab lookup hook (optional) so MR base normalization does not depend on `dynamic_cast`.
+  - [x] Milestone: staged-RDMA MR registration uses slab bases for both host-pinned CPU and host-pinned GPU staging.
+  - [x] Milestone: add targeted unit coverage proving slab reuse is taken when prereg is enabled.
+
+- [x] Phase 2 (P1): GPU VRAM staged-RDMA backend
+  - [x] Milestone: add typed config for staged-RDMA backend selection and VRAM pool sizing.
+  - [x] Milestone: implement `GpuVramStagingPool` + `GpuVramRdmaStager` and wire into RDMA staged fallback.
+  - [x] Milestone: add init-time validation and preregistration for VRAM pools using `ibv_reg_mr` (fail-fast; no runtime fallback).
+
+# Acceptance Checks
+
+- Default config produces no behavior change (STAGED_RDMA_BACKEND_HOST_PINNED staged RDMA).
+- P0:
+  - When `pinned_memory.classes[name=comm_gpu].rdma_preregister=true`, GPU staged RDMA uses slab-base MRs (no per-slice churn) and emits consistent MR registration metrics.
+- P1:
+  - With `rdma.staging_backend=STAGED_RDMA_BACKEND_GPU_VRAM`, communicator initialization fails if `ibv_reg_mr` preregistration for VRAM pools is unsupported/unavailable.
+  - On supported systems, staged RDMA for GPU tensors avoids D2H staging and remains bounded by configured VRAM pool.
+  - Runtime does not fall back to STAGED_RDMA_BACKEND_HOST_PINNED (forced mode).
+
+# Tasks
+
+## Phase 1 (P0)
+
+- Rename stagers for clarity:
+  - `DRAMStager` → `HostPinnedCpuStager`
+  - `GpuNetStager` → `HostPinnedGpuStager`
+- Rename `StageLease::host_ptr()` → `StageLease::exposed_ptr()` and update:
+  - RDMA response serialization (`ProtoReadResponseExSeg.addr`)
+  - StageLeaseRegistry-related logs/docs
+  - `core/communicator/README.md` to avoid “host pointer” wording for RDMA.
+- Add `MemoryStager` optional slab lookup (e.g., `mr_slab_for_ptr(void*) -> optional<Slab>`).
+- Implement slab lookup for:
+  - `HostPinnedCpuStager` (pinned pool slabs)
+  - `HostPinnedGpuStager` (pinned pool slabs)
+- Update `MakeStageFunction(...)` staged path:
+  - normalize `(mr_base, mr_bytes)` using stager-provided slab lookup.
+  - ensure preregistration (`MrCache`) is hit for slab-bases, not per-slice ptrs.
+- Add tests:
+  - a unit test that stages via `HostPinnedGpuStager` and verifies MR-cache keying uses slab base (e.g., preregister one slab and assert no new registrations occur for slice pointers).
+- Update docs:
+  - `core/communicator/README.md` to clarify preregistration behavior for GPU staging.
+
+## Phase 2 (P1)
+
+- Extend `proto/tensorcast/communicator/v1/communicator_config.proto`:
+  - `RdmaConfig::StagedRdmaBackend staging_backend`
+  - `uint64 vram_pool_bytes_per_gpu`
+  - `uint64 vram_slice_bytes`
+  - regenerate code (`bash tools/build_proto_python.sh`)
+- Update config normalization (if needed) to treat missing/unspecified values as STAGED_RDMA_BACKEND_HOST_PINNED without changing behavior.
+- Implement VRAM pool:
+  - per-GPU fixed-size pool, slice size derived from `rdma.vram_slice_bytes`.
+  - non-blocking acquire and immediate `ResourceExhausted` on failure (no runtime fallback).
+- Implement VRAM staged-RDMA staging:
+  - D2D copy into acquired VRAM slice.
+  - rely on preregistered `ibv_reg_mr` results for the VRAM pool (no per-slice registration churn).
+  - release on `RDMA_READ_DONE_EX` via `StageLease` lifecycle.
+- Implement init-time validation (forced mode):
+  - allocate VRAM pools
+  - preregister VRAM pool MRs for every NIC/PD via `ibv_reg_mr`
+  - fail communicator initialization if any preregistration step fails
+- Add tests:
+  - logic/unit tests that validate backend selection, credit release, and no MTCP usage of VRAM stager.
+  - optional integration tests that require real CUDA + verbs; skip otherwise.
+- Update docs:
+  - `core/communicator/README.md` to document staged backend configuration and prerequisites.
+
+# Test / Rollout / Backout
+
+- Tests (C++):
+  - After proto edits: `bash tools/build_proto_python.sh` and `bazel test //proto/... --test_output=errors`
+  - Run relevant communicator tests (most can use fake CUDA): `bazel test //core/communicator/... --define=use_fake_cuda=true`
+  - Add/maintain a targeted P0 regression test (fake CUDA): `bazel test //core/communicator/engine:staging_flow_controller_test --define=use_fake_cuda=true`
+  - Run STAGED_RDMA_BACKEND_GPU_VRAM staged-RDMA integration tests only on real CUDA + verbs machines; skip otherwise.
+- Rollout:
+  - Default remains STAGED_RDMA_BACKEND_HOST_PINNED; STAGED_RDMA_BACKEND_GPU_VRAM staging is opt-in and fail-fast (no runtime fallback).
+- Backout:
+  - Set `rdma.staging_backend=STAGED_RDMA_BACKEND_HOST_PINNED` (or leave unspecified).
+  - Revert the paired changeset if necessary; wire protocol remains unchanged.
+
+# Risks & Tracking
+
+- GPU VRAM pool sizing errors can cause load failures under concurrency; mitigation: bounded retries + clear metrics + configurable pool size.
+- `STAGED_RDMA_BACKEND_GPU_VRAM` is forced and fails fast. This is intended; mitigation is operational (change config to STAGED_RDMA_BACKEND_HOST_PINNED) and improved diagnostics/metrics during init.
+
+# Status
+
+- Implementation complete; Phase 1 and Phase 2 milestones checked off.
+- Proto regeneration: `bash tools/build_proto_python.sh`.
+- Tests run:
+  - `bazel test //core/communicator:stager_mr_normalization_test --define=use_fake_cuda=true`
+  - `bazel test //core/communicator:gpu_vram_rdma_stager_test --define=use_fake_cuda=true`
+  - `bazel test //proto/... --test_output=errors`

--- a/proto/tensorcast/communicator/v1/communicator_config.proto
+++ b/proto/tensorcast/communicator/v1/communicator_config.proto
@@ -20,6 +20,14 @@ message RdmaConfig {
   int32 traffic_class = 3; // default: 186 (TOS)
   int32 qp_timeout = 4; // default: 20
   int32 qp_retry = 5; // default: 7
+  enum StagedRdmaBackend {
+    STAGED_RDMA_BACKEND_UNSPECIFIED = 0; // treated as STAGED_RDMA_BACKEND_HOST_PINNED
+    STAGED_RDMA_BACKEND_HOST_PINNED = 1; // stage into host-pinned buffers (default)
+    STAGED_RDMA_BACKEND_GPU_VRAM = 2; // stage into GPU VRAM (RDMA-only)
+  }
+  StagedRdmaBackend staging_backend = 6;
+  uint64 vram_pool_bytes_per_gpu = 7;
+  uint64 vram_slice_bytes = 8;
 }
 
 message TransportConfig {

--- a/proto/tensorcast/daemon/v1/store_daemon.proto
+++ b/proto/tensorcast/daemon/v1/store_daemon.proto
@@ -604,28 +604,30 @@ message LeaseSegments {
   repeated LeasedSegment segments = 1;
 }
 message LeasedSegment {
-  int32 device_id = 1;
-  bytes cuda_ipc_handle = 2;
-  uint64 base_addr = 3;
+  // Physical storage backing this segment (must match a StorageEntry.storage_id).
+  string storage_id = 1;
+  // Byte offset within the referenced storage window where this segment begins.
+  uint64 storage_offset = 2;
+  // Logical byte offset within the artifact where this segment begins.
+  // This offset defines LIP's logical segment base and must obey artifact_chunk_bytes alignment rules.
+  uint64 artifact_offset = 3;
+  // Length of this segment in bytes.
   uint64 length = 4;
-  // Destination offset in the coalesced VRAM buffer (bytes).
-  // This locates the DATA interval within the SegmentPlan; PAD is handled by the daemon.
-  uint64 dst_offset = 5;
-  // Optional reference to a RegisterStorage entry. When set, the daemon reuses the
-  // associated storage metadata (region-backed or cuda handle) instead of the inline handle.
-  optional string storage_id = 6;
 }
 
 message StorageEntry {
   string storage_id = 1;
   int32 device_id = 2;
+  // Length of this storage window in bytes.
+  uint64 storage_length = 3;
   oneof storage_source {
-    bytes cuda_ipc_handle = 3;
+    // CUDA IPC handle for the allocation base pointer that backs this storage.
+    bytes cuda_ipc_handle = 4;
     string vram_region_id = 5;
   }
-  uint64 storage_length = 4;
-  // Base offset into the referenced region. When unset, defaults to zero.
-  optional uint64 region_base_offset = 6;
+  // Byte offset from the mapped base pointer (allocation base for cuda_ipc_handle, region base for vram_region_id)
+  // to the start of this storage window.
+  uint64 mapping_base_offset = 6;
 }
 
 message TensorAlias {

--- a/tensorcast/_C.pyi
+++ b/tensorcast/_C.pyi
@@ -75,6 +75,11 @@ def get_cuda_memory_handle(
     memory_ptr: _Ptr,
 ) -> bytes: ...
 
+def get_cuda_memory_handle_with_offset(
+    device_id: int,
+    memory_ptr: _Ptr,
+) -> Tuple[bytes, int]: ...
+
 
 def get_device_uuid_map() -> Dict[_DeviceId, str]: ...
 

--- a/tensorcast/_c_ext.py
+++ b/tensorcast/_c_ext.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025, TensorCast Team.
+#  Copyright (c) 2025-2026, TensorCast Team.
 
 """Lazy loader for the tensorcast._C native extension."""
 
@@ -93,6 +93,12 @@ def get_cuda_memory_handle(device_id: int, memory_ptr: int) -> bytes:
     return _load_c_ext().get_cuda_memory_handle(device_id, memory_ptr)
 
 
+def get_cuda_memory_handle_with_offset(
+    device_id: int, memory_ptr: int
+) -> tuple[bytes, int]:
+    return _load_c_ext().get_cuda_memory_handle_with_offset(device_id, memory_ptr)
+
+
 def restore_tensors_from_disk(
     meta_state_dict: Mapping[str, tuple[Sequence[int], Sequence[int], str, int]],
     disk_path: str | os.PathLike[str],
@@ -122,6 +128,7 @@ __all__ = [
     "compute_view_registration_plan",
     "get_c_ext",
     "get_cuda_memory_handle",
+    "get_cuda_memory_handle_with_offset",
     "get_cuda_memory_ptr",
     "get_device_uuid_map",
     "inspect_or_generate_descriptor",

--- a/tensorcast/api/_materialize.py
+++ b/tensorcast/api/_materialize.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025, TensorCast Team.
+#  Copyright (c) 2025-2026, TensorCast Team.
 
 from __future__ import annotations
 
@@ -303,25 +303,26 @@ def materialize_artifact_v2(
             raise DaemonUnavailable(
                 "Materialization payload is missing a mem_handle; tensor data is not available"
             )
-        for desc in descriptors:
-            meta_state_dict = {
-                desc.name: (
-                    list(desc.shape),
-                    list(desc.stride),
-                    desc.dtype,
-                    int(desc.storage_offset),
-                )
-            }
-            tensor_offsets: Mapping[int | torch.device, Mapping[str, int]] = {
-                dev_id: {desc.name: int(desc.buffer_offset)}
-            }
-            memory_ptrs: Mapping[int | torch.device, int] = {dev_id: cuda_memory_ptr}
-            tensors = restore_tensors(
-                meta_state_dict,
-                memory_ptrs,
-                tensor_offsets,
-                True,
+        meta_state_dict = {
+            desc.name: (
+                list(desc.shape),
+                list(desc.stride),
+                desc.dtype,
+                int(desc.storage_offset),
             )
+            for desc in descriptors
+        }
+        tensor_offsets: Mapping[int | torch.device, Mapping[str, int]] = {
+            dev_id: {desc.name: int(desc.buffer_offset) for desc in descriptors}
+        }
+        memory_ptrs: Mapping[int | torch.device, int] = {dev_id: cuda_memory_ptr}
+        tensors = restore_tensors(
+            meta_state_dict,
+            memory_ptrs,
+            tensor_offsets,
+            True,
+        )
+        for desc in descriptors:
             yield desc, tensors[desc.name]
 
     if opts.enable_verification:

--- a/tensorcast/api/_register.py
+++ b/tensorcast/api/_register.py
@@ -987,12 +987,10 @@ class _LeaseUploader:
                 base_offset = int(entry.base_ptr) - int(rec.base_ptr)
                 segments.append(
                     LeaseSegment(
-                        device_id=int(ctx.device_id),
-                        cuda_ipc_handle=None,
-                        base_addr=0,
-                        length=length_bytes,
-                        dst_offset=int(dst_offset),
                         storage_id=storage_id,
+                        storage_offset=0,
+                        artifact_offset=int(dst_offset),
+                        length=length_bytes,
                     )
                 )
                 storages_payload.append(
@@ -1002,7 +1000,7 @@ class _LeaseUploader:
                         cuda_ipc_handle=None,
                         storage_length=length_bytes,
                         vram_region_id=rec.region_id,
-                        region_base_offset=int(base_offset),
+                        mapping_base_offset=int(base_offset),
                     )
                 )
             else:
@@ -1014,12 +1012,10 @@ class _LeaseUploader:
                     )
                 segments.append(
                     LeaseSegment(
-                        device_id=int(ctx.device_id),
-                        cuda_ipc_handle=None,
-                        base_addr=int(base_offset),
-                        length=length_bytes,
-                        dst_offset=int(dst_offset),
                         storage_id=storage_id,
+                        storage_offset=0,
+                        artifact_offset=int(dst_offset),
+                        length=length_bytes,
                     )
                 )
                 storages_payload.append(
@@ -1028,6 +1024,7 @@ class _LeaseUploader:
                         device_id=int(ctx.device_id),
                         cuda_ipc_handle=handle_bytes,
                         storage_length=length_bytes,
+                        mapping_base_offset=int(base_offset),
                     )
                 )
         if not storages_payload:

--- a/tensorcast/api/_register.py
+++ b/tensorcast/api/_register.py
@@ -20,7 +20,7 @@ from opentelemetry.trace import SpanKind
 
 from tensorcast._c_ext import (
     compute_view_registration_plan,
-    get_cuda_memory_handle,
+    get_cuda_memory_handle_with_offset,
     get_cuda_memory_ptr,
     restore_tensors,
 )
@@ -931,8 +931,8 @@ class _LeaseUploader:
         handshake: Handshake,
         cancel_event: threading.Event | None = None,
     ) -> dict[str, torch.Tensor]:
-        def _export_cuda_ipc_handle(ptr: int) -> bytes:
-            return get_cuda_memory_handle(ctx.device_id, int(ptr))
+        def _export_cuda_ipc_handle(ptr: int) -> tuple[bytes, int]:
+            return get_cuda_memory_handle_with_offset(ctx.device_id, int(ptr))
 
         graph = ctx.storage_graph
         offsets_for_device = layout.offsets.get(int(ctx.device_id), {})
@@ -1007,12 +1007,16 @@ class _LeaseUploader:
                 )
             else:
                 # Fallback to legacy handle-based path.
-                handle_bytes = _export_cuda_ipc_handle(int(entry.base_ptr))
+                handle_bytes, base_offset = _export_cuda_ipc_handle(int(entry.base_ptr))
+                if not handle_bytes:
+                    raise TensorCastError(
+                        f"Failed to export CUDA IPC handle for storage '{storage_id}'"
+                    )
                 segments.append(
                     LeaseSegment(
                         device_id=int(ctx.device_id),
-                        cuda_ipc_handle=handle_bytes,
-                        base_addr=0,
+                        cuda_ipc_handle=None,
+                        base_addr=int(base_offset),
                         length=length_bytes,
                         dst_offset=int(dst_offset),
                         storage_id=storage_id,

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -999,9 +999,9 @@ class MaterializationPipeline:
             preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
 
         client = self._runtime.ensure_client()
+        if mark_started is not None:
+            mark_started()
         try:
-            if mark_started is not None:
-                mark_started()
             response = client.materialize_into_target_v2(
                 artifact_id=artifact_id,
                 target_layout=layout,

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -929,7 +929,7 @@ class MaterializationPipeline:
             device_id=int(device_id),
             storage_length=int(logical_total_size),
             vram_region_id=region.region_id,
-            region_base_offset=int(region_base_offset),
+            mapping_base_offset=int(region_base_offset),
         )
         layout.offsets.extend(offsets)
         digest = hashlib.sha256()

--- a/tensorcast/csrc/checkpoint_py.cc
+++ b/tensorcast/csrc/checkpoint_py.cc
@@ -973,6 +973,19 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           py::arg("device_id"),
           py::arg("memory_ptr"),
           "Get a CUDA IPC memory handle for a single allocation")
+      .def(
+          "get_cuda_memory_handle_with_offset",
+          [](int device_id, std::uint64_t memory_ptr_int) {
+            auto handle_or = tensorcast::checkpoint::get_cuda_memory_handle_with_offset(device_id, memory_ptr_int);
+            if (!handle_or.ok()) {
+              return py::make_tuple(py::bytes(""), py::int_(0));
+            }
+            const auto& [handle, base_offset] = *handle_or;
+            return py::make_tuple(py::bytes(handle), py::int_(base_offset));
+          },
+          py::arg("device_id"),
+          py::arg("memory_ptr"),
+          "Get a CUDA IPC memory handle for the backing allocation plus base offset for a pointer")
       .def("get_device_uuid_map", &tensorcast::checkpoint::get_device_uuid_map, "Get device uuid map")
       .def(
           "get_cuda_memory_ptr",

--- a/tensorcast/daemon_ctl.py
+++ b/tensorcast/daemon_ctl.py
@@ -1406,14 +1406,10 @@ class DaemonCtl:
             )
             for s in segments:
                 seg = req.lease_segments.segments.add()
-                seg.device_id = int(s.device_id)
-                if s.cuda_ipc_handle is not None:
-                    seg.cuda_ipc_handle = s.cuda_ipc_handle
-                seg.base_addr = int(s.base_addr)
+                seg.storage_id = s.storage_id
+                seg.storage_offset = int(s.storage_offset)
                 seg.length = int(s.length)
-                seg.dst_offset = int(s.dst_offset)
-                if s.storage_id:
-                    seg.storage_id = s.storage_id
+                seg.artifact_offset = int(s.artifact_offset)
             if storages:
                 for storage in storages:
                     entry = req.storage_entries.add()
@@ -1424,8 +1420,7 @@ class DaemonCtl:
                     if storage.vram_region_id:
                         entry.vram_region_id = storage.vram_region_id
                     entry.storage_length = int(storage.storage_length)
-                    if storage.region_base_offset is not None:
-                        entry.region_base_offset = int(storage.region_base_offset)
+                    entry.mapping_base_offset = int(storage.mapping_base_offset)
             if tensor_aliases:
                 for alias in tensor_aliases:
                     dst = req.tensor_aliases.add()

--- a/tensorcast/types.py
+++ b/tensorcast/types.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025, TensorCast Team.
+#  Copyright (c) 2025-2026, TensorCast Team.
 
 from __future__ import annotations
 
@@ -227,25 +227,27 @@ Plan = Union[CoalescedPlan, LeasePlan, StableDramPlan]
 class LeaseSegment(BaseModel):
     """A single lease segment exported from CUDA IPC and fed to the daemon.
 
-    dst_offset is mandatory to eliminate ordering assumptions and reduce
-    optional branching in downstream logic.
+    A LeaseSegment maps a physical storage window (referenced by storage_id) into
+    the artifact's logical address space.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    device_id: int
-    cuda_ipc_handle: bytes | None = None
-    base_addr: int = 0
+    storage_id: str
+    storage_offset: int = 0
+    artifact_offset: int
     length: int
-    dst_offset: int
-    storage_id: str | None = None
 
     @model_validator(mode="after")
-    def _validate_source(self) -> "LeaseSegment":
-        if self.cuda_ipc_handle is None and not self.storage_id:
-            raise ValueError(
-                "LeaseSegment requires either cuda_ipc_handle or storage_id"
-            )
+    def _validate_offsets(self) -> "LeaseSegment":
+        if not self.storage_id:
+            raise ValueError("LeaseSegment.storage_id must not be empty")
+        if self.storage_offset < 0:
+            raise ValueError("LeaseSegment.storage_offset must be non-negative")
+        if self.artifact_offset < 0:
+            raise ValueError("LeaseSegment.artifact_offset must be non-negative")
+        if self.length <= 0:
+            raise ValueError("LeaseSegment.length must be positive")
         return self
 
 
@@ -259,7 +261,7 @@ class RegisterStorage(BaseModel):
     cuda_ipc_handle: bytes | None = None
     storage_length: int
     vram_region_id: str | None = None
-    region_base_offset: int | None = None
+    mapping_base_offset: int = 0
 
     @model_validator(mode="after")
     def _validate_source(self) -> "RegisterStorage":
@@ -269,10 +271,8 @@ class RegisterStorage(BaseModel):
             raise ValueError(
                 "RegisterStorage requires exactly one of cuda_ipc_handle or vram_region_id"
             )
-        if has_region and self.region_base_offset is None:
-            raise ValueError(
-                "RegisterStorage.region_base_offset is required when vram_region_id is set"
-            )
+        if self.mapping_base_offset < 0:
+            raise ValueError("RegisterStorage.mapping_base_offset must be non-negative")
         return self
 
 

--- a/tests/python/api/test_materialization_pipeline_v2.py
+++ b/tests/python/api/test_materialization_pipeline_v2.py
@@ -87,18 +87,15 @@ class _FakeClient:
         self.unloaded: list[str] = []
         self.resolve_calls: list[tuple[str, bool]] = []
 
-    def get_artifact_index_by_id(self, artifact_id: str) -> bytes:
-        del artifact_id
-        return b"{}"
-
     def unload_replica(self, replica_uuid: str, *, disk_path: str = "") -> bool:
         self.unloaded.append(f"{replica_uuid}:{disk_path}")
         return True
 
-    def get_artifact_index_by_id(self, _artifact_id: str) -> bytes:
+    def get_artifact_index_by_id(self, artifact_id: str) -> bytes:
         # Region-backed get_into may probe artifact indices even when tests do not
         # set up a daemon. Returning an empty canonical index forces the region-backed
         # path to fall back cleanly.
+        del artifact_id
         return b"{}"
 
     def resolve_artifact_from_disk_v2(
@@ -144,9 +141,6 @@ class _RuntimeStub:
 
     def ensure_client(self) -> _FakeClient:
         return self.client
-
-    def get_artifact_index_cached(self, artifact_id: str):
-        return self._artifact_cache.get_artifact_index_cached(artifact_id)
 
     def cache_artifact_index(self, entry: ArtifactCacheEntry) -> None:
         self._artifact_cache.cache_artifact_index(entry)

--- a/tests/python/api/test_materialization_pipeline_v2.py
+++ b/tests/python/api/test_materialization_pipeline_v2.py
@@ -95,6 +95,12 @@ class _FakeClient:
         self.unloaded.append(f"{replica_uuid}:{disk_path}")
         return True
 
+    def get_artifact_index_by_id(self, _artifact_id: str) -> bytes:
+        # Region-backed get_into may probe artifact indices even when tests do not
+        # set up a daemon. Returning an empty canonical index forces the region-backed
+        # path to fall back cleanly.
+        return b"{}"
+
     def resolve_artifact_from_disk_v2(
         self, *, disk_path: str, verify_checksums: bool = True
     ):
@@ -138,6 +144,9 @@ class _RuntimeStub:
 
     def ensure_client(self) -> _FakeClient:
         return self.client
+
+    def get_artifact_index_cached(self, artifact_id: str):
+        return self._artifact_cache.get_artifact_index_cached(artifact_id)
 
     def cache_artifact_index(self, entry: ArtifactCacheEntry) -> None:
         self._artifact_cache.cache_artifact_index(entry)

--- a/tests/python/test_store_pipelines_unit.py
+++ b/tests/python/test_store_pipelines_unit.py
@@ -102,11 +102,11 @@ class _DummyRuntime:
     def ensure_client(self) -> _FakeClient:
         return self.client
 
-    def get_artifact_index_cached(self, artifact_id: str):
+    def get_artifact_index_cached(self, artifact_id: str) -> object | None:
         del artifact_id
         return None
 
-    def cache_artifact_index(self, entry) -> None:  # pragma: no cover - noop
+    def cache_artifact_index(self, entry: object) -> None:  # pragma: no cover - noop
         del entry
         return None
 
@@ -118,13 +118,7 @@ class _DummyRuntime:
     ) -> tuple[str | None, str | None]:  # pragma: no cover - noop
         return self.client.resolve_key_mapping(key)
 
-    def get_artifact_index_cached(self, _artifact_id: str):
-        return None
-
-    def get_artifact_index_by_disk_path(self, _disk_path: str):
-        return None
-
-    def cache_artifact_index(self, _entry) -> None:
+    def get_artifact_index_by_disk_path(self, _disk_path: str) -> object | None:
         return None
 
     def invalidate_artifact(

--- a/tests/python/test_store_pipelines_unit.py
+++ b/tests/python/test_store_pipelines_unit.py
@@ -62,6 +62,12 @@ class _FakeClient:
     def resolve_key_mapping(self, key: str) -> tuple[str | None, str | None]:
         return None, None
 
+    def get_artifact_index_by_id(self, _artifact_id: str) -> bytes:
+        # Region-backed get_into may probe indices before determining that no
+        # VRAM region is registered; return an empty canonical index so the
+        # region-backed path falls back cleanly.
+        return b"{}"
+
     def unload_replica(self, replica_uuid: str, *, disk_path: str = "") -> bool:
         self.unloaded.append(f"{replica_uuid}:{disk_path}")
         return True
@@ -114,6 +120,15 @@ class _DummyRuntime:
         self, *, key: str
     ) -> tuple[str | None, str | None]:  # pragma: no cover - noop
         return self.client.resolve_key_mapping(key)
+
+    def get_artifact_index_cached(self, _artifact_id: str):
+        return None
+
+    def get_artifact_index_by_disk_path(self, _disk_path: str):
+        return None
+
+    def cache_artifact_index(self, _entry) -> None:
+        return None
 
     def invalidate_artifact(
         self, artifact_id: str | None, *, key: str | None = None, reason: str | None = None

--- a/tests/python/test_store_pipelines_unit.py
+++ b/tests/python/test_store_pipelines_unit.py
@@ -55,17 +55,14 @@ class _FakeClient:
     def __init__(self) -> None:
         self.unloaded: list[str] = []
 
-    def get_artifact_index_by_id(self, artifact_id: str) -> bytes:
-        del artifact_id
-        return b"{}"
-
     def resolve_key_mapping(self, key: str) -> tuple[str | None, str | None]:
         return None, None
 
-    def get_artifact_index_by_id(self, _artifact_id: str) -> bytes:
+    def get_artifact_index_by_id(self, artifact_id: str) -> bytes:
         # Region-backed get_into may probe indices before determining that no
         # VRAM region is registered; return an empty canonical index so the
         # region-backed path falls back cleanly.
+        del artifact_id
         return b"{}"
 
     def unload_replica(self, replica_uuid: str, *, disk_path: str = "") -> bool:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables staged RDMA into GPU VRAM and unifies staging across transports with improved MR reuse and metrics.
> 
> - **Staging/Communicator**: Replaces `GpuNetStager`/`DRAMStager` with `HostPinnedGpuStager`/`HostPinnedCpuStager`; adds RDMA-only `GpuVramRdmaStager` + per-GPU VRAM pools; engine selects backend via `rdma.staging_backend` and preregisters host-pinned/VRAM slabs; switches to `StageLease::exposed_ptr()`; non-blocking staging retained; extensive metrics for staged backend, MR register, and prereg latencies
> - **MR handling**: `MemoryStager` gains `mr_slab_for_ptr` and helper to normalize registrations to slab bases; `MrCache` returns `{mr, registered}` and supports injectable (de)register fns
> - **Protocol/Build/Tests**: BUILD targets and README updated; new tests for MR normalization and GPU VRAM stager; docs added for unified staging and VRAM backend; proto adds `RdmaConfig.StagedRdmaBackend` + VRAM sizing fields
> - **CUDA backend**: Adds `mem_get_address_range` (fake/real); hardens `close_ipc_mem_handle`; new `get_cuda_memory_handle_with_offset` (plus header)
> - **Checkpoint restore**: CUDA IPC-backed tensors now share a ref-counted owner per mapping; set_device before cleanup on GPU; Python binding exposes handle-with-offset
> - **Python**: Registration exports handle+base_offset; materialization batches restores; minor pipeline and test harness adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b20b4fe7023aee48f699603ac1ebf9ab8dbce756. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->