### PR TITLE
chore(config): unify config discovery

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include examples/config/*.yaml

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pre-commit install
 # Ubuntu toolchain deps
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt update
-sudo apt install -y software-properties-common libxml2 libstdc++-12-dev gcc-13 g++-13
+sudo apt install -y software-properties-common libxml2 libstdc++-12-dev gcc-13 g++-13 python3
 ```
 
 ### Build

--- a/daemon/server_main.cc
+++ b/daemon/server_main.cc
@@ -419,6 +419,12 @@ int main(int argc, char** argv) {
   builder.AddChannelArgument("grpc.so_reuseport", cfg.server().grpc().so_reuseport() ? 1 : 0);
   builder.RegisterService(&service);
   std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
+
+  if (server == nullptr) {
+    LOG(ERROR) << "Failed to start gRPC server";
+    return 2;
+  }
+
   LOG(INFO) << "tensorcast-daemon listening on " << listen_addr;
 
   // Start worker lifecycle if configured

--- a/docs/deployment/global-store-deployment.md
+++ b/docs/deployment/global-store-deployment.md
@@ -19,7 +19,7 @@ The Global Store provides:
 
 ## Configuration
 
-Use a unified file-based configuration (YAML/JSON → Proto with strict validation); CLI flags and environment variables are not supported. See `examples/config/global_store_config.yaml` and pass it via `--config`.
+Use a unified file-based configuration (YAML/JSON → Proto with strict validation); CLI flags and environment variables are not supported. See `examples/config/global_store_config.yaml` and pass it via `--config`. The example defaults `database.db_file` to null (in-memory); set a persistent path for production deployments.
 
 ## Deployment Methods
 

--- a/docs/deployment/high-availability-usage.md
+++ b/docs/deployment/high-availability-usage.md
@@ -92,6 +92,8 @@ uv run tensorcast global start --config=/etc/tensorcast/global_store.yaml
 - Use a persistent DuckDB path (`database.db_file`) for recovery.
 - The CLI persists `cluster_token` under `~/.tensorcast/runtime/cluster_token` to detect split-brain and returns the metrics port in the startup log.
 - Add `--blocking` to keep the Global Store attached to the CLI and stop it when the CLI exits.
+- If you omit `--config`, the CLI uses `$TENSORCAST_GLOBAL_STORE_CONFIG` when set, otherwise `examples/config/global_store_config.yaml` (repo checkout or packaged wheel); if neither is found, startup fails. Defaults come from that file (including `listen.host: 0.0.0.0`).
+- The example config defaults `database.db_file` to null (in-memory); set a persistent path for HA. When set, `~` is expanded and parent directories are created on startup.
 
 ### Start Store Daemon with HA
 
@@ -105,6 +107,7 @@ uv run tensorcast daemon start \
 - The orchestrator writes an effective config that enables HA, injects the Global Store endpoint, and fills missing listen/p2p ports.
 - Startup will fail fast if `server.p2p_listen.port` is zero or if `advertise.host` is loopback/unspecified.
 - Add `--blocking` to keep the daemon attached to the CLI and stop it when the CLI exits (SIGTERM with a ~35s grace before SIGKILL).
+- If you omit `--config`, the CLI uses `$TENSORCAST_DAEMON_CONFIG` when set, otherwise `examples/config/store_daemon_config.yaml` (repo checkout or packaged wheel); if neither is found, startup fails.
 
 ### Manual RPC examples (generated stubs)
 

--- a/docs/deployment/store-daemon.md
+++ b/docs/deployment/store-daemon.md
@@ -26,10 +26,10 @@ Use the unified YAML config and start via CLI (default `--global-store-mode` is 
 uv run tensorcast-cli daemon start --global-store-mode connect --global-store-address 127.0.0.1:50051
 ```
 
-If you omit `--config`, the CLI tries `$TENSORCAST_DAEMON_CONFIG` or
-`~/.tensorcast/config/daemon.yaml` and otherwise materializes an embedded
-loopback config (port=0, storage under `~/.tensorcast`). Set listen/advertise
-addresses through the config file instead of CLI flags.
+If you omit `--config`, the CLI tries `$TENSORCAST_DAEMON_CONFIG`, then
+`examples/config/store_daemon_config.yaml` (repo checkout or packaged wheel),
+and errors if no config is found. Set listen/advertise addresses through the
+config file instead of CLI flags.
 You can also override config values inline with `--set KEY=VALUE` (repeatable).
 Example: `--set engine.memory_tiers.stable_bytes=4GB`.
 Common shortcuts: `--stable-bytes`, `--mem-pool-size-bytes`, `--enable-rdma`, `--log-level`.
@@ -42,17 +42,24 @@ namespace) that live inside the active Python environment. This allows the
 daemon to resolve ``libstore_engine``, ``libtorch`` and CUDA components even
 when only the binary is present on disk.
 
-During startup, the CLI can mirror daemon stdout and stderr into the invoking
-terminal in addition to persisting them under `~/.tensorcast/sessions/<id>/logs`.
 By default the daemon runs in the background after `tensorcast-cli daemon start`
-returns; add `--blocking` to keep it attached to the CLI, stream logs to the
-terminal, and stop it when the CLI exits (SIGTERM with a ~35s grace before
-SIGKILL).
+returns, and logs are persisted under `~/.tensorcast/sessions/<id>/logs` (view
+them with `uv run tensorcast-cli daemon logs`). Add `--blocking` to keep the daemon
+attached to the CLI, stream logs directly to the terminal (stdio inherited to
+avoid buffered crash output), and stop it when the CLI exits (SIGTERM with a
+~35s grace before SIGKILL). In blocking mode, logs are not persisted to the
+session log files.
 
 ## Manage Daemon Sessions
 
 Daemon sessions are tracked under `~/.tensorcast/sessions/<session_id>` and the
 current session id is stored in `~/.tensorcast/current_session`.
+Session metadata is written as soon as the daemon process starts (before
+readiness), so SDK `tc.init(mode="connect")` can discover the session while
+startup continues; retry if the daemon is still initializing. The CLI emits
+periodic readiness status messages if startup takes longer than a few seconds
+and probes both the configured listen host and loopback to avoid hanging on a
+non-local listen address.
 
 Only one Store Daemon instance is allowed per `$TENSORCAST_HOME`. If you run
 `tensorcast-cli daemon start` while another daemon is already running, the CLI

--- a/docs/designs/0039-artifact-first-sdk.md
+++ b/docs/designs/0039-artifact-first-sdk.md
@@ -36,7 +36,7 @@ Non-Goals
 - `tc.init(mode="connect", address="local")`  
 - `tc.init(mode="create", daemon_config_path=None, show_daemon_logs=True, install_signal_handlers=False, fate_share_sigterm=False)`  
   Connects to an existing daemon (`connect`) or launches a new per-process daemon (`create`); sets the global daemon address used by the process Store.  
-  **Default config:** if no config path is provided and none is discoverable, the SDK falls back to an embedded minimal daemon config (loopback bind, ephemeral or standard port, default cache path) so `tc.init(mode="create")` “just works” after install.
+  **Default config:** if no config path is provided, the SDK uses the discovered config (env or `examples/config/store_daemon_config.yaml` when available); if none is found, initialization fails with a config error.
 - `tc.shutdown()`, `tc.is_initialized()`.
 - `tc.artifact(key=None, artifact_id=None, disk_path=None, fallback=None) -> Artifact`  
   Lazy handle factory; no data transfer; resolves key/disk lazily on first touch. `artifact_async(...)` mirrors it.

--- a/docs/designs/0040-unified-cli-runtime.md
+++ b/docs/designs/0040-unified-cli-runtime.md
@@ -179,7 +179,7 @@ Key schemas (schema_version=1):
 ## Daemon lifecycle and HA injection
 
 - Daemon config is materialized per session into `effective_daemon_config.yaml`; CLI overlays apply first, ports may be user-set or discovered, and `ha_endpoints` is injected from the resolved Global Store address unless `global_store_mode="none"`.
-- Startup waits for daemon readiness via `GetServerConfig` and does not treat an open TCP port as ready, then writes runtime and session state atomically. PID records are append-only and include role, argv, and log paths.
+- Startup writes initial runtime/session state after process spawn (before readiness) so SDK/CLI discovery can see the session, then waits for readiness via `GetServerConfig` and refreshes state. PID records are append-only and include role, argv, and log paths.
 - Only one daemon instance is allowed per `$TENSORCAST_HOME`; `daemon start` refuses to launch a second instance and instead surfaces the existing session details.
 - CLI launches are detached from the caller process so daemons (and any CLI-started Global Store) stay running after the command returns unless `--blocking` is used.
 - Blocking-mode shutdown handlers are idempotent to avoid duplicate stop attempts when signals and `atexit` both fire.

--- a/examples/config/global_store_config.yaml
+++ b/examples/config/global_store_config.yaml
@@ -1,9 +1,9 @@
 # Config metadata for auditing and cluster safety.
 meta:
-  # Schema version label for auditing; keep empty unless you enforce schema checks.
-  schema_version: ""
+  # Schema version label for auditing; update if you enforce schema checks.
+  schema_version: "v1"
   # Free-form description for operators and change tracking.
-  description: ""
+  description: "default-global-store"
   # Cluster identity token used by daemons to avoid split-brain; echoed by HealthCheck.
   cluster_token: ""
 
@@ -27,7 +27,7 @@ server:
     # Advertised port; 0 uses the bound listen port.
     port: 0
   # Thread pool size for serving RPCs; increase for many concurrent daemons/clients.
-  max_workers: 20
+  max_workers: 10
   grpc:
     # Max concurrent HTTP/2 streams; 0 uses gRPC default.
     max_concurrent_streams: 0
@@ -53,7 +53,7 @@ server:
       # Optional client CA bundle for mTLS; empty disables client cert checks.
       client_ca_file: ""
   # Prometheus metrics HTTP port; 0 lets the service choose an available port.
-  metrics_port: 8000
+  metrics_port: 18000
 
 # Worker lifecycle and cleanup policy.
 worker_policy:

--- a/examples/config/store_daemon_config.yaml
+++ b/examples/config/store_daemon_config.yaml
@@ -149,8 +149,8 @@ communicator:
     buffers_per_flow: 4
     # Cap concurrent in-flight segments; 0 inherits buffers_per_flow.
     max_window_segments: 0
-    # Cap concurrent GPU channels so pool sizing is predictable (0 = auto).
-    expected_gpu_channels: 0
+    # Cap concurrent GPU channels so pool sizing is predictable (8 for 8-GPU defaults; 0 = auto).
+    expected_gpu_channels: 8
   rdma:
     # Outstanding WRs per QP; increase for bandwidth, decrease to reduce CPU/latency.
     outstanding_wr: 64

--- a/examples/test_get.py
+++ b/examples/test_get.py
@@ -1,11 +1,11 @@
-#  Copyright (c) 2025, TensorCast Team.
-
-import torch
+#  Copyright (c) 2026, TensorCast Team.
 
 import tensorcast as tc
 
-tc.init(mode="connect", address="127.0.0.1:50052")
+tc.init(mode="connect")
 
-device = "cuda:0" if torch.cuda.is_available() else "cpu"
-state_dict = tc.get(key="test:model:001", device=device)
-print(state_dict)
+device = "cuda:0"
+key = "demo:model:002"
+
+handle = tc.artifact(key=key)
+loaded = handle.tensor_dict(device=device)

--- a/examples/test_put.py
+++ b/examples/test_put.py
@@ -1,0 +1,15 @@
+#  Copyright (c) 2026, TensorCast Team.
+
+import torch
+
+import tensorcast as tc
+
+tc.init(mode="connect")
+
+device = "cuda:0"
+key = "demo:model:002"
+state_dict = {"layer.weight": torch.randn(8, 8, device=device)}
+expected_cpu = {name: tensor.cpu() for name, tensor in state_dict.items()}
+
+registered = tc.put(state_dict, key=key)
+print("artifact_id:", registered.artifact_id)

--- a/setup.py
+++ b/setup.py
@@ -525,6 +525,12 @@ class EditableWheelCommand(editable_wheel):
         copy_schema_sql()
         editable_wheel.run(self)
 
+class BuildPyCommand(build_py):
+    description = "Builds the Python package sources"
+
+    def run(self):
+        build_py.run(self)
+        copy_example_configs(self.build_lib)
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""
@@ -578,6 +584,24 @@ ext_modules = []
 
 
 package_data = {}
+
+
+EXAMPLE_CONFIG_FILENAMES = (
+    "global_store_config.yaml",
+    "store_daemon_config.yaml",
+)
+
+
+def copy_example_configs(build_lib: str) -> None:
+    src_dir = Path(dir_path) / "examples" / "config"
+    dest_dir = Path(build_lib) / "tensorcast" / "examples" / "config"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for name in EXAMPLE_CONFIG_FILENAMES:
+        src = src_dir / name
+        if not src.is_file():
+            raise FileNotFoundError(f"Missing example config: {src}")
+        copyfile(src, dest_dir / name)
+
 
 
 def find_cuda_runtime_lib_dir():

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ from shutil import copyfile, rmtree, which
 import torch  # Import torch to get version info
 import yaml
 from setuptools import find_packages, setup
+from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 from setuptools.command.editable_wheel import editable_wheel
 from setuptools.command.install import install
@@ -156,25 +157,30 @@ if (gpu_arch_version := os.environ.get("CU_VERSION")) is None:
 if BUILD_EXTENSION or BUILD_CORE:
     validate_build_environment()
 
+def _format_cuda_suffix(cuda_version: str | None) -> str | None:
+    if not cuda_version:
+        return None
+    parts = cuda_version.split(".")
+    if len(parts) >= 2:
+        return f"cu{parts[0]}{parts[1]}"
+    return f"cu{cuda_version.replace('.', '')}"
+
+
 def get_torch_version_suffix() -> str:
     """Get torch version suffix for package versioning."""
     # Get PyTorch version
     torch_version = torch.__version__.split('+')[0]  # Remove +cu118 etc.
     torch_major_minor = '.'.join(torch_version.split('.')[:2])  # Get major.minor
 
-    # Get CUDA version from torch
+    # Get CUDA version from torch even when no GPU is present.
     cuda_suffix = ""
-    if torch.cuda.is_available():
-        # Extract CUDA version from torch version string if available
-        if '+' in torch.__version__ and 'cu' in torch.__version__:
-            cuda_part = torch.__version__.split('+')[1]
-            if cuda_part.startswith('cu'):
-                cuda_suffix = f".{cuda_part}"  # Use dot instead of +
-        else:
-            # Try to get CUDA version from torch.version.cuda
-            cuda_version = torch.version.cuda
-            cuda_major_minor = ''.join(cuda_version.split('.')[:2])
-            cuda_suffix = f".cu{cuda_major_minor}"  # Use dot instead of +
+    cuda_tag = _format_cuda_suffix(torch.version.cuda)
+    if cuda_tag:
+        cuda_suffix = f".{cuda_tag}"
+    elif "+cu" in torch.__version__:
+        cuda_part = torch.__version__.split("+", 1)[1]
+        if cuda_part.startswith("cu"):
+            cuda_suffix = f".{cuda_part}"
 
     # Format: torch26 or torch26.cu118 (PEP 440 compliant)
     torch_suffix = f"torch{torch_major_minor.replace('.', '')}{cuda_suffix}"
@@ -379,6 +385,36 @@ def copy_schema_sql() -> None:
         print(f"Warning: Failed to copy schema.sql into package: {e}")
 
 
+def ensure_proto_python_generated() -> None:
+    """Ensure generated Python protos exist and are linked into the package tree."""
+    proto_gen_dir = Path(dir_path) / "proto" / "gen" / "python" / "tensorcast"
+    if not proto_gen_dir.exists():
+        script_path = Path(dir_path) / "tools" / "build_proto_python.sh"
+        if not script_path.exists():
+            raise RuntimeError(
+                f"Missing generated protos at {proto_gen_dir} and build script not found at {script_path}"
+            )
+        print("Generating Python proto stubs via tools/build_proto_python.sh")
+        subprocess.check_call(["bash", str(script_path)], cwd=dir_path)
+
+    if not proto_gen_dir.exists():
+        raise RuntimeError(f"Python proto stubs not found at {proto_gen_dir}")
+
+    proto_link = Path(dir_path) / "tensorcast" / "proto"
+    if proto_link.exists():
+        return
+    if proto_link.is_symlink():
+        try:
+            proto_link.unlink()
+        except Exception:
+            pass
+    proto_link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.symlink(str(proto_gen_dir.resolve()), str(proto_link))
+        print(f"Created symlink: {proto_link} -> {proto_gen_dir}")
+    except Exception as e:
+        print(f"Warning: Failed to create proto symlink: {e}")
+
 
 def find_bazel_daemon_binary() -> Path | None:
     candidate = Path(dir_path) / "bazel-bin" / "daemon" / "tensorcast_daemon"
@@ -529,8 +565,10 @@ class BuildPyCommand(build_py):
     description = "Builds the Python package sources"
 
     def run(self):
+        ensure_proto_python_generated()
         build_py.run(self)
         copy_example_configs(self.build_lib)
+
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""
@@ -580,28 +618,18 @@ class CleanCommand(Command):
                 os.remove(path)
 
 
+class BuildPyCommand(build_py):
+    description = "Builds the Python package sources"
+
+    def run(self):
+        ensure_proto_python_generated()
+        build_py.run(self)
+
+
 ext_modules = []
 
 
 package_data = {}
-
-
-EXAMPLE_CONFIG_FILENAMES = (
-    "global_store_config.yaml",
-    "store_daemon_config.yaml",
-)
-
-
-def copy_example_configs(build_lib: str) -> None:
-    src_dir = Path(dir_path) / "examples" / "config"
-    dest_dir = Path(build_lib) / "tensorcast" / "examples" / "config"
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    for name in EXAMPLE_CONFIG_FILENAMES:
-        src = src_dir / name
-        if not src.is_file():
-            raise FileNotFoundError(f"Missing example config: {src}")
-        copyfile(src, dest_dir / name)
-
 
 
 def find_cuda_runtime_lib_dir():
@@ -815,6 +843,7 @@ cmd_class = {
         "develop": DevelopCommand,
         "bdist_wheel": BdistCommand,
         "editable_wheel": EditableWheelCommand,
+        "build_py": BuildPyCommand,
 }
 
 if BuildExtension is not None:
@@ -827,7 +856,16 @@ setup(
     cmdclass=cmd_class,
     zip_safe=False,
     packages=find_packages(exclude=["*.csrc.*"]),
-    package_data={"tensorcast": ["schema.sql", "*.so", "lib/*.so", "bin/*"]},
+    package_data={
+        "tensorcast": [
+            "schema.sql",
+            "*.so",
+            "lib/*.so",
+            "bin/*",
+            "proto/**/*.py",
+            "proto/**/*.pyi",
+        ]
+    },
     exclude_package_data={
         # "tensorcast": [
         #     "tensorcast/csrc/*.cc",

--- a/tensorcast/cli.py
+++ b/tensorcast/cli.py
@@ -163,8 +163,9 @@ def daemon():
     type=click.Path(exists=True, path_type=Path),
     help=(
         "Path to unified daemon config (YAML/JSON). "
-        "If omitted, tries $TENSORCAST_DAEMON_CONFIG or ~/.tensorcast/config/daemon.yaml, "
-        "falling back to an embedded default."
+        "If omitted, tries $TENSORCAST_DAEMON_CONFIG, "
+        "then examples/config/store_daemon_config.yaml (repo or packaged wheel). "
+        "Errors if no config is found."
     ),
 )
 @click.option(
@@ -494,7 +495,13 @@ def global_group():
 
 @global_group.command("start")
 @click.option(
-    "--config", type=click.Path(path_type=Path), help="Global Store config path"
+    "--config",
+    type=click.Path(path_type=Path),
+    help=(
+        "Global Store config path (defaults to $TENSORCAST_GLOBAL_STORE_CONFIG, "
+        "or examples/config/global_store_config.yaml (repo or packaged wheel) when available). "
+        "Errors if no config is found."
+    ),
 )
 @click.option("--listen-host", default=None, help="Listen host override")
 @click.option(

--- a/tensorcast/cli_utils/config.py
+++ b/tensorcast/cli_utils/config.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import importlib.resources
 import json
 import os
 import secrets
@@ -29,12 +30,10 @@ from tensorcast.cli_utils.paths import (
     DaemonSession,
     GlobalSession,
     global_session_paths,
-    home_dir,
     runtime_lock_path,
     runtime_root,
 )
 from tensorcast.cli_utils.process import file_lock
-from tensorcast.daemon_runtime_config import dump_daemon_config
 from tensorcast.proto.config.v1 import common_pb2 as common_pb
 from tensorcast.proto.config.v1 import daemon_config_pb2 as cfg_pb
 from tensorcast.proto.config.v1 import global_store_config_pb2 as gsc_pb
@@ -43,13 +42,35 @@ _CLUSTER_TOKEN_FILENAME = "cluster_token"
 _CLUSTER_TOKEN_HMAC_KEY = b"tensorcast-cluster-token"
 
 
+def _discover_repo_example_config(filename: str) -> Path | None:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "examples" / "config" / filename
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _discover_packaged_example_config(filename: str) -> Path | None:
+    try:
+        root = importlib.resources.files("tensorcast")
+    except Exception:
+        return None
+    candidate = root / "examples" / "config" / filename
+    try:
+        if candidate.is_file():
+            return Path(str(candidate))
+    except Exception:
+        return None
+    return None
+
+
 def discover_global_store_config() -> Path | None:
     """Discover a default Global Store config.
 
     Order:
     1) $TENSORCAST_GLOBAL_STORE_CONFIG
-    2) ~/.tensorcast/config/global_store.yaml or .yml
-    3) None (caller should fall back to embedded config)
+    2) examples/config/global_store_config.yaml (repo checkout or packaged wheel)
+    3) None (caller should treat this as an error)
     """
 
     env = os.environ.get("TENSORCAST_GLOBAL_STORE_CONFIG")
@@ -58,12 +79,12 @@ def discover_global_store_config() -> Path | None:
         if p.exists():
             return p
 
-    cfg_dir = home_dir() / "config"
-    cfg_dir.mkdir(parents=True, exist_ok=True)
-    for name in ("global_store.yaml", "global_store.yml"):
-        candidate = cfg_dir / name
-        if candidate.exists():
-            return candidate
+    example = _discover_repo_example_config("global_store_config.yaml")
+    if example is not None:
+        return example
+    example = _discover_packaged_example_config("global_store_config.yaml")
+    if example is not None:
+        return example
     return None
 
 
@@ -123,8 +144,8 @@ def discover_daemon_config() -> Path | None:
 
     Order:
     1) $TENSORCAST_DAEMON_CONFIG
-    2) ~/.tensorcast/config/daemon.yaml or .yml
-    3) None (callers should fall back to embedded defaults)
+    2) examples/config/store_daemon_config.yaml (repo checkout or packaged wheel)
+    3) None (caller should treat this as an error)
     """
 
     env = os.environ.get("TENSORCAST_DAEMON_CONFIG")
@@ -133,12 +154,12 @@ def discover_daemon_config() -> Path | None:
         if path.exists():
             return path
 
-    cfg_dir = home_dir() / "config"
-    cfg_dir.mkdir(parents=True, exist_ok=True)
-    for name in ("daemon.yaml", "daemon.yml"):
-        candidate = cfg_dir / name
-        if candidate.exists():
-            return candidate
+    example = _discover_repo_example_config("store_daemon_config.yaml")
+    if example is not None:
+        return example
+    example = _discover_packaged_example_config("store_daemon_config.yaml")
+    if example is not None:
+        return example
     return None
 
 
@@ -217,13 +238,11 @@ def materialize_daemon_config(
     if config_path is not None:
         return Path(config_path).expanduser()
 
-    cfg = build_embedded_daemon_config(
-        session, restrict_to_localhost=restrict_to_localhost
+    raise ServiceError(
+        "No Store Daemon config found. Provide --config or set "
+        "TENSORCAST_DAEMON_CONFIG. Expected examples/config/store_daemon_config.yaml "
+        "to be available in the repo or packaged wheel."
     )
-    effective_path = session.effective_config_path
-    effective_path.parent.mkdir(parents=True, exist_ok=True)
-    dump_daemon_config(cfg, effective_path)
-    return effective_path
 
 
 def _cluster_token_path() -> Path:
@@ -276,7 +295,7 @@ def build_embedded_global_store_config(
     session: GlobalSession | None = None,
     *,
     cluster_token: str,
-    listen_host: str = "127.0.0.1",
+    listen_host: str = "0.0.0.0",
     listen_port: int = 0,
     metrics_port: int = 0,
 ) -> gsc_pb.GlobalStoreConfig:
@@ -284,7 +303,7 @@ def build_embedded_global_store_config(
 
     inst = session or global_session_paths()
     cfg = gsc_pb.GlobalStoreConfig()
-    cfg.server.listen.host = listen_host or "127.0.0.1"
+    cfg.server.listen.host = listen_host or "0.0.0.0"
     cfg.server.listen.port = max(0, int(listen_port or 0))
     cfg.server.max_workers = 10
     cfg.server.metrics_port = max(0, int(metrics_port or 0))

--- a/tensorcast/cli_utils/global_store_manager.py
+++ b/tensorcast/cli_utils/global_store_manager.py
@@ -17,7 +17,6 @@ import click
 import psutil
 
 from tensorcast.cli_utils.config import (
-    build_embedded_global_store_config,
     discover_global_store_config,
     dump_global_store_config,
     load_or_create_cluster_token,
@@ -30,6 +29,7 @@ from tensorcast.cli_utils.health import (
     ping_global_store,
     wait_for_global_store,
 )
+from tensorcast.cli_utils.network import resolve_connect_host
 from tensorcast.cli_utils.paths import (
     GlobalSession,
     clear_current_global_session_if_matches,
@@ -175,40 +175,49 @@ def _resolve_config(
     """Load or build a GlobalStoreConfig and persist it under the session."""
 
     pb: gsc_pb.GlobalStoreConfig | None = None
+    cfg_source: Path | None = None
     if config_path is not None:
-        pb = GlobalStoreConfig.load_proto_from_file(str(config_path))
+        cfg_source = Path(config_path)
     else:
         discovered = discover_global_store_config()
         if discovered:
-            pb = GlobalStoreConfig.load_proto_from_file(str(discovered))
-    if pb is None:
-        pb = build_embedded_global_store_config(
-            inst,
-            cluster_token=cluster_token,
-            listen_host=listen_host or "127.0.0.1",
-            listen_port=listen_port or 0,
-            metrics_port=metrics_port or 0,
-        )
-    else:
-        if listen_host is not None:
-            pb.server.listen.host = listen_host
-        if listen_port is not None:
-            pb.server.listen.port = max(0, int(listen_port))
-        if not pb.server.listen.host:
-            pb.server.listen.host = "127.0.0.1"
-        if metrics_port is not None:
-            pb.server.metrics_port = max(0, int(metrics_port))
-        if not pb.database.db_file:
-            pb.database.db_file = str(inst.root / "global_store.duckdb")
-        if not pb.observability.logging.file:
-            pb.observability.logging.file = str(inst.logs / "global_store.out")
-        if not pb.meta.schema_version:
-            pb.meta.schema_version = "v1"
-        if not pb.meta.description:
-            pb.meta.description = "generated-by-cli"
-        pb.meta.cluster_token = cluster_token
+            cfg_source = Path(discovered)
 
-    listen_host_eff = pb.server.listen.host or "127.0.0.1"
+    if cfg_source is None:
+        raise ServiceError(
+            "No Global Store config found. Provide --config or set "
+            "TENSORCAST_GLOBAL_STORE_CONFIG. Expected examples/config/global_store_config.yaml "
+            "to be available in the repo or packaged wheel."
+        )
+
+    try:
+        pb = GlobalStoreConfig.load_proto_from_file(str(cfg_source))
+    except Exception as exc:  # noqa: BLE001
+        raise ServiceError(
+            f"Failed to load Global Store config from {cfg_source}: {exc}"
+        ) from exc
+
+    assert pb is not None
+
+    if listen_host is not None:
+        pb.server.listen.host = listen_host
+    if listen_port is not None:
+        pb.server.listen.port = max(0, int(listen_port))
+    if not pb.server.listen.host:
+        pb.server.listen.host = "0.0.0.0"
+    if metrics_port is not None:
+        pb.server.metrics_port = max(0, int(metrics_port))
+    if not pb.database.db_file:
+        pb.database.db_file = str(inst.root / "global_store.duckdb")
+    if not pb.observability.logging.file:
+        pb.observability.logging.file = str(inst.logs / "global_store.out")
+    if not pb.meta.schema_version:
+        pb.meta.schema_version = "v1"
+    if not pb.meta.description:
+        pb.meta.description = "generated-by-cli"
+    pb.meta.cluster_token = cluster_token
+
+    listen_host_eff = pb.server.listen.host or "0.0.0.0"
     if pb.server.listen.port <= 0:
         pb.server.listen.port = select_free_port(
             preferred=50051, host=listen_host_eff, probe_span=32
@@ -431,7 +440,7 @@ def start_global_store(
         _cleanup_failed_start(proc, log_threads, inst, so, se)
         raise
 
-    connect_host = pb_cfg.server.listen.host or "127.0.0.1"
+    connect_host = resolve_connect_host(pb_cfg.server.listen.host)
     connect_port = int(pb_cfg.server.listen.port or 0)
     address = f"{connect_host}:{connect_port}"
     health = wait_for_global_store(address, timeout=None, proc=proc)
@@ -449,7 +458,7 @@ def start_global_store(
         cluster_token = health.cluster_token
 
     listen_host_eff = (
-        health.listen_host if health else pb_cfg.server.listen.host or "127.0.0.1"
+        health.listen_host if health else pb_cfg.server.listen.host or "0.0.0.0"
     )
     listen_port_eff = (
         health.listen_port if health else int(pb_cfg.server.listen.port or 0) or None

--- a/tensorcast/cli_utils/network.py
+++ b/tensorcast/cli_utils/network.py
@@ -8,7 +8,7 @@ import contextlib
 import socket
 import subprocess
 import time
-from typing import Any
+from typing import Any, Callable, Iterable
 
 import grpc
 
@@ -44,31 +44,59 @@ def wait_daemon_ready(
     timeout: float | None = 20.0,
     *,
     proc: subprocess.Popen[Any] | None = None,
-) -> bool:
+    progress: Callable[[float, Exception | None], None] | None = None,
+    progress_interval: float = 5.0,
+    extra_hosts: Iterable[str] | None = None,
+) -> str | None:
     deadline = None if timeout is None else time.time() + timeout
-    addr = f"{host}:{port}"
+    start_ts = time.time()
+    last_report = start_ts
     last_err: Exception | None = None
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for candidate in (host, *(extra_hosts or [])):
+        if not candidate:
+            continue
+        if candidate in seen:
+            continue
+        candidates.append(candidate)
+        seen.add(candidate)
     if proc is not None and proc.poll() is not None:
-        return False
-    channel = grpc.insecure_channel(addr)
-    stub = store_daemon_pb2_grpc.StoreDaemonServiceStub(channel)
+        return None
+    stubs: list[
+        tuple[str, grpc.Channel, store_daemon_pb2_grpc.StoreDaemonServiceStub]
+    ] = []
+    for candidate in candidates:
+        addr = f"{candidate}:{port}"
+        channel = grpc.insecure_channel(addr)
+        stubs.append(
+            (candidate, channel, store_daemon_pb2_grpc.StoreDaemonServiceStub(channel))
+        )
     try:
         while deadline is None or time.time() < deadline:
             if proc is not None and proc.poll() is not None:
-                return False
-            try:
-                stub.GetServerConfig(
-                    store_daemon_pb2.GetServerConfigRequest(), timeout=0.8
-                )
-                return True
-            except Exception as e:  # noqa: BLE001
-                last_err = e
-                if proc is not None and proc.poll() is not None:
-                    return False
-                time.sleep(0.2)
+                return None
+            for candidate, _channel, stub in stubs:
+                try:
+                    stub.GetServerConfig(
+                        store_daemon_pb2.GetServerConfigRequest(), timeout=0.8
+                    )
+                    return candidate
+                except Exception as e:  # noqa: BLE001
+                    last_err = e
+                    if proc is not None and proc.poll() is not None:
+                        return None
+            now = time.time()
+            if progress is not None and now - last_report >= max(
+                progress_interval, 0.5
+            ):
+                progress(now - start_ts, last_err)
+                last_report = now
+            time.sleep(0.2)
     finally:
-        with contextlib.suppress(Exception):
-            channel.close()
+        for _candidate, channel, _stub in stubs:
+            with contextlib.suppress(Exception):
+                channel.close()
     # For debugging purposes; caller can log if desired
     _ = last_err
-    return False
+    return None

--- a/tensorcast/cli_utils/service_manager.py
+++ b/tensorcast/cli_utils/service_manager.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025, TensorCast Team.
+#  Copyright (c) 2025-2026, TensorCast Team.
 
 """Slim service management façade for StoreDaemon (Linux-only).
 
@@ -95,7 +95,7 @@ def discover_default_config_path() -> Path | None:
 
     Order:
     1) $TENSORCAST_DAEMON_CONFIG if set and exists
-    2) ~/.tensorcast/config/daemon.yaml or ~/.tensorcast/config/daemon.yml
+    2) examples/config/store_daemon_config.yaml (repo checkout or packaged wheel)
     """
     return discover_daemon_config()
 
@@ -125,7 +125,12 @@ def start_service(
     - If config listen.port is 0 or missing, pick a free TCP port and pass derived config to daemon.
     - Startup is always blocking: this call returns only once the daemon is ready (or the process exits).
     """
-    cfg = load_daemon_config(config_path)
+    try:
+        cfg = load_daemon_config(config_path)
+    except Exception as exc:  # noqa: BLE001
+        raise ServiceError(
+            f"Failed to load Store Daemon config from {config_path}: {exc}"
+        ) from exc
     cfg_modified = False
     if config_overrides:
         try:
@@ -145,13 +150,12 @@ def start_service(
 
     # Restrict to loopback if requested (SDK private launch)
     if restrict_to_localhost:
-        with contextlib.suppress(Exception):
-            if cfg.server.listen.host != "127.0.0.1":
-                cfg.server.listen.host = "127.0.0.1"
-                cfg_modified = True
-            if cfg.server.p2p_listen.host and cfg.server.p2p_listen.host != "127.0.0.1":
-                cfg.server.p2p_listen.host = "127.0.0.1"
-                cfg_modified = True
+        if cfg.server.listen.host != "127.0.0.1":
+            cfg.server.listen.host = "127.0.0.1"
+            cfg_modified = True
+        if cfg.server.p2p_listen.host and cfg.server.p2p_listen.host != "127.0.0.1":
+            cfg.server.p2p_listen.host = "127.0.0.1"
+            cfg_modified = True
 
     host = cfg.server.listen.host or "127.0.0.1"
     port = int(cfg.server.listen.port or 0)
@@ -191,13 +195,13 @@ def start_service(
             cfg.high_availability.ClearField("global_store_endpoints")
             for endpoint in endpoints:
                 try:
-                    host, port_str = endpoint.rsplit(":", 1)
-                    port_val = int(port_str)
+                    _host, _port_str = endpoint.rsplit(":", 1)
+                    _port_val = int(_port_str)
                 except Exception as exc:  # noqa: BLE001
                     raise ServiceError(f"Invalid HA endpoint '{endpoint}'") from exc
                 ep = cfg.high_availability.global_store_endpoints.add()
-                ep.host = host
-                ep.port = port_val
+                ep.host = _host
+                ep.port = _port_val
             cfg_modified = True
     if ha_enabled is False and cfg.high_availability.global_store_endpoints:
         cfg.high_availability.ClearField("global_store_endpoints")
@@ -232,17 +236,23 @@ def start_service(
 
     try:
         preexec_fn = preexec_fate_sharing if fate_share else preexec_detached
-        use_pipes = blocking or fate_share
-        stdout_target = (
-            subprocess.PIPE
-            if use_pipes
-            else (so if so is not None else subprocess.DEVNULL)
-        )
-        stderr_target = (
-            subprocess.PIPE
-            if use_pipes
-            else (se if se is not None else subprocess.DEVNULL)
-        )
+        inherit_stdio = blocking and to_console
+        use_pipes = (blocking or fate_share) and not inherit_stdio
+        if inherit_stdio:
+            # Attach daemon stdio directly to the terminal to preserve crash logs.
+            stdout_target = None
+            stderr_target = None
+        else:
+            stdout_target = (
+                subprocess.PIPE
+                if use_pipes
+                else (so if so is not None else subprocess.DEVNULL)
+            )
+            stderr_target = (
+                subprocess.PIPE
+                if use_pipes
+                else (se if se is not None else subprocess.DEVNULL)
+            )
         proc = subprocess.Popen(
             args,
             stdin=subprocess.DEVNULL,
@@ -355,8 +365,44 @@ def start_service(
         _cleanup_failed_start(proc, log_threads, inst, so, se)
         raise
 
-    ready = wait_daemon_ready(connect_host, port, timeout=None, proc=proc)
-    if not ready:
+    # Persist session metadata early so SDK auto-discovery works while startup continues.
+    _persist_state()
+
+    fallback_hosts: list[str] = []
+    if connect_host not in {"127.0.0.1", "localhost"}:
+        fallback_hosts.append("127.0.0.1")
+
+    progress_cb = None
+    if to_console:
+        fallback_note = (
+            f" (fallback: {', '.join(fallback_hosts)})" if fallback_hosts else ""
+        )
+        click.echo(
+            f"Waiting for daemon readiness at {connect_host}:{port}{fallback_note}...",
+            err=True,
+        )
+
+        def _progress(elapsed_s: float, last_err: Exception | None) -> None:
+            suffix = f" Last error: {last_err}" if last_err else ""
+            click.echo(
+                (
+                    "Still waiting for daemon readiness at "
+                    f"{connect_host}:{port} ({elapsed_s:.1f}s elapsed).{suffix}"
+                ),
+                err=True,
+            )
+
+        progress_cb = _progress
+
+    ready_host = wait_daemon_ready(
+        connect_host,
+        port,
+        timeout=None,
+        proc=proc,
+        progress=progress_cb,
+        extra_hosts=fallback_hosts,
+    )
+    if not ready_host:
         retcode = proc.poll()
         _cleanup_failed_start(proc, log_threads, inst, so, se)
         log_hint = f" See logs under {inst.logs}" if persist_logs else ""
@@ -368,6 +414,9 @@ def start_service(
         raise ServiceError(
             f"Daemon exited during startup (address={connect_host}:{port})." + log_hint
         )
+    if ready_host != connect_host:
+        connect_host = ready_host
+        object.__setattr__(inst, "address", f"{connect_host}:{port}")
 
     # Best-effort backfill of effective listen/p2p ports from daemon once it is serving.
     with contextlib.suppress(Exception):

--- a/tensorcast/global_store/README.md
+++ b/tensorcast/global_store/README.md
@@ -333,7 +333,7 @@ Configuration uses `tensorcast.config.v1.GlobalStoreConfig` proto, loaded from Y
 
 ```yaml
 database:
-  db_file: /var/lib/tensorcast/global_store.db  # null for in-memory
+  db_file: null  # null for in-memory
 
 server:
   # Bind address (server-side); 0.0.0.0 exposes all interfaces.
@@ -355,7 +355,7 @@ worker_policy:
     snapshot_max_rows: 200
 ```
 
-`server.listen` is the bind address, while `server.advertise` is the routable address returned by GetServerInfo and used for clients when it is routable. If `advertise.host` is set but non-routable, startup fails. If it is unset, the server attempts to auto-detect a suitable IPv4 address and logs the resolved value; clients ignore unspecified advertised hosts (for example, `0.0.0.0`) and fall back to a connectable listen host.
+`server.listen` is the bind address, while `server.advertise` is the routable address returned by GetServerInfo and used for clients when it is routable. If `advertise.host` is set but non-routable, startup fails. If it is unset, the server attempts to auto-detect a suitable IPv4 address and logs the resolved value; clients ignore unspecified advertised hosts (for example, `0.0.0.0`) and fall back to a connectable listen host. When `database.db_file` is set, `~` is expanded and its parent directory is created on startup. When `tensorcast-cli global start` runs without `--config`, it uses `$TENSORCAST_GLOBAL_STORE_CONFIG` when set, otherwise `examples/config/global_store_config.yaml` (repo checkout or packaged wheel); if neither is found, startup fails. The example file defaults to `listen.host: 0.0.0.0` and `db_file: null`.
 
 ## Extending the Global Store
 

--- a/tensorcast/global_store/config/settings.py
+++ b/tensorcast/global_store/config/settings.py
@@ -91,7 +91,9 @@ class GlobalStoreConfig(BaseModel):
 
         # Map to Pydantic
         # Database
-        db_file = Path(pb.database.db_file) if pb.database.db_file else None
+        db_file = (
+            Path(pb.database.db_file).expanduser() if pb.database.db_file else None
+        )
         # Server
         listen_host = "127.0.0.1"
         listen_port = 50051

--- a/tensorcast/global_store/grpc_service.py
+++ b/tensorcast/global_store/grpc_service.py
@@ -12,6 +12,7 @@ import ipaddress
 import threading
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Optional, cast
 from uuid import UUID
 
@@ -132,12 +133,17 @@ class GlobalStoreServicer(global_store_pb2_grpc.GlobalStoreServiceServicer):
         self._runtime_info: dict[str, Any] = {}
 
         # Initialize database connection
-        if db_file is None:
+        db_path: Path | None = None
+        if db_file:
+            db_path = Path(db_file).expanduser()
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if db_path is None:
             logger.info("Using in-memory DuckDB database")
             self.connection = duckdb.connect()
         else:
-            logger.info(f"Using persistent DuckDB database at: {db_file}")
-            self.connection = duckdb.connect(str(db_file))
+            logger.info("Using persistent DuckDB database at: %s", db_path)
+            self.connection = duckdb.connect(str(db_path))
 
         # Initialize database schema
         cursor = self.connection.cursor()

--- a/tensorcast/startup.py
+++ b/tensorcast/startup.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025, TensorCast Team.
+#  Copyright (c) 2025-2026, TensorCast Team.
 
 """
 Runtime startup and connection utilities for TensorCast.
@@ -156,9 +156,9 @@ def init(
 
     When launching, the SDK will pick a config in the following order:
     1) user-provided `daemon_config_path`
-    2) discovered default via `discover_default_config_path()`
-    3) embedded minimal config (loopback bind, ephemeral port, writable cache
-       under ~/.tensorcast or a tempdir).
+    2) discovered default via `discover_default_config_path()` (env or
+       examples/config/store_daemon_config.yaml when available)
+    3) error if no config is found.
 
     Args:
         mode: Required init mode. Use "connect" to attach to an existing daemon,
@@ -229,7 +229,7 @@ def init(
                 "Use mode='connect' to attach to an existing daemon."
             )
 
-        # Launch requires a config file (optional; defaults to embedded)
+        # Launch requires a config file (optional; defaults to example config when available).
         cfg_path: Path | None = None
         restrict_localhost = True
         cfg = None

--- a/tests/python/api/test_startup_embedded_config.py
+++ b/tests/python/api/test_startup_embedded_config.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025, TensorCast Team.
+#  Copyright (c) 2025-2026, TensorCast Team.
 
 # Copyright (c) 2025, TensorCast Team.
 
@@ -9,20 +9,35 @@ from pathlib import Path
 import pytest
 
 from tensorcast.cli_utils import config as cli_config
+from tensorcast.cli_utils.errors import ServiceError
 from tensorcast.cli_utils.paths import session_paths
-from tensorcast.daemon_runtime_config import load_daemon_config
 
 
-def test_embedded_daemon_config_is_materialized(
+def test_example_daemon_config_is_used_when_available(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("TENSORCAST_HOME", str(tmp_path))
+    monkeypatch.delenv("TENSORCAST_DAEMON_CONFIG", raising=False)
     inst = session_paths()
 
-    cfg_path = cli_config.materialize_daemon_config(inst, None, restrict_to_localhost=True)
-    cfg = load_daemon_config(cfg_path)
+    repo_root = Path(__file__).resolve().parents[3]
+    example_cfg = repo_root / "examples" / "config" / "store_daemon_config.yaml"
+    assert example_cfg.exists()
 
-    assert cfg.server.listen.host == "127.0.0.1"
-    assert int(cfg.server.listen.port) == 0
-    assert cfg.high_availability.enabled is False
-    assert str(inst.root) in cfg.server.storage_path
+    cfg_path = cli_config.materialize_daemon_config(inst, None, restrict_to_localhost=True)
+    assert cfg_path.resolve() == example_cfg.resolve()
+
+
+def test_missing_daemon_config_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("TENSORCAST_HOME", str(tmp_path))
+    monkeypatch.delenv("TENSORCAST_DAEMON_CONFIG", raising=False)
+    monkeypatch.setattr(cli_config, "_discover_repo_example_config", lambda _: None)
+    monkeypatch.setattr(cli_config, "_discover_packaged_example_config", lambda _: None)
+    inst = session_paths()
+
+    with pytest.raises(ServiceError, match="No Store Daemon config found"):
+        cli_config.materialize_daemon_config(
+            inst, None, restrict_to_localhost=True
+        )

--- a/tests/python/cli/test_global_store_config.py
+++ b/tests/python/cli/test_global_store_config.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025, TensorCast Team.
+#  Copyright (c) 2025-2026, TensorCast Team.
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ def test_build_embedded_global_store_config(monkeypatch, tmp_path):
         session, cluster_token="cluster-1", listen_port=0, metrics_port=0
     )
 
-    assert cfg.server.listen.host == "127.0.0.1"
+    assert cfg.server.listen.host == "0.0.0.0"
     assert cfg.server.listen.port == 0
     assert cfg.server.metrics_port == 0
     assert cfg.database.db_file == str(session.root / "global_store.duckdb")
@@ -56,14 +56,25 @@ def test_select_free_port_falls_back_when_taken():
 
 def test_discover_global_store_config_prefers_env(monkeypatch, tmp_path):
     monkeypatch.setenv("TENSORCAST_HOME", str(tmp_path))
-    cfg_dir = tmp_path / ".tensorcast" / "config"
-    cfg_dir.mkdir(parents=True, exist_ok=True)
-    home_cfg = cfg_dir / "global_store.yaml"
-    home_cfg.write_text("server: {}", encoding="utf-8")
-
     env_cfg = tmp_path / "env_cfg.yaml"
     env_cfg.write_text("server: {}", encoding="utf-8")
     monkeypatch.setenv("TENSORCAST_GLOBAL_STORE_CONFIG", str(env_cfg))
 
     discovered = cfg_utils.discover_global_store_config()
     assert discovered == env_cfg
+
+
+def test_discover_global_store_config_falls_back_to_examples(monkeypatch, tmp_path):
+    monkeypatch.setenv("TENSORCAST_HOME", str(tmp_path))
+    monkeypatch.delenv("TENSORCAST_GLOBAL_STORE_CONFIG", raising=False)
+
+    example_cfg = None
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "examples" / "config" / "global_store_config.yaml"
+        if candidate.exists():
+            example_cfg = candidate
+            break
+
+    assert example_cfg is not None
+    discovered = cfg_utils.discover_global_store_config()
+    assert discovered == example_cfg

--- a/tests/python/cli/test_service_manager_backfill.py
+++ b/tests/python/cli/test_service_manager_backfill.py
@@ -70,7 +70,9 @@ def test_start_service_backfills_ports(monkeypatch, tmp_path):
     monkeypatch.setattr(service_manager, "ensure_cpp_daemon_binary", lambda: Path("/bin/true"))
     monkeypatch.setattr(service_manager.subprocess, "Popen", _fake_popen)
     monkeypatch.setattr(service_manager, "ensure_process_started", lambda *args, **kwargs: None)
-    monkeypatch.setattr(service_manager, "wait_daemon_ready", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        service_manager, "wait_daemon_ready", lambda host, _port, **_kwargs: host
+    )
     monkeypatch.setattr(service_manager, "start_log_threads", lambda *args, **kwargs: [])
     monkeypatch.setattr(service_manager, "get_daemon_config", lambda *args, **kwargs: fake_cfg)
     monkeypatch.setattr(service_manager, "preexec_fate_sharing", lambda: None)
@@ -123,7 +125,9 @@ def test_start_service_applies_config_overrides(monkeypatch, tmp_path):
     monkeypatch.setattr(service_manager, "ensure_cpp_daemon_binary", lambda: Path("/bin/true"))
     monkeypatch.setattr(service_manager.subprocess, "Popen", _fake_popen)
     monkeypatch.setattr(service_manager, "ensure_process_started", lambda *args, **kwargs: None)
-    monkeypatch.setattr(service_manager, "wait_daemon_ready", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        service_manager, "wait_daemon_ready", lambda host, _port, **_kwargs: host
+    )
     monkeypatch.setattr(service_manager, "start_log_threads", lambda *args, **kwargs: [])
     monkeypatch.setattr(service_manager, "get_daemon_config", lambda *args, **kwargs: None)
     monkeypatch.setattr(service_manager, "preexec_fate_sharing", lambda: None)

--- a/tests/python/global_store/test_configuration.py
+++ b/tests/python/global_store/test_configuration.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025, TensorCast Team.
+#  Copyright (c) 2025-2026, TensorCast Team.
 
 """Tests for Global Store configuration management."""
 
@@ -106,6 +106,14 @@ class TestConfiguration:
         config = GlobalStoreConfig.from_file(str(p))
         assert config.port == 50055
         assert str(config.db_file) == "/path/with/spaces.db"
+
+    def test_config_expands_user_db_path(self, tmp_path, monkeypatch):
+        cfg = {"database": {"db_file": "~/global_store.db"}}
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = GlobalStoreConfig.from_file(str(p))
+        assert str(config.db_file) == str(tmp_path / "global_store.db")
 
     def test_config_repr(self):
         """Test configuration string representation."""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies config discovery and hardens startup across CLI/SDK/GS; example configs are now packaged and required when no explicit path is provided.
> 
> - Config discovery: `discover_daemon_config`/`discover_global_store_config` now search `$TENSORCAST_*_CONFIG` then `examples/config/*.yaml` (repo or packaged wheel); if none found, startup fails. SDK `tc.init(mode="create")` and CLI help/docs updated accordingly. `MANIFEST.in` + `setup.py` now package/copy example configs into `tensorcast/examples/config`.
> - Global Store: defaults revised (`schema_version: v1`, `max_workers: 10`, `metrics_port: 18000`, example `db_file: null`); embedded build uses `listen.host: 0.0.0.0`. `~` in `database.db_file` is expanded and parent dirs created on startup. Manager loads YAML strictly, resolves connect host, and requires a config.
> - Daemon lifecycle: session metadata is persisted before readiness; readiness wait probes configured host with loopback fallback and progress messages; blocking mode inherits stdio. HA endpoint parsing/validation improved. Networking util `wait_daemon_ready` returns the winning host; added `resolve_connect_host`.
> - C++ daemon: return error when `grpc::ServerBuilder::BuildAndStart()` fails; minor README prereq tweak (adds `python3`).
> - Docs/examples/tests: deployment/design docs reflect new discovery and defaults; new `examples/test_put.py`, simplified `examples/test_get.py`; tests updated/added for config fallback, path expansion, and readiness behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2069e48d51e1cb1e3f4f6b21e1fc51303a247da9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->