### PR TITLE
feat: introduce DeferredLoader for safetensors

### DIFF
--- a/core/store/README.md
+++ b/core/store/README.md
@@ -167,6 +167,7 @@ graph TB
 ### Variant-Aware Views (v1)
 
 - `StoreEngine::compute_view_plan(canonical_index_json, ViewSpec)` constructs a deterministic `ViewPlan` by delegating to the loader `ViewPlanner`. v1 supports single-dimension `narrow` (slice) operations.
+- When `tensor_names`/subset selection is provided, `ViewPlanner` packs tensors in the provided order (including full-name subsets) so `view_index_json` offsets match client-declared ordering for `MaterializeIntoTarget`.
 - `StoreEngine::view_plan_allows_alias(const ViewPlan&)` exposes the loader selection analysis so callers can short-circuit to zero-copy aliasing when (and only when) the selection is contiguous, segment-aligned, and no transforms are required.
 - `StoreEngine::compute_view_data_hash_from_source(SeekableSource&, ViewPlan, leaf_bytes)` delegates to the shared `ViewHashComputer`, which streams the canonical byte space, applies transforms when required, and computes the variant `view_data_hash` using the standard TreeHash pipeline used by ingestion and registration flows.
 

--- a/core/store/materialization/dataplane/view/tests/view_planner_test.cc
+++ b/core/store/materialization/dataplane/view/tests/view_planner_test.cc
@@ -145,8 +145,40 @@ TEST_CASE("ViewPlanner keeps identity for full-name subset", "[view_planner]") {
   auto plan_or = ViewPlanner::compute_view_plan(canonical, spec, subset);
   REQUIRE(plan_or.ok());
   const auto& plan = *plan_or;
-  CHECK(plan.is_identity);
+  CHECK_FALSE(plan.is_identity);
   CHECK(plan.view_index_json == tensorcast::store::loader::rebuild_stable_canonical_index(canonical, 0).value());
+}
+
+TEST_CASE("ViewPlanner preserves subset ordering", "[view_planner]") {
+  nlohmann::json index = nlohmann::json::object();
+  index["alpha"] = tensor_entry(
+      /*offset=*/0,
+      /*size=*/16,
+      /*shape=*/{4},
+      /*stride=*/{1},
+      /*dtype=*/"torch.float32",
+      /*storage_offset=*/0);
+  index["beta"] = tensor_entry(
+      /*offset=*/16,
+      /*size=*/16,
+      /*shape=*/{4},
+      /*stride=*/{1},
+      /*dtype=*/"torch.float32",
+      /*storage_offset=*/0);
+  const std::string canonical = index.dump();
+
+  ViewSpec spec;
+  const std::vector<std::string> subset{"beta", "alpha"};
+
+  auto plan_or = ViewPlanner::compute_view_plan(canonical, spec, subset);
+  REQUIRE(plan_or.ok());
+  const auto& plan = *plan_or;
+
+  CHECK_FALSE(plan.is_identity);
+  const auto view_json = nlohmann::json::parse(plan.view_index_json);
+  REQUIRE(view_json.size() == 2);
+  CHECK(view_json.at("beta")[0].get<uint64_t>() == 0);
+  CHECK(view_json.at("alpha")[0].get<uint64_t>() == 16);
 }
 
 TEST_CASE("ViewPlanner emits contiguous aligned range for 1D narrow", "[view_planner]") {

--- a/core/store/materialization/dataplane/view/view_planner.cc
+++ b/core/store/materialization/dataplane/view/view_planner.cc
@@ -312,8 +312,7 @@ absl::StatusOr<BidirectionalViewPlan> compute_bidirectional_internal(
     }
   }
 
-  const bool subset_full = !subset_filter.empty() && subset_filter.size() == canonical_entries.size();
-  const bool subset_enabled = !subset_filter.empty() && !subset_full;
+  const bool subset_enabled = !subset_filter.empty();
 
   bool has_transform = false;
   uint64_t view_cursor = 0;
@@ -322,7 +321,22 @@ absl::StatusOr<BidirectionalViewPlan> compute_bidirectional_internal(
   bool any_requires_materialization = false;
   TransformPlan transform_plan;
   std::vector<std::string> ordered_names;
-  ordered_names.reserve(canonical_entries.size());
+  if (subset_enabled) {
+    ordered_names.reserve(subset_names.size());
+    absl::flat_hash_set<std::string> seen;
+    seen.reserve(subset_names.size());
+    for (const auto& name : subset_names) {
+      if (!seen.insert(name).second) {
+        continue;
+      }
+      ordered_names.push_back(name);
+    }
+  } else {
+    ordered_names.reserve(canonical_entries.size());
+    for (const auto& [name, entry] : canonical_entries) {
+      ordered_names.push_back(name);
+    }
+  }
   std::unordered_map<std::string, uint64_t> offsets;
   std::unordered_map<std::string, uint64_t> sizes;
   std::unordered_map<std::string, CanonicalTensorMeta> metas;
@@ -332,17 +346,18 @@ absl::StatusOr<BidirectionalViewPlan> compute_bidirectional_internal(
   metas.reserve(canonical_entries.size());
   canonical_offsets.reserve(canonical_entries.size());
 
-  for (const auto& [name, entry] : canonical_entries) {
-    if (subset_enabled && !subset_filter.contains(name)) {
+  for (const auto& name : ordered_names) {
+    auto entry_it = canonical_entries.find(name);
+    if (entry_it == canonical_entries.end()) {
       continue;
     }
+    const auto& entry = entry_it->second;
     const uint64_t aligned_start = (view_cursor + (kAlignmentBytes - 1)) / kAlignmentBytes * kAlignmentBytes;
     if (aligned_start > view_cursor) {
       selection_plan.ranges.push_back(make_pad_range(view_cursor, aligned_start - view_cursor));
       view_cursor = aligned_start;
     }
 
-    ordered_names.push_back(name);
     canonical_offsets[name] = entry.offset;
     const auto spec_it = spec.tensors.find(name);
     const TensorViewOps* ops = (spec_it == spec.tensors.end() ? nullptr : &spec_it->second);

--- a/daemon/service/materialize_into_target_validation_test.cc
+++ b/daemon/service/materialize_into_target_validation_test.cc
@@ -215,6 +215,46 @@ TEST_CASE("MaterializeIntoTarget accepts subset selection", "[daemon][materializ
   REQUIRE(status.error_code() == grpc::StatusCode::NOT_FOUND);
 }
 
+TEST_CASE("MaterializeIntoTarget accepts ordered full selection", "[daemon][materialize][into_target]") {
+  ValidationFixture fix;
+  MaterializeIntoTargetRequest req;
+  req.set_artifact_id("mi2:dummy:dummy");
+  req.set_device_uuid("gpu-0");
+  req.set_pid(123);
+  req.add_tensor_names("b");
+  req.add_tensor_names("a");
+
+  auto* layout = req.mutable_target_layout();
+  layout->set_layout_kind(tensorcast::daemon::v2::TargetLayout::LAYOUT_KIND_COALESCED_UNSPECIFIED);
+  layout->set_index_kind(tensorcast::daemon::v2::TargetLayout::INDEX_KIND_VIEW);
+  layout->set_tensor_spec_kind(tensorcast::daemon::v2::TargetLayout::TENSOR_SPEC_KIND_OFFSETS);
+
+  auto* storage = layout->add_storages();
+  storage->set_storage_id("storage-0");
+  storage->set_device_id(0);
+  storage->set_storage_length(12);
+  storage->set_vram_region_id("region-0");
+  storage->set_mapping_base_offset(0);
+
+  auto* offset_b = layout->add_offsets();
+  offset_b->set_name("b");
+  offset_b->set_storage_id("storage-0");
+  offset_b->set_storage_offset(0);
+  offset_b->set_logical_length(4);
+
+  auto* offset_a = layout->add_offsets();
+  offset_a->set_name("a");
+  offset_a->set_storage_id("storage-0");
+  offset_a->set_storage_offset(8);
+  offset_a->set_logical_length(4);
+
+  MaterializeIntoTargetResponse resp;
+  auto status = run_request(fix.controller, req, resp);
+
+  REQUIRE_FALSE(status.ok());
+  REQUIRE(status.error_code() == grpc::StatusCode::NOT_FOUND);
+}
+
 TEST_CASE("MaterializeIntoTarget accepts view spec subset", "[daemon][materialize][into_target]") {
   ValidationFixture fix;
   MaterializeIntoTargetRequest req;

--- a/docs/designs/0052-deferred-slice-materialization.md
+++ b/docs/designs/0052-deferred-slice-materialization.md
@@ -2,7 +2,7 @@
 slug: 0052-deferred-slice-materialization
 title: Deferred Slice Materialization for vLLM (On‑Demand Slice + Deferred Copy)
 areas: ["sdk", "daemon", "core", "global_store", "proto"]
-status: draft
+status: accepted
 created: 2026-01-17
 last_updated: 2026-01-18
 related_code:
@@ -106,6 +106,17 @@ Interoperability with existing handles:
 - `DeferredLoader` is created from an `Artifact` handle (canonical or derived view). If the handle already has a view spec (e.g., `artifact.slice(...)`), the loader inherits it; callers may omit `slice=` when slicing is already encoded in the handle.
 - `slice=` reuses the existing `SliceSpec` conventions (`Artifact.slice(...)` / `ViewBuilder.slice(...)`).
 
+# Naming Compliance
+
+Python API naming follows the repository conventions:
+
+- Classes (`PascalCase`): `DeferredLoader`, `DeferredCommitResult`.
+- Methods/functions (`snake_case`): `Artifact.deferred_loader`, `DeferredLoader.tensor`, `DeferredLoader.plan`,
+  `DeferredLoader.commit`, `DeferredLoader.close`.
+
+No new public C++ APIs are introduced in Phase 1; existing `ViewPlanner` and `MaterializeIntoTarget` behavior is
+extended without adding new symbols, so naming conventions remain unchanged.
+
 # Architecture & Interfaces
 
 ## High-Level Execution Model (Phase 1)
@@ -198,6 +209,9 @@ Invariants:
 - `commit()` is the only readiness barrier.
 - Placeholder bytes are undefined until `commit()` succeeds; on any failure, callers must treat bytes as undefined.
 - Slice requests are validated against canonical index metadata (dtype/shape bounds + narrow constraints).
+- Core restriction: `MaterializationFacade` rejects multi-storage targets when a server-side view transform is required.
+  Phase 1 stays safe by supporting only `narrow` (no transforms) and using a single arena; future transpose support must
+  either force single storage or switch to client-side transforms.
 
 Representative errors:
 

--- a/docs/internals/model-loading.md
+++ b/docs/internals/model-loading.md
@@ -94,6 +94,22 @@ without allocating VRAM.
 See [tensor_dict_into dataflow](tensor_dict_into_dataflow.md) for the detailed
 sequence and constraints.
 
+## Deferred Slice Materialization
+
+Deferred loaders expose vLLM-friendly placeholder binding while still using the
+region-backed data plane:
+
+- `Artifact.deferred_loader(...)` allocates a client-owned CUDA arena, registers
+  the arena as a VRAM region, and returns CUDA tensors immediately.
+- `DeferredLoader.tensor(...)` returns placeholder views into the arena; no I/O
+  occurs until `commit()`.
+- `commit()` issues a single `MaterializeIntoTarget` RPC with ordered
+  `tensor_names` so `ViewPlanner` packs the subset in that order (8B alignment),
+  and `TargetLayout` respects per-storage boundaries when streaming.
+- Optional `publish=True` registers the filled slice artifact via
+  `VRAM_LEASED` (LIP), enabling P2P reuse without creating a daemon-owned
+  replica.
+
 ### Lease-In-Place Fast Path & Use Leases
 
 `MaterializeByKey` still resolves the human key via `MetadataGateway::resolve_key_mapping`, but before it coordinates transport it now asks `LipManager::try_satisfy_from_lip` for a replica that already lives on the requested GPU. When this fast path hits, the daemon reuses the existing CUDA IPC handle, marks the status as `ALLOCATED`, and returns both `artifact_id` and `used_disk_path` to the client without invoking the bulk materialization pipeline. If the fast path misses, the controller immediately falls through to the engine-backed path described below.

--- a/docs/plans/0052-deferred-slice-materialization.md
+++ b/docs/plans/0052-deferred-slice-materialization.md
@@ -3,11 +3,35 @@ slug: 0052-deferred-slice-materialization
 title: Plan - Deferred Slice Materialization for vLLM
 links:
   design: ../designs/0052-deferred-slice-materialization.md
+areas:
+  - sdk
+  - daemon
+  - core
+  - global_store
+  - proto
+related_code:
+  - tensorcast/api/store/artifact.py
+  - tensorcast/api/store/materialization.py
+  - tensorcast/api/store/views.py
+  - tensorcast/api/store/view_composer.py
+  - tensorcast/api/_region_cache.py
+  - tensorcast/api/store/runtime.py
+  - tensorcast/api/_materialize.py
+  - tensorcast/api/store/types.py
+  - proto/tensorcast/daemon/v2/store_daemon.proto
+  - daemon/service/controllers/materialization_controller.cc
+  - daemon/service/controllers/registration_controller.cc
+  - core/store/runtime/ingestion/materialization_facade.cc
+  - core/store/materialization/dataplane/sinks/target_layout_gpu_sink.{h,cc}
+  - core/store/materialization/dataplane/view/view_planner.{h,cc}
+  - core/store/materialization/dataplane/view/view_plan_source.{h,cc}
+  - core/store/materialization/dataplane/runtime/pump.{h,cc}
+  - docs/internals/model-loading.md
 ---
 
 # Objective
 
-Enable vLLM’s “meta-init + per‑param weight_loader” integration by providing a TensorCast `DeferredLoader` that:
+Enable vLLM's "meta-init + per-param weight_loader" integration by providing a TensorCast `DeferredLoader` that:
 
 - returns placeholder CUDA tensors immediately (views into a client-owned arena),
 - fills them with a single daemon data-plane call at `DeferredLoader.commit()` (via `MaterializeIntoTarget`),
@@ -15,52 +39,91 @@ Enable vLLM’s “meta-init + per‑param weight_loader” integration by provi
 
 # Current State & Grounding
 
-- Region-backed ingestion is implemented (`MaterializeIntoTarget` + `TargetLayout`) and already supports multi-storage ordered concatenation.
-- View planning/execution primitives exist (`ViewPlanner`, `ViewPlanSource`, `pump_ranges`).
-- Unified lifecycle/leases exist for daemon-exported handles and registration TTLs; avoid inventing new placeholder lease systems.
-- Global Store view routing is not implemented (view transport falls back to canonical), so Phase 1 publishing must not depend on view-aware routing.
+- Region-backed ingestion is implemented in the SDK (`MaterializationPipeline._materialize_into_target`), building a
+  `TargetLayout` over client-registered VRAM regions and calling `materialize_into_target_v2`
+  (`tensorcast/api/store/materialization.py`).
+- View construction and hashing exist (`compute_view_index_bytes`, `compute_view_id`, `compute_view_subset_hash`),
+  and the view runtime supports `narrow` selection in core (`core/store/materialization/dataplane/view/*`).
+- `TargetLayoutGpuSink` rejects writes that span storage boundaries, so `TargetLayout` offsets must be grouped by storage
+  and materialization must respect per-storage range constraints (`core/store/materialization/dataplane/sinks/`).
+- SDK region-backed layouts require registered VRAM regions and consult the client cache
+  (`tensorcast/api/_region_cache.py`).
+- Registration and publish primitives exist (VRAM region registration, begin/feed/commit registered artifacts) via the
+  daemon controllers and SDK APIs (`daemon/service/controllers/registration_controller.cc`,
+  `tensorcast/api/store/__init__.py`).
+- Global Store view-aware routing is still canonical-only; Phase 1 must not depend on view routing for correctness.
+
+# Scope & Guardrails
+
+- No new daemon RPCs in Phase A/B. `MaterializeIntoTarget` is the only data-plane call in `commit()`.
+- Do not introduce a new placeholder lease system; placeholders are client-owned CUDA buffers.
+- Slices are `narrow` only in Phase A/B. Other view ops stay out of scope.
+- Avoid ad-hoc env vars; reuse existing config and runtime discovery paths.
 
 # Phases & Milestones
 
-## Phase A — SDK-first deferred loader (no new daemon RPCs)
+- [x] Phase A: SDK-first deferred loader (no new daemon RPCs)
+  - [x] Milestone A1: Add `Artifact.deferred_loader(device=...)` and a concrete `DeferredLoader` type.
+    - Define public surface in `tensorcast/api/store/artifact.py` and export in `tensorcast/api/store/__init__.py`.
+    - Implement context manager semantics and lifecycle checks consistent with `Artifact` and `StoreRuntimeContext`.
+  - [x] Milestone A2: Client-owned CUDA arena allocation + VRAM region registration.
+    - Allocate a single contiguous CUDA buffer for Phase A and map sub-tensors as views.
+    - Register the allocation with `RegisterVramRegion` and update the local region cache so
+      `_materialize_into_target` can find it.
+    - Track TTL and unregister on close/failure paths.
+  - [x] Milestone A3: Implement `DeferredLoader.tensor(name, slice=...)`.
+    - Parse and validate slice specs against canonical index bytes (dtype, shape, narrow bounds).
+    - Record per-tensor view ops and selection list in a loader-local plan structure.
+    - Return a CUDA tensor view into the arena; contents undefined until `commit()`.
+  - [x] Milestone A4: Implement `DeferredLoader.commit()` using a single `MaterializeIntoTarget`.
+    - Reuse `_build_region_backed_layout` logic to build `TargetLayout` and offsets per storage.
+    - Compute view index bytes via `compute_view_index_bytes` and pass view metadata consistently
+      (`view`, `view_id`, `view_subset_hash`).
+    - Enforce per-storage range constraints aligned with `TargetLayoutGpuSink`.
+    - Map failures into `ArtifactError` with the same error policy as existing materialization.
 
-- [ ] Milestone A1: Add `Artifact.deferred_loader(device=...)` API and `DeferredLoader` implementation skeleton.
-- [ ] Milestone A2: Implement client-owned arena allocation strategy (single allocation first; multi-storage follow-on).
-- [ ] Milestone A3: Implement `DeferredLoader.tensor(name, slice=...)`:
-  - validate against canonical index bytes
-  - allocate an arena view tensor and record the slice request
-- [ ] Milestone A4: Implement `DeferredLoader.commit()` using a single `MaterializeIntoTarget` call:
-  - build `TargetLayout` over arena storages
-  - encode selection as view/subset (narrow-only; packed + PAD=0)
-  - ensure commit respects target storage boundary constraints (per-storage ranges, consistent with existing pipeline)
+- [x] Phase B: Deterministic packing + publish path (still no new RPCs)
+  - [x] Milestone B1: Packing modes in the SDK.
+    - Append mode (default) for vLLM binding order.
+    - Plan-first mode that sorts tensors deterministically (e.g., canonical index order) and pre-computes layout.
+  - [x] Milestone B2: Optional publish after commit using existing registration.
+    - Register storages as VRAM regions (if not already) and publish a `VRAM_LEASED` (LIP) artifact using
+      begin/feed/commit registration flow.
+    - Return publish metadata (artifact id, TTL, storage ids, view id/subset hash).
+    - Avoid dependence on Global Store view routing; publishing uses canonical identifiers and view metadata only.
 
-## Phase B — Determinism and publish-friendly mode
+- [ ] Phase C: Unified readiness semantics (system-level follow-on, out of Phase A/B scope)
+  - [ ] Milestone C1: Define a single wait/cancel/status surface that can back deferred loaders and future async ops.
+  - [ ] Milestone C2: Migrate `ConfirmReplica` and new deferred paths to the unified surface.
 
-- [ ] Milestone B1: Add explicit packing modes:
-  - append mode (default; matches vLLM immediate binding)
-  - plan-first mode (deterministic packed layout; required for stable publishing)
-- [ ] Milestone B2: Implement optional publication after commit via existing registration:
-  - register arena storages as VRAM regions (`RegisterVramRegion`)
-  - publish as `VRAM_LEASED` (LIP) with TTL via `Begin/Feed/CommitRegisteredArtifact`
-  - return a publish result (`artifact_id`, TTL, and any debug metadata)
+- [ ] Phase D: First-class view reuse (system-level follow-on)
+  - [ ] Milestone D1: Implement Global Store view-aware routing.
+  - [ ] Milestone D2: Promote `TargetLayout.TENSOR_TABLE` to a first-class layout mode.
 
-## Phase C — Unified readiness semantics (system-level follow-on)
+# Tasks (Cross-Cutting)
 
-- [ ] Milestone C1: Implement daemon-side `QueryReplicaStatus` + `ReleaseReplica` (or an equivalent unified ticket API) so async readiness is not special-cased via `ConfirmReplica`.
-- [ ] Milestone C2: Update SDK so any future async/deferred surfaces share the same wait/cancel/status mechanism.
+- [x] SDK wiring: add type hints, error mapping, and structured metrics parity with existing materialize flows.
+- [x] Daemon/core review: verify `MaterializeIntoTarget` already accepts view/subset metadata needed by deferred loader.
+- [x] Docs: update `docs/internals/model-loading.md` with deferred loader flow and mention target layout constraints.
 
-## Phase D — First-class variant reuse (system-level follow-on)
+# Acceptance Checks
 
-- [ ] Milestone D1: Implement Global Store view-aware routing (replace canonical fallback for `request_view_transport`).
-- [ ] Milestone D2: Promote `TargetLayout.TENSOR_TABLE` to a first-class mode to reduce reliance on packed linear ByteSpaces for future complex layouts.
+- Deferred loader returns CUDA tensors immediately and performs no IO until `commit()`.
+- `commit()` executes exactly one daemon data-plane call and fills the arena correctly.
+- Slice validation matches canonical index metadata and rejects invalid narrow bounds.
+- Optional publish produces a usable artifact id that can be P2P-materialized by another node.
 
-## Tests + Docs
+# Test / Rollout / Backout
 
-- [ ] Python tests (fake CUDA): `DeferredLoader` placeholder semantics + commit barrier correctness.
-- [ ] (Optional) integration tests: publish via `VRAM_LEASED` and P2P materialize on a second daemon.
-- [ ] Update `docs/internals/model-loading.md` to document deferred loader semantics and how it relates to `tensor_dict_into` and publishing.
+- Tests:
+  - Added C++ `ViewPlanner` subset ordering coverage and daemon validation for ordered full selections.
+  - Added Python deferred loader tests (placeholder layout, invalid slices, commit order) gated by CUDA availability.
+  - Optional integration test covers publish path and P2P materialization on a second daemon.
+- Rollout: add `Artifact.deferred_loader` as an opt-in API; no changes to existing `Artifact.tensor*` semantics.
+- Backout: remove the new SDK entry point and leave daemon/core paths untouched.
 
-# Rollout / Backout
+# Risks & Tracking
 
-- Roll out behind a new `Artifact` method (`Artifact.deferred_loader`) without changing existing `Artifact.tensor*` semantics.
-- Back out by removing the SDK entry point and keeping `MaterializeIntoTarget` unchanged; no schema changes required for Phase A/B.
+- Target layout constraints: multi-storage boundaries must be respected or materialization will fail.
+- Memory footprint: arena allocation size needs guardrails and predictable limits in append mode.
+- View routing gap: publish path must tolerate canonical-only routing in Global Store.

--- a/tensorcast/api/store/README.md
+++ b/tensorcast/api/store/README.md
@@ -53,6 +53,20 @@ managing clients manually.
   are computed exactly once in the derived view (no double-application of the
   parent slice).
 
+## Deferred Slice Materialization (vLLM)
+
+- `artifact.deferred_loader(device=..., packing="append", capacity_bytes=...)` returns
+  a `DeferredLoader` that issues no I/O until `commit()`.
+- `loader.tensor(name, slice=...)` returns a CUDA placeholder backed by a
+  client-owned arena; contents are undefined until `commit()` completes.
+- `packing="append"` preserves call order; `packing="plan"` requires `plan(...)`
+  first to precompute a deterministic layout before calling `tensor(...)`.
+- `commit()` performs a single `MaterializeIntoTarget` RPC to fill the arena;
+  `publish=True` optionally registers the packed slice artifact via
+  `VRAM_LEASED` (LIP).
+- `capacity_bytes` bounds the arena size (defaults to the base canonical/view
+  total size); exceeding it raises `RESOURCE_EXHAUSTED`.
+
 ## Batching, Async, and Prefetch
 
 - Use `with artifact.batch(device="cuda:0")` to coalesce multiple tensor fetches

--- a/tensorcast/api/store/__init__.py
+++ b/tensorcast/api/store/__init__.py
@@ -31,6 +31,7 @@ from tensorcast.api.store.batch_context import (
     MaterializationBatcher,
     PrefetchTicket,
 )
+from tensorcast.api.store.deferred_loader import DeferredCommitResult, DeferredLoader
 from tensorcast.api.store.handles import RegisteredArtifact
 from tensorcast.api.store.materialization import MaterializationPipeline
 from tensorcast.api.store.registration import RegistrationPipeline
@@ -683,6 +684,8 @@ __all__ = [
     "ArtifactStatusCode",
     "CanonicalIndex",
     "CanonicalIndexEntry",
+    "DeferredCommitResult",
+    "DeferredLoader",
     "FallbackOptions",
     "LeaseHandle",
     "MaterializationPayload",

--- a/tensorcast/api/store/artifact.py
+++ b/tensorcast/api/store/artifact.py
@@ -20,6 +20,7 @@ from tensorcast.api._view_ops import (
 )
 from tensorcast.api.store.cache import ArtifactCacheEntry
 from tensorcast.api.store.common import canonical_index_from_bytes
+from tensorcast.api.store.deferred_loader import DeferredLoader
 from tensorcast.api.store.materialization import MaterializationPipeline
 from tensorcast.api.store.retry import map_materialization_error
 from tensorcast.api.store.types import (
@@ -384,6 +385,22 @@ class Artifact:
 
     def view_builder(self) -> ViewBuilder:
         return ViewBuilder(artifact_ref=weakref.ref(self), composer=ViewSpecComposer())
+
+    def deferred_loader(
+        self,
+        *,
+        device: torch.device | str,
+        packing: str = "append",
+        capacity_bytes: int | None = None,
+    ) -> DeferredLoader:
+        """Return a deferred loader for vLLM-style placeholder binding."""
+        self._require_components()
+        return DeferredLoader(
+            artifact=self,
+            device=device,
+            packing=packing,
+            capacity_bytes=capacity_bytes,
+        )
 
     def batch(self, *, device: torch.device | str) -> "BatchContext":
         from tensorcast.api.store.batch_context import BatchContext
@@ -1102,9 +1119,14 @@ class Artifact:
                 )
             resolved_view_id: str | None = None
             if self._view_spec is not None and not self._view_spec.is_identity:
-                resolved_view_id = compute_view_id(
-                    self._view_spec.proto, canonical_index_bytes
-                )
+                view_proto = self._view_spec.proto
+                if view_proto is None:
+                    raise ArtifactError(
+                        "View spec proto missing while resolving view_id",
+                        status_code="FAILED_PRECONDITION",
+                        retryable=False,
+                    )
+                resolved_view_id = compute_view_id(view_proto, canonical_index_bytes)
             view_cache = ViewMetadataCache(
                 view_id=str(resolved_view_id or view_hash),
                 view_index_bytes=view_index_bytes,

--- a/tensorcast/api/store/deferred_loader.py
+++ b/tensorcast/api/store/deferred_loader.py
@@ -333,6 +333,8 @@ class DeferredLoader:
                 tensor_name, self._slice_specs.get(tensor_name)
             )
 
+        offset = 0
+        end = 0
         if self._packing == "append":
             offset = _align_bytes(self._cursor_bytes, _ALIGNMENT_BYTES)
             if offset % self._element_size(spec.dtype) != 0:
@@ -348,9 +350,6 @@ class DeferredLoader:
                     status_code="RESOURCE_EXHAUSTED",
                     retryable=False,
                 )
-            self._cursor_bytes = end
-            self._order.append(tensor_name)
-            self._offsets[tensor_name] = offset
             spec = _TensorSpec(
                 shape=spec.shape,
                 stride=spec.stride,
@@ -358,7 +357,6 @@ class DeferredLoader:
                 size_bytes=spec.size_bytes,
                 offset_bytes=offset,
             )
-            self._specs[tensor_name] = spec
         else:
             if tensor_name not in self._offsets:
                 raise ArtifactError(
@@ -370,6 +368,11 @@ class DeferredLoader:
 
         self._ensure_arena()
         tensor = self._materialize_tensor(spec)
+        if self._packing == "append":
+            self._cursor_bytes = end
+            self._order.append(tensor_name)
+            self._offsets[tensor_name] = offset
+            self._specs[tensor_name] = spec
         self._tensors[tensor_name] = tensor
         return tensor
 
@@ -617,6 +620,8 @@ class DeferredLoader:
                     for idx, dim in enumerate(entry.shape)
                 )
                 stride = _compact_stride(shape)
+        if not stride:
+            stride = _compact_stride(shape)
         if tuple(stride) != _compact_stride(shape):
             raise ArtifactError(
                 f"Tensor '{name}' is not contiguous; deferred loader requires contiguous layouts",

--- a/tensorcast/api/store/deferred_loader.py
+++ b/tensorcast/api/store/deferred_loader.py
@@ -1,0 +1,697 @@
+#  Copyright (c) 2026, TensorCast Team.
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Mapping, Sequence
+
+import torch
+
+from tensorcast.api import _metrics as store_metrics
+from tensorcast.api._device import device_uuid_for, resolve_device
+from tensorcast.api._view_ops import (
+    SliceSpec,
+    ViewSpecBuildResult,
+    build_view_spec,
+    validate_narrow,
+)
+from tensorcast.api.store.materialization import _build_source_policy
+from tensorcast.api.store.retry import map_materialization_error
+from tensorcast.api.store.types import ArtifactError, FallbackOptions
+from tensorcast.api.store.view_composer import ViewSpecComposer
+from tensorcast.proto.daemon.v2 import store_daemon_pb2
+
+if TYPE_CHECKING:
+    from tensorcast.api._config import RegisterArtifactOptions
+    from tensorcast.api.store import Store
+    from tensorcast.api.store.artifact import Artifact
+    from tensorcast.api.store.handles import RegisteredArtifact
+    from tensorcast.api.store.runtime import StoreRuntimeContext
+    from tensorcast.api.store.types import CanonicalIndex, CanonicalIndexEntry
+
+
+_ALIGNMENT_BYTES = 8
+
+
+@dataclass(frozen=True, slots=True)
+class DeferredCommitResult:
+    tensor_names: tuple[str, ...]
+    view_id: str | None
+    view_subset_hash: bytes | None
+    storage_ids: tuple[str, ...]
+    logical_size_bytes: int
+    published_artifact: "RegisteredArtifact | None" = None
+
+
+@dataclass(frozen=True, slots=True)
+class _TensorSpec:
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    dtype: torch.dtype
+    size_bytes: int
+    offset_bytes: int
+
+
+def _align_bytes(value: int, alignment: int) -> int:
+    if alignment <= 1:
+        return int(value)
+    return ((int(value) + alignment - 1) // alignment) * alignment
+
+
+def _compact_stride(shape: Sequence[int]) -> tuple[int, ...]:
+    stride: list[int] = []
+    acc = 1
+    for dim in reversed(shape):
+        stride.append(acc)
+        acc *= max(1, int(dim))
+    return tuple(reversed(stride))
+
+
+def _numel(shape: Sequence[int]) -> int:
+    total = 1
+    for dim in shape:
+        dim_value = int(dim)
+        if dim_value <= 0:
+            return 0
+        total *= dim_value
+    return total
+
+
+class DeferredLoader:
+    """Allocate CUDA placeholders for slices and materialize once at commit()."""
+
+    def __init__(
+        self,
+        *,
+        artifact: "Artifact",
+        device: torch.device | str,
+        packing: str = "append",
+        capacity_bytes: int | None = None,
+    ) -> None:
+        store, runtime, pipeline = artifact._require_components()
+        artifact._ensure_metadata()
+
+        self._store: Store = store
+        self._runtime: StoreRuntimeContext = runtime
+        self._pipeline = pipeline
+        self._artifact = artifact
+        self._fallback: FallbackOptions | None = artifact._fallback
+
+        device_obj = torch.device(device)
+        if device_obj.type != "cuda":
+            raise ArtifactError(
+                "DeferredLoader requires a CUDA device",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        self._device = device_obj
+        self._device_id = resolve_device(device_obj, allow_cpu=False)
+
+        mode = str(packing).strip().lower()
+        if mode not in {"append", "plan"}:
+            raise ArtifactError(
+                "packing must be 'append' or 'plan'",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        self._packing = mode
+
+        base_index = artifact._effective_index()
+        self._base_index: CanonicalIndex = base_index
+        self._entries_by_name: dict[str, CanonicalIndexEntry] = {
+            entry.name: entry for entry in base_index.entries
+        }
+        if not self._entries_by_name:
+            raise ArtifactError(
+                "Artifact canonical index is empty",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+
+        base_spec = artifact._view_spec
+        if base_spec is not None and base_spec.has_transpose:
+            raise ArtifactError(
+                "DeferredLoader only supports narrow view operations",
+                status_code="UNIMPLEMENTED",
+                retryable=False,
+            )
+        self._base_view_spec = base_spec
+        self._base_view_depth = artifact._view_depth
+
+        if capacity_bytes is None:
+            padding = max(0, len(base_index.entries) - 1) * (_ALIGNMENT_BYTES - 1)
+            capacity = int(base_index.total_size_bytes) + int(padding)
+        else:
+            capacity = int(capacity_bytes)
+        if capacity <= 0:
+            raise ArtifactError(
+                "capacity_bytes must be positive",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        self._capacity_bytes = capacity
+
+        self._cursor_bytes = 0
+        self._order: list[str] = []
+        self._offsets: dict[str, int] = {}
+        self._specs: dict[str, _TensorSpec] = {}
+        self._tensors: dict[str, torch.Tensor] = {}
+        self._slice_specs: dict[str, SliceSpec] = {}
+        self._element_size_cache: dict[torch.dtype, int] = {}
+
+        self._arena: torch.Tensor | None = None
+        self._arena_storage: torch.UntypedStorage | None = None
+        self._region_id: str | None = None
+
+        self._planned = False
+        self._committed = False
+        self._closed = False
+
+    def __enter__(self) -> "DeferredLoader":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    def plan(
+        self,
+        tensor_names: Sequence[str],
+        *,
+        slices: Mapping[str, SliceSpec] | None = None,
+    ) -> None:
+        self._ensure_open()
+        if self._packing != "plan":
+            raise ArtifactError(
+                "plan() is only valid when packing='plan'",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        if self._planned:
+            raise ArtifactError(
+                "DeferredLoader plan already finalized",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        if self._tensors:
+            raise ArtifactError(
+                "plan() must be called before tensor()",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+
+        ordered = [str(name) for name in tensor_names]
+        if not ordered:
+            raise ArtifactError(
+                "plan() requires at least one tensor name",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        if len(set(ordered)) != len(ordered):
+            raise ArtifactError(
+                "plan() tensor_names must be unique",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        for name in ordered:
+            if name not in self._entries_by_name:
+                raise ArtifactError(
+                    f"Unknown tensor '{name}' in plan()",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+
+        ordered_set = set(ordered)
+        if slices:
+            for name, slice_spec in slices.items():
+                if name not in self._entries_by_name:
+                    raise ArtifactError(
+                        f"Unknown tensor '{name}' in plan() slices",
+                        status_code="INVALID_ARGUMENT",
+                        retryable=False,
+                    )
+                if name not in ordered_set:
+                    raise ArtifactError(
+                        f"Tensor '{name}' in plan() slices is not in tensor_names",
+                        status_code="INVALID_ARGUMENT",
+                        retryable=False,
+                    )
+                self._validate_slice(name, slice_spec)
+                self._slice_specs[name] = slice_spec
+
+        cursor = 0
+        offsets: dict[str, int] = {}
+        specs: dict[str, _TensorSpec] = {}
+        for name in sorted(ordered):
+            spec = self._build_tensor_spec(name, self._slice_specs.get(name))
+            offset = _align_bytes(cursor, _ALIGNMENT_BYTES)
+            if offset % self._element_size(spec.dtype) != 0:
+                raise ArtifactError(
+                    f"Aligned offset for '{name}' is not divisible by dtype size",
+                    status_code="FAILED_PRECONDITION",
+                    retryable=False,
+                )
+            cursor = offset + spec.size_bytes
+            offsets[name] = offset
+            specs[name] = _TensorSpec(
+                shape=spec.shape,
+                stride=spec.stride,
+                dtype=spec.dtype,
+                size_bytes=spec.size_bytes,
+                offset_bytes=offset,
+            )
+
+        if cursor > self._capacity_bytes:
+            raise ArtifactError(
+                "DeferredLoader plan exceeds capacity_bytes",
+                status_code="RESOURCE_EXHAUSTED",
+                retryable=False,
+            )
+
+        self._order = sorted(ordered)
+        self._offsets = offsets
+        self._specs = specs
+        self._cursor_bytes = cursor
+        self._planned = True
+        self._ensure_arena()
+
+    def tensor(self, name: str, *, slice: SliceSpec | None = None) -> torch.Tensor:
+        self._ensure_open()
+        if self._committed:
+            raise ArtifactError(
+                "DeferredLoader already committed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        tensor_name = str(name)
+        existing = self._tensors.get(tensor_name)
+        if existing is not None:
+            if slice is not None:
+                prior = self._slice_specs.get(tensor_name)
+                if prior is None or prior != slice:
+                    raise ArtifactError(
+                        f"Tensor '{tensor_name}' already requested with a different slice",
+                        status_code="INVALID_ARGUMENT",
+                        retryable=False,
+                    )
+            return existing
+
+        if tensor_name not in self._entries_by_name:
+            raise ArtifactError(
+                f"Unknown tensor '{tensor_name}'",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+
+        if self._packing == "plan" and not self._planned:
+            raise ArtifactError(
+                "packing='plan' requires calling plan() before tensor()",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+
+        if slice is not None:
+            if self._packing == "plan" and self._planned:
+                planned = self._slice_specs.get(tensor_name)
+                if planned is None or planned != slice:
+                    raise ArtifactError(
+                        f"Tensor '{tensor_name}' slice does not match the plan",
+                        status_code="INVALID_ARGUMENT",
+                        retryable=False,
+                    )
+            else:
+                self._validate_slice(tensor_name, slice)
+                self._slice_specs[tensor_name] = slice
+
+        spec = self._specs.get(tensor_name)
+        if spec is None:
+            spec = self._build_tensor_spec(
+                tensor_name, self._slice_specs.get(tensor_name)
+            )
+
+        if self._packing == "append":
+            offset = _align_bytes(self._cursor_bytes, _ALIGNMENT_BYTES)
+            if offset % self._element_size(spec.dtype) != 0:
+                raise ArtifactError(
+                    f"Aligned offset for '{tensor_name}' is not divisible by dtype size",
+                    status_code="FAILED_PRECONDITION",
+                    retryable=False,
+                )
+            end = offset + spec.size_bytes
+            if end > self._capacity_bytes:
+                raise ArtifactError(
+                    "DeferredLoader arena exhausted; increase capacity_bytes",
+                    status_code="RESOURCE_EXHAUSTED",
+                    retryable=False,
+                )
+            self._cursor_bytes = end
+            self._order.append(tensor_name)
+            self._offsets[tensor_name] = offset
+            spec = _TensorSpec(
+                shape=spec.shape,
+                stride=spec.stride,
+                dtype=spec.dtype,
+                size_bytes=spec.size_bytes,
+                offset_bytes=offset,
+            )
+            self._specs[tensor_name] = spec
+        else:
+            if tensor_name not in self._offsets:
+                raise ArtifactError(
+                    f"Tensor '{tensor_name}' is not part of the plan",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            spec = self._specs[tensor_name]
+
+        self._ensure_arena()
+        tensor = self._materialize_tensor(spec)
+        self._tensors[tensor_name] = tensor
+        return tensor
+
+    def commit(
+        self,
+        *,
+        publish: bool | RegisterArtifactOptions | None = None,
+    ) -> DeferredCommitResult:
+        self._ensure_open()
+        if self._committed:
+            raise ArtifactError(
+                "DeferredLoader already committed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        if not self._tensors:
+            raise ArtifactError(
+                "DeferredLoader has no tensors to materialize",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        if self._packing == "plan":
+            planned = set(self._order)
+            if planned and planned != set(self._tensors):
+                raise ArtifactError(
+                    "DeferredLoader plan requires requesting every planned tensor",
+                    status_code="FAILED_PRECONDITION",
+                    retryable=False,
+                )
+
+        composed_spec = self._compose_view_spec()
+        view_spec_proto = composed_spec.proto if composed_spec else None
+
+        target = dict(self._tensors)
+        artifact_id = self._artifact._ensure_identified()
+        canonical_index = self._artifact._canonical_index
+        canonical_index_bytes = self._artifact._canonical_index_bytes
+        if canonical_index is None or canonical_index_bytes is None:
+            raise ArtifactError(
+                "Missing canonical index for deferred materialization",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+
+        selection_order = tuple(self._order)
+        region_layout = self._pipeline._build_region_backed_layout(
+            canonical_index=canonical_index,
+            canonical_index_bytes=canonical_index_bytes,
+            target=target,
+            device_id=self._device_id,
+            tensor_names=selection_order,
+            view_spec=view_spec_proto,
+            view_id=None,
+            view_index_hint=None,
+            selection_order=selection_order,
+        )
+
+        preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO
+        disk_path: str | None = None
+        effective_prefer = (
+            self._fallback.prefer if self._fallback is not None else "auto"
+        )
+        if self._fallback is not None:
+            if self._fallback.prefer == "p2p":
+                preference = (
+                    store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_P2P
+                )
+            elif self._fallback.prefer == "disk":
+                preference = (
+                    store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
+                )
+            disk_path = self._fallback.disk_path
+        if (
+            disk_path
+            and preference == store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_AUTO
+        ):
+            preference = store_daemon_pb2.SourcePreference.SOURCE_PREFERENCE_PREFER_DISK
+
+        allow_p2p = True if self._fallback is None else bool(self._fallback.allow_p2p)
+        if effective_prefer == "local":
+            allow_p2p = False
+        allow_disk = effective_prefer != "local" or bool(disk_path)
+        source_policy = _build_source_policy(
+            preference=preference,
+            allow_p2p=allow_p2p,
+            allow_disk=allow_disk,
+        )
+
+        client = self._runtime.ensure_client()
+        try:
+            response = client.materialize_into_target_v2(
+                artifact_id=artifact_id,
+                target_layout=region_layout.layout,
+                device_uuid=device_uuid_for(self._device_id),
+                preference=preference,
+                source_policy=source_policy,
+                disk_path=disk_path,
+                tensor_names=region_layout.selection_names,
+                view=view_spec_proto,
+                view_id=region_layout.view_id if view_spec_proto is None else None,
+                view_subset_hash=region_layout.view_subset_hash,
+            )
+        except Exception as exc:  # noqa: BLE001
+            error = map_materialization_error(exc)
+            if error.status_code in {"DATA_LOSS", "FAILED_PRECONDITION"}:
+                self._unregister_region()
+            raise ArtifactError(
+                str(error),
+                status_code=error.status_code,
+                retryable=False,
+            ) from exc
+
+        if (
+            response.status
+            != store_daemon_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_ALLOCATED
+        ):
+            self._unregister_region()
+            raise ArtifactError(
+                "MaterializeIntoTarget returned non-success status",
+                status_code="DATA_LOSS",
+                retryable=False,
+            )
+        store_metrics.record_region_backed_verification_skipped(
+            self._runtime.daemon_endpoint
+        )
+
+        published_artifact: RegisteredArtifact | None = None
+        if publish:
+            from tensorcast.api._config import PlanType, RegisterArtifactOptions
+
+            options: RegisterArtifactOptions
+            if isinstance(publish, RegisterArtifactOptions):
+                options = publish
+            else:
+                options = RegisterArtifactOptions(plan=PlanType.VRAM_LEASED)
+            if options.plan is not PlanType.VRAM_LEASED or not options.lease_in_place:
+                options = options.model_copy(
+                    update={"plan": PlanType.VRAM_LEASED, "lease_in_place": True}
+                )
+            published_artifact = self._store.register(target, options=options)
+
+        self._committed = True
+        storage_ids = tuple(
+            storage.storage_id for storage in region_layout.layout.storages
+        )
+        return DeferredCommitResult(
+            tensor_names=region_layout.selection_names,
+            view_id=region_layout.view_id,
+            view_subset_hash=region_layout.view_subset_hash,
+            storage_ids=storage_ids,
+            logical_size_bytes=region_layout.logical_total_size,
+            published_artifact=published_artifact,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._unregister_region()
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise ArtifactError(
+                "DeferredLoader is closed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        if self._runtime.closed:
+            raise ArtifactError(
+                "Store is closed",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+
+    def _ensure_arena(self) -> None:
+        if self._arena is not None:
+            if self._region_id is None:
+                self._register_region(self._arena)
+            return
+        arena = torch.empty(
+            (self._capacity_bytes,),
+            dtype=torch.uint8,
+            device=self._device,
+        )
+        self._arena = arena
+        self._arena_storage = arena.untyped_storage()
+        self._register_region(arena)
+
+    def _register_region(self, arena: torch.Tensor) -> None:
+        if self._region_id is not None:
+            return
+        ttl_ms = self._runtime._DEFAULT_LEASE_TTL_MS
+        handle = self._store.register_vram_region(
+            device_id=self._device_id,
+            base_ptr=int(arena.data_ptr()),
+            size_bytes=int(self._capacity_bytes),
+            ttl_ms=int(ttl_ms),
+        )
+        self._region_id = handle.region_id
+
+    def _unregister_region(self) -> None:
+        if self._region_id is None:
+            return
+        region_id = self._region_id
+        self._region_id = None
+        with contextlib.suppress(Exception):
+            self._store.unregister_vram_region(region_id)
+
+    def _element_size(self, dtype: torch.dtype) -> int:
+        cached = self._element_size_cache.get(dtype)
+        if cached is not None:
+            return cached
+        size = int(torch.empty((), dtype=dtype).element_size())
+        self._element_size_cache[dtype] = size
+        return size
+
+    def _validate_slice(self, name: str, spec: SliceSpec) -> None:
+        entry = self._entries_by_name[name]
+        try:
+            validate_narrow(name, entry.shape, spec)
+        except ValueError as exc:
+            raise ArtifactError(
+                str(exc),
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            ) from exc
+
+    def _build_tensor_spec(self, name: str, spec: SliceSpec | None) -> _TensorSpec:
+        entry = self._entries_by_name[name]
+        shape = entry.shape
+        stride = entry.stride
+        narrow = None
+        if spec is not None:
+            try:
+                narrow = validate_narrow(name, entry.shape, spec)
+            except ValueError as exc:
+                raise ArtifactError(
+                    str(exc),
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                ) from exc
+            if narrow is not None:
+                shape = tuple(
+                    narrow.length if idx == narrow.dim else int(dim)
+                    for idx, dim in enumerate(entry.shape)
+                )
+                stride = _compact_stride(shape)
+        if tuple(stride) != _compact_stride(shape):
+            raise ArtifactError(
+                f"Tensor '{name}' is not contiguous; deferred loader requires contiguous layouts",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        numel = _numel(shape)
+        if numel <= 0:
+            raise ArtifactError(
+                f"Tensor '{name}' has invalid shape for deferred materialization",
+                status_code="INVALID_ARGUMENT",
+                retryable=False,
+            )
+        if spec is None or narrow is None:
+            size_bytes = int(entry.size_bytes)
+        else:
+            size_bytes = numel * self._element_size(entry.dtype)
+        return _TensorSpec(
+            shape=tuple(int(dim) for dim in shape),
+            stride=tuple(int(dim) for dim in stride),
+            dtype=entry.dtype,
+            size_bytes=int(size_bytes),
+            offset_bytes=0,
+        )
+
+    def _materialize_tensor(self, spec: _TensorSpec) -> torch.Tensor:
+        if self._arena_storage is None:
+            raise ArtifactError(
+                "DeferredLoader arena is not initialized",
+                status_code="FAILED_PRECONDITION",
+                retryable=False,
+            )
+        offset_elems = spec.offset_bytes // self._element_size(spec.dtype)
+        tensor = torch.empty((), device=self._device, dtype=spec.dtype)
+        tensor.set_(
+            self._arena_storage,
+            int(offset_elems),
+            spec.shape,
+            spec.stride,
+        )
+        return tensor
+
+    def _compose_view_spec(self) -> ViewSpecBuildResult | None:
+        if not self._slice_specs and (
+            self._base_view_spec is None or self._base_view_spec.is_identity
+        ):
+            return None
+        entry_shapes = {
+            entry.name: tuple(entry.shape) for entry in self._base_index.entries
+        }
+        if self._slice_specs:
+            build_spec = build_view_spec(
+                entry_shapes=entry_shapes,
+                slices=self._slice_specs,
+                transpose=None,
+            )
+            if build_spec.has_transpose:
+                raise ArtifactError(
+                    "DeferredLoader only supports narrow view operations",
+                    status_code="UNIMPLEMENTED",
+                    retryable=False,
+                )
+        else:
+            build_spec = None
+        composer = ViewSpecComposer()
+        composed_spec, _, _ = composer.compose(
+            canonical_index=self._base_index,
+            parent_spec=self._base_view_spec,
+            child_spec=build_spec,
+            parent_depth=self._base_view_depth,
+            subset_names=None,
+        )
+        if composed_spec is None or composed_spec.is_identity:
+            return None
+        return composed_spec
+
+
+__all__ = ["DeferredCommitResult", "DeferredLoader"]

--- a/tensorcast/api/store/materialization.py
+++ b/tensorcast/api/store/materialization.py
@@ -865,6 +865,7 @@ class MaterializationPipeline:
         view_spec: store_daemon_pb2.ViewSpec | None,
         view_id: str | None,
         view_index_hint: bytes | None,
+        selection_order: Sequence[str] | None = None,
     ) -> _RegionBackedLayout:
         entries_by_name = {entry.name: entry for entry in canonical_index.entries}
         if not entries_by_name:
@@ -895,7 +896,28 @@ class MaterializationPipeline:
                 retryable=False,
             )
 
-        selection_names = tuple(sorted(target_names))
+        if selection_order is not None:
+            selection_names = tuple(str(name) for name in selection_order)
+            if not selection_names:
+                raise ArtifactError(
+                    "selection_order must not be empty when provided",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            if len(set(selection_names)) != len(selection_names):
+                raise ArtifactError(
+                    "selection_order must not contain duplicates",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+            if set(selection_names) != target_names:
+                raise ArtifactError(
+                    "selection_order must match target tensor names",
+                    status_code="INVALID_ARGUMENT",
+                    retryable=False,
+                )
+        else:
+            selection_names = tuple(sorted(target_names))
         full_selection = target_names == canonical_names
 
         normalized_ops: dict[str, list[dict[str, int | str]]] = {}
@@ -934,13 +956,17 @@ class MaterializationPipeline:
                 )
             resolved_view_id = view_id
 
-        needs_view_index = bool(normalized_ops) or not full_selection
+        needs_view_index = (
+            bool(normalized_ops) or not full_selection or selection_order is not None
+        )
         view_index_bytes: bytes | None = None
         if needs_view_index:
             if view_spec is None and view_index_hint is not None:
                 view_index_bytes = view_index_hint
             else:
-                subset_payload = None if full_selection else list(selection_names)
+                subset_payload = None
+                if selection_order is not None or not full_selection:
+                    subset_payload = list(selection_names)
                 view_payload = compute_view_index_bytes(
                     canonical_index_bytes, normalized_ops, subset_payload
                 )

--- a/tensorcast/api/store/view_composer.py
+++ b/tensorcast/api/store/view_composer.py
@@ -300,7 +300,14 @@ class ViewSpecComposer:
             view_id: str | None = None
             if composed_spec is not None and not composed_spec.is_identity:
                 canonical_bytes = _serialize_index(canonical_index)
-                view_id = compute_view_id(composed_spec.proto, canonical_bytes)
+                view_proto = composed_spec.proto
+                if view_proto is None:
+                    raise ArtifactError(
+                        "View spec proto missing while computing view_id",
+                        status_code="FAILED_PRECONDITION",
+                        retryable=False,
+                    )
+                view_id = compute_view_id(view_proto, canonical_bytes)
             view_cache = ViewMetadataCache(
                 view_id=view_id or view_hash,
                 view_index_bytes=view_index_bytes,

--- a/tests/python/test_deferred_loader.py
+++ b/tests/python/test_deferred_loader.py
@@ -24,10 +24,18 @@ def _skip_if_no_cuda() -> None:
         pytest.skip("CUDA not available - deferred loader requires CUDA tensors")
 
 
-def _make_index_bytes() -> bytes:
+def _make_index_bytes(
+    *, shape: list[int] | None = None, stride: list[int] | None = None
+) -> bytes:
+    shape_value = shape if shape is not None else [4]
+    stride_value = stride if stride is not None else [1]
+    numel = 1
+    for dim in shape_value:
+        numel *= int(dim)
+    size_bytes = int(numel) * 4
     index = {
-        "alpha": [0, 16, [4], [1], "torch.float32", 0],
-        "beta": [16, 16, [4], [1], "torch.float32", 0],
+        "alpha": [0, size_bytes, shape_value, stride_value, "torch.float32", 0],
+        "beta": [size_bytes, size_bytes, shape_value, stride_value, "torch.float32", 0],
     }
     return json.dumps(index, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
@@ -123,6 +131,24 @@ def store_and_client(
         runtime.executor.shutdown(wait=False)
 
 
+@pytest.fixture
+def store_and_client_empty_stride(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[Store, FakeDeferredClient]]:
+    _skip_if_no_cuda()
+    client = FakeDeferredClient(_make_index_bytes(stride=[]))
+    runtime = FakeRuntime(client)
+    store = Store("fake://daemon", runtime=runtime)
+    monkeypatch.setattr(
+        store_mod, "get_cuda_memory_handle", lambda *args, **kwargs: b"fake-handle"
+    )
+    monkeypatch.setattr(deferred_loader_mod, "device_uuid_for", lambda device_id: "gpu-0")
+    try:
+        yield store, client
+    finally:
+        runtime.executor.shutdown(wait=False)
+
+
 def test_deferred_loader_invalid_slice_raises(
     store_and_client: tuple[Store, FakeDeferredClient],
 ) -> None:
@@ -160,3 +186,46 @@ def test_deferred_loader_commit_preserves_order(
     assert result.tensor_names == ("beta", "alpha")
     assert result.view_id is None
     assert result.view_subset_hash is not None
+
+
+def test_deferred_loader_empty_stride_is_contiguous(
+    store_and_client_empty_stride: tuple[Store, FakeDeferredClient],
+) -> None:
+    store, _ = store_and_client_empty_stride
+    artifact = store.artifact(artifact_id="artifact-1")
+    with artifact.deferred_loader(device="cuda:0") as loader:
+        tensor = loader.tensor("alpha")
+        assert tensor.is_contiguous()
+        assert tuple(tensor.stride()) == (1,)
+
+
+def test_deferred_loader_append_retry_does_not_duplicate_order(
+    store_and_client: tuple[Store, FakeDeferredClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, client = store_and_client
+    artifact = store.artifact(artifact_id="artifact-1")
+
+    with artifact.deferred_loader(device="cuda:0") as loader:
+        original_ensure = loader._ensure_arena
+
+        def _boom() -> None:
+            raise ArtifactError(
+                "arena unavailable",
+                status_code="RESOURCE_EXHAUSTED",
+                retryable=True,
+            )
+
+        monkeypatch.setattr(loader, "_ensure_arena", _boom)
+        with pytest.raises(ArtifactError):
+            loader.tensor("alpha")
+        assert loader._order == []
+        assert loader._cursor_bytes == 0
+        assert "alpha" not in loader._offsets
+
+        monkeypatch.setattr(loader, "_ensure_arena", original_ensure)
+        loader.tensor("alpha")
+        result = loader.commit()
+
+    assert result.tensor_names == ("alpha",)
+    assert len(client.materialize_calls) == 1

--- a/tests/python/test_deferred_loader.py
+++ b/tests/python/test_deferred_loader.py
@@ -1,0 +1,162 @@
+#  Copyright (c) 2025-2026, TensorCast Team.
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import types
+from typing import Any, Iterator
+
+import pytest
+import torch
+
+import tensorcast.api.store as store_mod
+from tensorcast.api import _region_cache as region_cache
+from tensorcast.api.store import ArtifactError, Store
+from tensorcast.api.store.cache import ArtifactCacheEntry
+from tensorcast.api.store import deferred_loader as deferred_loader_mod
+from tensorcast.proto.daemon.v2 import store_daemon_pb2
+from tensorcast.types import VramRegionHandle
+
+
+def _skip_if_no_cuda() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available - deferred loader requires CUDA tensors")
+
+
+def _make_index_bytes() -> bytes:
+    index = {
+        "alpha": [0, 16, [4], [1], "torch.float32", 0],
+        "beta": [16, 16, [4], [1], "torch.float32", 0],
+    }
+    return json.dumps(index, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+class FakeDeferredClient:
+    def __init__(self, index_bytes: bytes) -> None:
+        self._index_bytes = index_bytes
+        self.materialize_calls: list[dict[str, Any]] = []
+        self.register_calls: list[dict[str, Any]] = []
+        self.unregister_calls: list[str] = []
+
+    def get_artifact_index_by_id(self, artifact_id: str) -> bytes:
+        return self._index_bytes
+
+    def register_vram_region(
+        self,
+        *,
+        device_id: int,
+        size_bytes: int,
+        ttl_ms: int,
+        cuda_ipc_handle: bytes,
+        region_name: str | None = None,
+    ) -> VramRegionHandle:
+        self.register_calls.append(
+            {
+                "device_id": device_id,
+                "size_bytes": size_bytes,
+                "ttl_ms": ttl_ms,
+                "handle": cuda_ipc_handle,
+                "region_name": region_name,
+            }
+        )
+        return VramRegionHandle(region_id="region:deferred", ttl_ms=ttl_ms)
+
+    def unregister_vram_region(self, region_id: str, *, force: bool | None = None) -> bool:
+        self.unregister_calls.append(region_id)
+        return True
+
+    def materialize_into_target_v2(self, **kwargs: Any) -> Any:
+        self.materialize_calls.append(kwargs)
+        return types.SimpleNamespace(
+            status=store_daemon_pb2.MaterializeReplicaStatus.MATERIALIZE_REPLICA_STATUS_ALLOCATED
+        )
+
+
+class FakeRuntime:
+    _DEFAULT_LEASE_TTL_MS = 600_000
+
+    def __init__(self, client: FakeDeferredClient) -> None:
+        self._client = client
+        self.daemon_endpoint = "fake://daemon"
+        self.closed = False
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        self._cache: dict[str, ArtifactCacheEntry] = {}
+
+    def ensure_client(self) -> FakeDeferredClient:
+        return self._client
+
+    def track_future(self, future: concurrent.futures.Future[object]) -> None:
+        return None
+
+    def get_artifact_index_cached(self, artifact_id: str) -> ArtifactCacheEntry | None:
+        return self._cache.get(artifact_id)
+
+    def cache_artifact_index(self, entry: ArtifactCacheEntry) -> None:
+        self._cache[entry.artifact_id] = entry
+
+    def invalidate_artifact(self, *args: object, **kwargs: object) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _clear_region_cache() -> Iterator[None]:
+    yield
+    for device_id in list(region_cache._REGIONS_BY_DEVICE.keys()):
+        for rec in list(region_cache._REGIONS_BY_DEVICE[device_id]):
+            region_cache.unregister_region(rec.region_id)
+
+
+@pytest.fixture
+def store_and_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[Store, FakeDeferredClient]]:
+    _skip_if_no_cuda()
+    client = FakeDeferredClient(_make_index_bytes())
+    runtime = FakeRuntime(client)
+    store = Store("fake://daemon", runtime=runtime)
+    monkeypatch.setattr(store_mod, "get_cuda_memory_handle", lambda *args, **kwargs: b"fake-handle")
+    monkeypatch.setattr(deferred_loader_mod, "device_uuid_for", lambda device_id: "gpu-0")
+    try:
+        yield store, client
+    finally:
+        runtime.executor.shutdown(wait=False)
+
+
+def test_deferred_loader_invalid_slice_raises(
+    store_and_client: tuple[Store, FakeDeferredClient],
+) -> None:
+    store, _ = store_and_client
+    artifact = store.artifact(artifact_id="artifact-1")
+    with artifact.deferred_loader(device="cuda:0") as loader:
+        with pytest.raises(ArtifactError):
+            loader.tensor("alpha", slice=slice(5, 6))
+
+
+def test_deferred_loader_commit_preserves_order(
+    store_and_client: tuple[Store, FakeDeferredClient],
+) -> None:
+    store, client = store_and_client
+    artifact = store.artifact(artifact_id="artifact-1")
+
+    with artifact.deferred_loader(device="cuda:0") as loader:
+        tensor_beta = loader.tensor("beta")
+        tensor_alpha = loader.tensor("alpha")
+        arena = loader._arena
+        assert arena is not None
+        assert tensor_beta.data_ptr() == arena.data_ptr() + loader._offsets["beta"]
+        assert tensor_alpha.data_ptr() == arena.data_ptr() + loader._offsets["alpha"]
+        assert tensor_beta.is_cuda
+        assert tensor_alpha.is_cuda
+        assert tuple(tensor_beta.shape) == (4,)
+        assert tuple(tensor_alpha.shape) == (4,)
+        result = loader.commit()
+
+    assert len(client.materialize_calls) == 1
+    call = client.materialize_calls[0]
+    assert tuple(call["tensor_names"]) == ("beta", "alpha")
+    layout = call["target_layout"]
+    assert layout.index_kind == store_daemon_pb2.TargetLayout.INDEX_KIND_VIEW
+    assert result.tensor_names == ("beta", "alpha")
+    assert result.view_id is None
+    assert result.view_subset_hash is not None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables vLLM-friendly deferred slice loading and ordered packing across SDK and core.
> 
> - **SDK**: Adds `Artifact.deferred_loader(...)` and `DeferredLoader` to allocate client-owned CUDA arenas, return placeholder tensors immediately, and `commit()` once via `MaterializeIntoTarget` (optional publish). Exports in `__init__.py` and documents in `tensorcast/api/store/README.md`.
> - **Materialization**: `_build_region_backed_layout(...)` now accepts `selection_order` and computes view index bytes when order/subset is provided, ensuring RPC `tensor_names` and `ViewPlanner` packing match.
> - **Core (ViewPlanner)**: Preserves provided subset order (including full-name subsets), removes identity assumption in that case, and aligns packing (8B). Adds tests for ordering and narrow behavior.
> - **Daemon tests**: Validates `MaterializeIntoTarget` with ordered full selections and existing subset cases.
> - **Docs**: Marks design 0052 as accepted and updates internals/plan to describe deferred loader flow and ordered packing semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d156a19372e48daef5c551fc7d79393ac4baf1cf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->