### PR TITLE
feat(view): implement stride-aware coalescing in ViewPlanSource for e…

### DIFF
--- a/core/common/memory/pinned_buffer_pool.cc
+++ b/core/common/memory/pinned_buffer_pool.cc
@@ -25,7 +25,7 @@
 #include <string>
 #include <utility>
 
-#include <numaif.h>
+#include <linux/mempolicy.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 

--- a/core/store/materialization/dataplane/BUILD
+++ b/core/store/materialization/dataplane/BUILD
@@ -247,7 +247,9 @@ sc_cc_library(
         ":view_planner",
         "//core/store/materialization/contracts:view_plan",
         "//core/store/materialization/contracts:view_spec",
+        "@abseil-cpp//absl/synchronization",
         "@gsl",
+        "@opentelemetry-cpp//api:api",
     ],
 )
 

--- a/core/store/materialization/dataplane/README.md
+++ b/core/store/materialization/dataplane/README.md
@@ -15,3 +15,9 @@ removed, making these targets the single source of truth for dataplane code.
   - `auto` selects `O_DIRECT` for large payloads (currently `> 5GiB`) and will fall back to buffered I/O if `open(O_DIRECT)` fails with a common “unsupported” errno (see `direct_io_fallback_errno()` / `direct_io_fallback_reason()`).
 - `GpuMemorySink::Options::{gpu_sched_enabled,gpu_sched_limit_bytes,gpu_sched_limit_copies}`
   - Limits per-GPU in-flight H2D bytes/copies for `write_at_async()` to reduce transient oversubscription; stats are readable via `get_gpu_scheduler_stats(device_id)`.
+
+## View Execution (SelectionPlan)
+
+- `ViewPlanSource` compiles `SelectionPlan` ranges into indexed execution runs to avoid per-call linear scans.
+- Strided `narrow(axis=1)`-style runs use row-block coalesced reads plus host packing, with PAD=0 semantics preserved.
+- Strided execution is auto-gated by run length, row width, and amplification bounds; `VLOG(1)` summarizes read/pack/caching totals per instance.

--- a/core/store/materialization/dataplane/view/tests/view_plan_source_test.cc
+++ b/core/store/materialization/dataplane/view/tests/view_plan_source_test.cc
@@ -1,9 +1,11 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "core/store/materialization/dataplane/view/view_plan_source.h"
 
 #include <array>
+#include <atomic>
 #include <cstring>
+#include <thread>
 #include <vector>
 
 #include "catch2/catch_test_macros.hpp"
@@ -33,12 +35,24 @@ class VectorSource final : public tensorcast::store::loader::SeekableSource {
     }
     const size_t available = static_cast<size_t>(std::min<uint64_t>(bytes, data_.size() - offset));
     std::memcpy(dst, data_.data() + offset, available);
+    read_calls_.fetch_add(1, std::memory_order_relaxed);
+    read_bytes_.fetch_add(available, std::memory_order_relaxed);
     return available;
+  }
+
+  uint64_t read_calls() const {
+    return read_calls_.load(std::memory_order_relaxed);
+  }
+
+  uint64_t read_bytes() const {
+    return read_bytes_.load(std::memory_order_relaxed);
   }
 
  private:
   std::vector<uint8_t> data_;
   uint64_t cursor_{0};
+  std::atomic<uint64_t> read_calls_{0};
+  std::atomic<uint64_t> read_bytes_{0};
 };
 
 SelectionPlan::Range data_range(uint64_t src, uint64_t dst, uint64_t len) {
@@ -71,6 +85,35 @@ SelectionPlan build_sample_plan() {
   plan.is_segment_aligned = false;
   plan.requires_materialization = false;
   return plan;
+}
+
+SelectionPlan build_strided_plan(uint64_t src_base, uint64_t row_len, uint64_t stride, uint64_t rows) {
+  SelectionPlan plan;
+  plan.ranges.reserve(rows);
+  for (uint64_t row = 0; row < rows; ++row) {
+    plan.ranges.push_back(data_range(src_base + row * stride, row * row_len, row_len));
+  }
+  plan.total_bytes = rows * row_len;
+  plan.num_ranges = static_cast<uint32_t>(plan.ranges.size());
+  plan.is_contiguous = false;
+  plan.is_segment_aligned = false;
+  plan.requires_materialization = false;
+  return plan;
+}
+
+std::vector<uint8_t> build_strided_expected(
+    const std::vector<uint8_t>& backing,
+    uint64_t src_base,
+    uint64_t row_len,
+    uint64_t stride,
+    uint64_t rows) {
+  std::vector<uint8_t> expected(rows * row_len);
+  for (uint64_t row = 0; row < rows; ++row) {
+    const uint64_t src_offset = src_base + row * stride;
+    const uint64_t dst_offset = row * row_len;
+    std::memcpy(expected.data() + dst_offset, backing.data() + src_offset, row_len);
+  }
+  return expected;
 }
 
 } // namespace
@@ -130,4 +173,94 @@ TEST_CASE("ViewPlanSource reports alias eligibility from plan", "[view_plan_sour
   ViewPlanSource src(&base, contiguous_plan);
   CHECK(src.alias_eligible());
   CHECK_FALSE(src.requires_materialization());
+}
+
+TEST_CASE("ViewPlanSource coalesces strided runs", "[view_plan_source]") {
+  constexpr uint64_t kRowLen = 4096;
+  constexpr uint64_t kStride = 8192;
+  constexpr uint64_t kRows = 128;
+  const uint64_t backing_bytes = (kRows - 1) * kStride + kRowLen;
+  std::vector<uint8_t> backing(backing_bytes);
+  for (size_t i = 0; i < backing.size(); ++i) {
+    backing[i] = static_cast<uint8_t>(i % 251);
+  }
+
+  VectorSource base(backing);
+  SelectionPlan plan = build_strided_plan(/*src_base=*/0, kRowLen, kStride, kRows);
+  ViewPlanSource src(&base, plan);
+
+  std::vector<uint8_t> out(plan.total_bytes);
+  auto bytes_or = src.read_at(0, out.data(), out.size());
+  REQUIRE(bytes_or.ok());
+  CHECK(*bytes_or == out.size());
+
+  auto expected = build_strided_expected(backing, /*src_base=*/0, kRowLen, kStride, kRows);
+  CHECK(out == expected);
+  CHECK(base.read_calls() < kRows);
+}
+
+TEST_CASE("ViewPlanSource handles partial strided reads across rows", "[view_plan_source]") {
+  constexpr uint64_t kRowLen = 4096;
+  constexpr uint64_t kStride = 8192;
+  constexpr uint64_t kRows = 128;
+  const uint64_t backing_bytes = (kRows - 1) * kStride + kRowLen;
+  std::vector<uint8_t> backing(backing_bytes);
+  for (size_t i = 0; i < backing.size(); ++i) {
+    backing[i] = static_cast<uint8_t>((i * 7) % 255);
+  }
+
+  VectorSource base(backing);
+  SelectionPlan plan = build_strided_plan(/*src_base=*/0, kRowLen, kStride, kRows);
+  ViewPlanSource src(&base, plan);
+
+  auto expected = build_strided_expected(backing, /*src_base=*/0, kRowLen, kStride, kRows);
+  const uint64_t offset = 2000;
+  const size_t bytes = 12000;
+  std::vector<uint8_t> out(bytes);
+  auto bytes_or = src.read_at(offset, out.data(), out.size());
+  REQUIRE(bytes_or.ok());
+  CHECK(*bytes_or == out.size());
+
+  const auto slice_start = static_cast<std::vector<uint8_t>::difference_type>(offset);
+  const auto slice_end = static_cast<std::vector<uint8_t>::difference_type>(offset + bytes);
+  std::vector<uint8_t> sliced(expected.begin() + slice_start, expected.begin() + slice_end);
+  CHECK(out == sliced);
+}
+
+TEST_CASE("ViewPlanSource supports concurrent strided read_at", "[view_plan_source]") {
+  constexpr uint64_t kRowLen = 4096;
+  constexpr uint64_t kStride = 8192;
+  constexpr uint64_t kRows = 128;
+  const uint64_t backing_bytes = (kRows - 1) * kStride + kRowLen;
+  std::vector<uint8_t> backing(backing_bytes);
+  for (size_t i = 0; i < backing.size(); ++i) {
+    backing[i] = static_cast<uint8_t>(i % 199);
+  }
+
+  VectorSource base(backing);
+  SelectionPlan plan = build_strided_plan(/*src_base=*/0, kRowLen, kStride, kRows);
+  ViewPlanSource src(&base, plan);
+
+  auto expected = build_strided_expected(backing, /*src_base=*/0, kRowLen, kStride, kRows);
+  std::vector<uint8_t> out_a(kRowLen * 4);
+  std::vector<uint8_t> out_b(kRowLen * 4);
+  absl::StatusOr<size_t> st_a;
+  absl::StatusOr<size_t> st_b;
+
+  std::thread t1([&]() { st_a = src.read_at(0, out_a.data(), out_a.size()); });
+  std::thread t2([&]() { st_b = src.read_at(kRowLen * 10, out_b.data(), out_b.size()); });
+  t1.join();
+  t2.join();
+
+  REQUIRE(st_a.ok());
+  REQUIRE(st_b.ok());
+  CHECK(*st_a == out_a.size());
+  CHECK(*st_b == out_b.size());
+  const auto slice_a_end = static_cast<std::vector<uint8_t>::difference_type>(out_a.size());
+  std::vector<uint8_t> sliced_a(expected.begin(), expected.begin() + slice_a_end);
+  const auto slice_b_start = static_cast<std::vector<uint8_t>::difference_type>(kRowLen * 10);
+  const auto slice_b_end = static_cast<std::vector<uint8_t>::difference_type>(kRowLen * 10 + out_b.size());
+  std::vector<uint8_t> sliced_b(expected.begin() + slice_b_start, expected.begin() + slice_b_end);
+  CHECK(out_a == sliced_a);
+  CHECK(out_b == sliced_b);
 }

--- a/core/store/materialization/dataplane/view/view_plan_source.cc
+++ b/core/store/materialization/dataplane/view/view_plan_source.cc
@@ -51,23 +51,23 @@ struct MetricsHandles {
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>> amplification_ratio;
 };
 
+MetricsHandles init_metrics_handles() {
+  MetricsHandles handles;
+  handles.meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+  handles.base_read_calls = handles.meter->CreateDoubleCounter("tc_view_plan_source_base_read_calls_total");
+  handles.base_read_bytes = handles.meter->CreateDoubleCounter("tc_view_plan_source_base_read_bytes_total");
+  handles.output_bytes = handles.meter->CreateDoubleCounter("tc_view_plan_source_output_bytes_total");
+  handles.pack_bytes = handles.meter->CreateDoubleCounter("tc_view_plan_source_pack_bytes_total");
+  handles.strided_runs = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_runs_total");
+  handles.strided_fallback_runs = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_fallback_runs_total");
+  handles.cache_hits = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_cache_hits_total");
+  handles.cache_misses = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_cache_misses_total");
+  handles.amplification_ratio = handles.meter->CreateDoubleHistogram("tc_view_plan_source_amplification_ratio");
+  return handles;
+}
+
 MetricsHandles& metrics_handles() {
-  static MetricsHandles handles;
-  if (!handles.meter) {
-    handles.meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
-  }
-  if (!handles.base_read_calls) {
-    handles.base_read_calls = handles.meter->CreateDoubleCounter("tc_view_plan_source_base_read_calls_total");
-    handles.base_read_bytes = handles.meter->CreateDoubleCounter("tc_view_plan_source_base_read_bytes_total");
-    handles.output_bytes = handles.meter->CreateDoubleCounter("tc_view_plan_source_output_bytes_total");
-    handles.pack_bytes = handles.meter->CreateDoubleCounter("tc_view_plan_source_pack_bytes_total");
-    handles.strided_runs = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_runs_total");
-    handles.strided_fallback_runs =
-        handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_fallback_runs_total");
-    handles.cache_hits = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_cache_hits_total");
-    handles.cache_misses = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_cache_misses_total");
-    handles.amplification_ratio = handles.meter->CreateDoubleHistogram("tc_view_plan_source_amplification_ratio");
-  }
+  static MetricsHandles handles = init_metrics_handles();
   return handles;
 }
 
@@ -549,7 +549,12 @@ absl::StatusOr<size_t> ViewPlanSource::fill_strided_run(
             stats_.strided_runtime_fallbacks.fetch_add(1, std::memory_order_relaxed);
           }
         }
-        return copy_from_strided_ranges(run, local_offset, out, remaining);
+        const size_t already_copied = bytes - remaining;
+        auto fallback_or = copy_from_strided_ranges(run, local_offset, out, remaining);
+        if (!fallback_or.ok()) {
+          return fallback_or.status();
+        }
+        return already_copied + *fallback_or;
       }
       return block_or.status();
     }

--- a/core/store/materialization/dataplane/view/view_plan_source.cc
+++ b/core/store/materialization/dataplane/view/view_plan_source.cc
@@ -1,19 +1,151 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #include "core/store/materialization/dataplane/view/view_plan_source.h"
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
+#include <map>
+#include <memory>
+#include <new>
+#include <utility>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/synchronization/mutex.h"
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/metrics/meter.h"
+#include "opentelemetry/metrics/provider.h"
 
 namespace tensorcast::store::loader {
 
 namespace {
 
-uint64_t range_end(const SelectionPlan::Range& range) {
-  return range.dst_offset + range.length;
+constexpr uint64_t STRIDED_RUN_MIN_RANGES = 128;
+constexpr uint64_t STRIDED_MIN_ROW_LEN_BYTES = 4096;
+constexpr uint64_t STRIDED_MAX_AMPLIFICATION = 8;
+constexpr uint64_t STRIDED_BLOCK_TARGET_BYTES = 16ULL * 1024 * 1024;
+constexpr uint64_t STRIDED_BLOCK_MAX_BYTES = 64ULL * 1024 * 1024;
+
+struct StridedBlock {
+  size_t run_index{0};
+  uint64_t first_row{0};
+  uint64_t rows{0};
+  uint64_t src_begin{0};
+  std::vector<uint8_t> data;
+};
+
+struct MetricsHandles {
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Meter> meter;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> base_read_calls;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> base_read_bytes;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> output_bytes;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> pack_bytes;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> strided_runs;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> strided_fallback_runs;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> cache_hits;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Counter<double>> cache_misses;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Histogram<double>> amplification_ratio;
+};
+
+MetricsHandles& metrics_handles() {
+  static MetricsHandles handles;
+  if (!handles.meter) {
+    handles.meter = opentelemetry::metrics::Provider::GetMeterProvider()->GetMeter("tensorcast.daemon", "1.0.0");
+  }
+  if (!handles.base_read_calls) {
+    handles.base_read_calls = handles.meter->CreateDoubleCounter("tc_view_plan_source_base_read_calls_total");
+    handles.base_read_bytes = handles.meter->CreateDoubleCounter("tc_view_plan_source_base_read_bytes_total");
+    handles.output_bytes = handles.meter->CreateDoubleCounter("tc_view_plan_source_output_bytes_total");
+    handles.pack_bytes = handles.meter->CreateDoubleCounter("tc_view_plan_source_pack_bytes_total");
+    handles.strided_runs = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_runs_total");
+    handles.strided_fallback_runs =
+        handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_fallback_runs_total");
+    handles.cache_hits = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_cache_hits_total");
+    handles.cache_misses = handles.meter->CreateDoubleCounter("tc_view_plan_source_strided_cache_misses_total");
+    handles.amplification_ratio = handles.meter->CreateDoubleHistogram("tc_view_plan_source_amplification_ratio");
+  }
+  return handles;
 }
+
+void record_view_plan_source_metrics(
+    uint64_t base_read_calls,
+    uint64_t base_read_bytes,
+    uint64_t output_bytes,
+    uint64_t pack_bytes,
+    uint64_t strided_runs,
+    uint64_t strided_fallback_runs,
+    uint64_t cache_hits,
+    uint64_t cache_misses,
+    double amplification_ratio) {
+  try {
+    static const std::map<std::string, opentelemetry::common::AttributeValue> kEmptyAttrs;
+    auto& handles = metrics_handles();
+    handles.base_read_calls->Add(
+        static_cast<double>(base_read_calls),
+        opentelemetry::common::KeyValueIterableView(kEmptyAttrs),
+        opentelemetry::context::Context{});
+    handles.base_read_bytes->Add(
+        static_cast<double>(base_read_bytes),
+        opentelemetry::common::KeyValueIterableView(kEmptyAttrs),
+        opentelemetry::context::Context{});
+    handles.output_bytes->Add(
+        static_cast<double>(output_bytes),
+        opentelemetry::common::KeyValueIterableView(kEmptyAttrs),
+        opentelemetry::context::Context{});
+    handles.pack_bytes->Add(
+        static_cast<double>(pack_bytes),
+        opentelemetry::common::KeyValueIterableView(kEmptyAttrs),
+        opentelemetry::context::Context{});
+    handles.strided_runs->Add(
+        static_cast<double>(strided_runs),
+        opentelemetry::common::KeyValueIterableView(kEmptyAttrs),
+        opentelemetry::context::Context{});
+    handles.strided_fallback_runs->Add(
+        static_cast<double>(strided_fallback_runs),
+        opentelemetry::common::KeyValueIterableView(kEmptyAttrs),
+        opentelemetry::context::Context{});
+    handles.cache_hits->Add(
+        static_cast<double>(cache_hits),
+        opentelemetry::common::KeyValueIterableView(kEmptyAttrs),
+        opentelemetry::context::Context{});
+    handles.cache_misses->Add(
+        static_cast<double>(cache_misses),
+        opentelemetry::common::KeyValueIterableView(kEmptyAttrs),
+        opentelemetry::context::Context{});
+    handles.amplification_ratio->Record(
+        amplification_ratio,
+        opentelemetry::common::KeyValueIterableView(kEmptyAttrs),
+        opentelemetry::context::Context{});
+  } catch (...) {
+    VLOG(1) << "metrics counters tc_view_plan_source_* unavailable";
+  }
+}
+
+bool amplification_within_limit(uint64_t stride, uint64_t row_len) {
+  if (row_len == 0) {
+    return false;
+  }
+  if (STRIDED_MAX_AMPLIFICATION == 0) {
+    return false;
+  }
+  if (row_len > std::numeric_limits<uint64_t>::max() / STRIDED_MAX_AMPLIFICATION) {
+    return false;
+  }
+  return stride <= STRIDED_MAX_AMPLIFICATION * row_len;
+}
+
+} // namespace
+
+struct ViewPlanSource::StridedBlockCache {
+  absl::Mutex mutex;
+  std::shared_ptr<const StridedBlock> block ABSL_GUARDED_BY(mutex);
+};
+
+namespace {
 
 class OwningViewPlanSource final : public SeekableSource {
  public:
@@ -52,13 +184,240 @@ ViewPlanSource::ViewPlanSource(gsl::not_null<SeekableSource*> base, SelectionPla
   std::sort(ranges_.begin(), ranges_.end(), [](const SelectionPlan::Range& a, const SelectionPlan::Range& b) {
     return a.dst_offset < b.dst_offset;
   });
+  build_runs();
+  if (!runs_.empty()) {
+    strided_disabled_ = std::make_unique<std::atomic<uint8_t>[]>(runs_.size());
+    for (size_t idx = 0; idx < runs_.size(); ++idx) {
+      strided_disabled_[idx].store(0, std::memory_order_relaxed);
+    }
+  }
+  if (strided_runs_total_ > 0) {
+    strided_cache_ = std::make_unique<StridedBlockCache>();
+  }
+}
+
+ViewPlanSource::~ViewPlanSource() {
+  const uint64_t base_read_calls = stats_.base_read_calls.load(std::memory_order_relaxed);
+  const uint64_t base_read_bytes = stats_.base_read_bytes.load(std::memory_order_relaxed);
+  const uint64_t output_bytes = stats_.output_bytes.load(std::memory_order_relaxed);
+  const uint64_t pack_bytes = stats_.pack_bytes.load(std::memory_order_relaxed);
+  const uint64_t cache_hits = stats_.cache_hits.load(std::memory_order_relaxed);
+  const uint64_t cache_misses = stats_.cache_misses.load(std::memory_order_relaxed);
+  const uint64_t runtime_fallbacks = stats_.strided_runtime_fallbacks.load(std::memory_order_relaxed);
+  const uint64_t strided_fallback_runs = strided_fallback_runs_total_ + runtime_fallbacks;
+  const double amplification =
+      output_bytes == 0 ? 0.0 : static_cast<double>(base_read_bytes) / static_cast<double>(output_bytes);
+
+  VLOG(1) << "ViewPlanSource summary: output_bytes=" << output_bytes << " base_read_calls=" << base_read_calls
+          << " base_read_bytes=" << base_read_bytes << " pack_bytes=" << pack_bytes
+          << " strided_runs=" << strided_runs_total_ << " strided_fallback_runs=" << strided_fallback_runs
+          << " cache_hits=" << cache_hits << " cache_misses=" << cache_misses << " amplification=" << amplification;
+
+  record_view_plan_source_metrics(
+      base_read_calls,
+      base_read_bytes,
+      output_bytes,
+      pack_bytes,
+      strided_runs_total_,
+      strided_fallback_runs,
+      cache_hits,
+      cache_misses,
+      amplification);
+}
+
+bool ViewPlanSource::should_enable_strided(const ExecutionRun& run) {
+  if (run.rows < STRIDED_RUN_MIN_RANGES) {
+    return false;
+  }
+  if (run.row_len < STRIDED_MIN_ROW_LEN_BYTES) {
+    return false;
+  }
+  if (run.row_len > STRIDED_BLOCK_MAX_BYTES) {
+    return false;
+  }
+  return amplification_within_limit(run.stride, run.row_len);
+}
+
+uint64_t ViewPlanSource::compute_rows_per_block(const ExecutionRun& run) {
+  if (run.stride == 0) {
+    return 1;
+  }
+  uint64_t rows_per_block = STRIDED_BLOCK_TARGET_BYTES / run.stride;
+  if (rows_per_block == 0) {
+    rows_per_block = 1;
+  }
+  uint64_t max_rows = 1;
+  if (STRIDED_BLOCK_MAX_BYTES > run.row_len) {
+    max_rows = 1 + (STRIDED_BLOCK_MAX_BYTES - run.row_len) / run.stride;
+  }
+  if (rows_per_block > max_rows) {
+    rows_per_block = max_rows;
+  }
+  return std::max<uint64_t>(rows_per_block, 1);
+}
+
+void ViewPlanSource::build_runs() {
+  runs_.clear();
+  run_starts_.clear();
+  strided_runs_total_ = 0;
+  strided_fallback_runs_total_ = 0;
+
+  if (ranges_.empty()) {
+    return;
+  }
+
+  runs_.reserve(ranges_.size());
+  size_t idx = 0;
+  while (idx < ranges_.size()) {
+    const auto& range = ranges_[idx];
+    if (range.length == 0) {
+      ++idx;
+      continue;
+    }
+    if (range.kind == SelectionPlan::Range::Kind::kPad) {
+      size_t start = idx;
+      uint64_t dst_begin = range.dst_offset;
+      uint64_t dst_end = dst_begin + range.length;
+      ++idx;
+      while (idx < ranges_.size()) {
+        const auto& next = ranges_[idx];
+        if (next.kind != SelectionPlan::Range::Kind::kPad) {
+          break;
+        }
+        if (next.length == 0 || next.dst_offset != dst_end) {
+          break;
+        }
+        dst_end += next.length;
+        ++idx;
+      }
+      ExecutionRun run;
+      run.kind = ExecutionRun::Kind::kPad;
+      run.dst_begin = dst_begin;
+      run.dst_end = dst_end;
+      run.range_index = start;
+      run.range_count = idx - start;
+      runs_.push_back(run);
+      continue;
+    }
+
+    bool strided_candidate = false;
+    uint64_t stride = 0;
+    if (idx + 1 < ranges_.size()) {
+      const auto& next = ranges_[idx + 1];
+      if (next.kind == SelectionPlan::Range::Kind::kData && next.length == range.length &&
+          next.dst_offset == range.dst_offset + range.length && next.src_offset > range.src_offset) {
+        stride = next.src_offset - range.src_offset;
+        strided_candidate = stride > range.length;
+      }
+    }
+
+    if (strided_candidate) {
+      const size_t start = idx;
+      const uint64_t row_len = range.length;
+      const uint64_t dst_begin = range.dst_offset;
+      const uint64_t src_base = range.src_offset;
+      size_t cursor = idx;
+      uint64_t expected_dst = dst_begin;
+      uint64_t expected_src = src_base;
+      while (cursor < ranges_.size()) {
+        const auto& current = ranges_[cursor];
+        if (current.kind != SelectionPlan::Range::Kind::kData || current.length != row_len ||
+            current.dst_offset != expected_dst || current.src_offset != expected_src) {
+          break;
+        }
+        expected_dst += row_len;
+        expected_src += stride;
+        ++cursor;
+      }
+      const uint64_t rows = static_cast<uint64_t>(cursor - start);
+      ExecutionRun run;
+      run.kind = ExecutionRun::Kind::kStrided;
+      run.dst_begin = dst_begin;
+      run.dst_end = dst_begin + (row_len * rows);
+      run.src_base = src_base;
+      run.row_len = row_len;
+      run.stride = stride;
+      run.rows = rows;
+      run.range_index = start;
+      run.range_count = cursor - start;
+      run.strided_candidate = should_enable_strided(run);
+      if (run.strided_candidate) {
+        run.rows_per_block = compute_rows_per_block(run);
+      } else {
+        ++strided_fallback_runs_total_;
+      }
+      ++strided_runs_total_;
+      runs_.push_back(run);
+      idx = cursor;
+      continue;
+    }
+
+    size_t start = idx;
+    uint64_t dst_begin = range.dst_offset;
+    uint64_t dst_end = dst_begin + range.length;
+    uint64_t src_begin = range.src_offset;
+    uint64_t src_end = src_begin + range.length;
+    ++idx;
+    while (idx < ranges_.size()) {
+      const auto& next = ranges_[idx];
+      if (next.kind != SelectionPlan::Range::Kind::kData) {
+        break;
+      }
+      if (next.dst_offset != dst_end || next.src_offset != src_end) {
+        break;
+      }
+      dst_end += next.length;
+      src_end += next.length;
+      ++idx;
+    }
+    ExecutionRun run;
+    run.kind = ExecutionRun::Kind::kContiguous;
+    run.dst_begin = dst_begin;
+    run.dst_end = dst_end;
+    run.src_begin = src_begin;
+    run.range_index = start;
+    run.range_count = idx - start;
+    runs_.push_back(run);
+  }
+
+  run_starts_.reserve(runs_.size());
+  for (const auto& run : runs_) {
+    run_starts_.push_back(run.dst_begin);
+  }
+}
+
+size_t ViewPlanSource::find_run_index(uint64_t offset) const {
+  if (run_starts_.empty()) {
+    return 0;
+  }
+  auto it = std::upper_bound(run_starts_.begin(), run_starts_.end(), offset);
+  if (it == run_starts_.begin()) {
+    return 0;
+  }
+  return static_cast<size_t>(it - run_starts_.begin() - 1);
+}
+
+absl::StatusOr<size_t> ViewPlanSource::read_base(uint64_t offset, uint8_t* dst, size_t bytes) {
+  if (bytes == 0) {
+    return static_cast<size_t>(0);
+  }
+  stats_.base_read_calls.fetch_add(1, std::memory_order_relaxed);
+  auto read_or = base_->read_at(offset, dst, bytes);
+  if (!read_or.ok()) {
+    return read_or.status();
+  }
+  stats_.base_read_bytes.fetch_add(*read_or, std::memory_order_relaxed);
+  if (*read_or != bytes) {
+    return absl::InternalError("short read while executing view selection plan");
+  }
+  return *read_or;
 }
 
 absl::StatusOr<size_t> ViewPlanSource::copy_from_range(
     const SelectionPlan::Range& range,
     uint64_t range_offset,
     uint8_t* dst,
-    size_t bytes) const {
+    size_t bytes) {
   if (bytes == 0) {
     return static_cast<size_t>(0);
   }
@@ -67,14 +426,154 @@ absl::StatusOr<size_t> ViewPlanSource::copy_from_range(
     return bytes;
   }
   const uint64_t source_offset = range.src_offset + range_offset;
-  auto read_or = base_->read_at(source_offset, dst, bytes);
-  if (!read_or.ok()) {
-    return read_or.status();
+  return read_base(source_offset, dst, bytes);
+}
+
+absl::StatusOr<size_t> ViewPlanSource::copy_from_strided_ranges(
+    const ExecutionRun& run,
+    uint64_t run_offset,
+    uint8_t* dst,
+    size_t bytes) {
+  if (bytes == 0) {
+    return static_cast<size_t>(0);
   }
-  if (*read_or != bytes) {
-    return absl::InternalError("short read while executing view selection plan");
+  if (run.row_len == 0) {
+    return absl::InternalError("invalid strided run row length");
   }
-  return *read_or;
+  const uint64_t first_row = run_offset / run.row_len;
+  uint64_t row_offset = run_offset % run.row_len;
+  size_t range_index = run.range_index + static_cast<size_t>(first_row);
+  const size_t range_limit = run.range_index + run.range_count;
+  size_t remaining = bytes;
+  uint8_t* out = dst;
+
+  while (remaining > 0 && range_index < range_limit) {
+    const auto& range = ranges_[range_index];
+    const size_t available = static_cast<size_t>(range.length - row_offset);
+    const size_t take = std::min(remaining, available);
+    auto copied_or = copy_from_range(range, row_offset, out, take);
+    if (!copied_or.ok()) {
+      return copied_or.status();
+    }
+    out += *copied_or;
+    remaining -= *copied_or;
+    row_offset = 0;
+    ++range_index;
+  }
+  return bytes - remaining;
+}
+
+absl::StatusOr<size_t> ViewPlanSource::fill_strided_run(
+    size_t run_index,
+    const ExecutionRun& run,
+    uint64_t run_offset,
+    uint8_t* dst,
+    size_t bytes) {
+  if (bytes == 0) {
+    return static_cast<size_t>(0);
+  }
+  if (!run.strided_candidate || !strided_cache_) {
+    return copy_from_strided_ranges(run, run_offset, dst, bytes);
+  }
+  if (strided_disabled_ && strided_disabled_[run_index].load(std::memory_order_relaxed) != 0) {
+    return copy_from_strided_ranges(run, run_offset, dst, bytes);
+  }
+  if (run.row_len == 0 || run.rows == 0) {
+    return absl::InternalError("invalid strided run");
+  }
+
+  auto load_block = [&](uint64_t row) -> absl::StatusOr<std::shared_ptr<const StridedBlock>> {
+    if (strided_cache_) {
+      absl::MutexLock lock(&strided_cache_->mutex);
+      const auto cached = strided_cache_->block;
+      if (cached && cached->run_index == run_index && row >= cached->first_row &&
+          row < cached->first_row + cached->rows) {
+        stats_.cache_hits.fetch_add(1, std::memory_order_relaxed);
+        return cached;
+      }
+    }
+
+    stats_.cache_misses.fetch_add(1, std::memory_order_relaxed);
+    const uint64_t rows_per_block = std::max<uint64_t>(run.rows_per_block, 1);
+    const uint64_t block_first_row = row - (row % rows_per_block);
+    uint64_t block_rows = std::min(rows_per_block, run.rows - block_first_row);
+
+    while (block_rows > 0) {
+      const uint64_t block_bytes = (block_rows - 1) * run.stride + run.row_len;
+      if (block_bytes > STRIDED_BLOCK_MAX_BYTES) {
+        block_rows /= 2;
+        continue;
+      }
+      auto block = std::make_shared<StridedBlock>();
+      block->run_index = run_index;
+      block->first_row = block_first_row;
+      block->rows = block_rows;
+      block->src_begin = run.src_base + block_first_row * run.stride;
+      try {
+        block->data.resize(static_cast<size_t>(block_bytes));
+      } catch (const std::bad_alloc&) {
+        block_rows /= 2;
+        continue;
+      }
+      auto read_or = read_base(block->src_begin, block->data.data(), block->data.size());
+      if (!read_or.ok()) {
+        return read_or.status();
+      }
+      if (strided_cache_) {
+        absl::MutexLock lock(&strided_cache_->mutex);
+        strided_cache_->block = block;
+      }
+      return block;
+    }
+
+    return absl::ResourceExhaustedError("unable to allocate strided block buffer");
+  };
+
+  uint64_t local_offset = run_offset;
+  size_t remaining = bytes;
+  uint8_t* out = dst;
+
+  while (remaining > 0) {
+    const uint64_t row = local_offset / run.row_len;
+    uint64_t row_offset = local_offset % run.row_len;
+    if (row >= run.rows) {
+      return absl::InternalError("strided run offset out of range");
+    }
+    auto block_or = load_block(row);
+    if (!block_or.ok()) {
+      if (absl::IsResourceExhausted(block_or.status())) {
+        if (strided_disabled_) {
+          uint8_t expected = 0;
+          if (strided_disabled_[run_index].compare_exchange_strong(
+                  expected, 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
+            stats_.strided_runtime_fallbacks.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+        return copy_from_strided_ranges(run, local_offset, out, remaining);
+      }
+      return block_or.status();
+    }
+    const auto& block = *block_or;
+    const uint64_t block_end_row = block->first_row + block->rows;
+    uint64_t active_row = row;
+    while (remaining > 0 && active_row < block_end_row) {
+      const size_t available = static_cast<size_t>(run.row_len - row_offset);
+      const size_t take = std::min(remaining, available);
+      const uint64_t block_offset = (active_row - block->first_row) * run.stride + row_offset;
+      std::memcpy(out, block->data.data() + block_offset, take);
+      stats_.pack_bytes.fetch_add(take, std::memory_order_relaxed);
+      out += take;
+      remaining -= take;
+      local_offset += take;
+      row_offset += take;
+      if (row_offset == run.row_len) {
+        ++active_row;
+        row_offset = 0;
+      }
+    }
+  }
+
+  return bytes;
 }
 
 absl::StatusOr<size_t> ViewPlanSource::read(void* dst, size_t max_bytes) {
@@ -96,26 +595,44 @@ absl::StatusOr<size_t> ViewPlanSource::read_at(uint64_t offset, void* dst, size_
   size_t copied = 0;
   uint64_t cursor = offset;
 
-  for (const auto& range : ranges_) {
-    if (cursor >= range_end(range)) {
+  size_t run_index = find_run_index(offset);
+  while (run_index < runs_.size() && copied < to_copy) {
+    const auto& run = runs_[run_index];
+    if (cursor >= run.dst_end) {
+      ++run_index;
       continue;
     }
-    if (cursor < range.dst_offset) {
+    if (cursor < run.dst_begin) {
       return absl::InternalError("selection plan contains uncovered gaps");
     }
-    const uint64_t local_offset = cursor - range.dst_offset;
-    const size_t available = static_cast<size_t>(range.length - local_offset);
+    const uint64_t run_offset = cursor - run.dst_begin;
+    const size_t available = static_cast<size_t>(run.dst_end - cursor);
     const size_t chunk = std::min(to_copy - copied, available);
-    auto copied_or = copy_from_range(range, local_offset, out + copied, chunk);
+    absl::StatusOr<size_t> copied_or;
+    switch (run.kind) {
+      case ExecutionRun::Kind::kPad:
+        std::memset(out + copied, 0, chunk);
+        copied_or = chunk;
+        break;
+      case ExecutionRun::Kind::kContiguous:
+        copied_or = read_base(run.src_begin + run_offset, out + copied, chunk);
+        break;
+      case ExecutionRun::Kind::kStrided:
+        copied_or = fill_strided_run(run_index, run, run_offset, out + copied, chunk);
+        break;
+    }
     if (!copied_or.ok()) {
       return copied_or.status();
     }
     copied += *copied_or;
     cursor += *copied_or;
-    if (copied == to_copy) {
+    if (*copied_or == 0) {
       break;
     }
+    ++run_index;
   }
+
+  stats_.output_bytes.fetch_add(copied, std::memory_order_relaxed);
   return copied;
 }
 

--- a/core/store/materialization/dataplane/view/view_plan_source.h
+++ b/core/store/materialization/dataplane/view/view_plan_source.h
@@ -1,7 +1,8 @@
-// Copyright (c) 2025, TensorCast Team.
+// Copyright (c) 2025-2026, TensorCast Team.
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -20,6 +21,7 @@ namespace tensorcast::store::loader {
 class ViewPlanSource final : public SeekableSource {
  public:
   ViewPlanSource(gsl::not_null<SeekableSource*> base, SelectionPlan plan);
+  ~ViewPlanSource() override;
 
   [[nodiscard]] bool alias_eligible() const {
     return alias_eligible_;
@@ -37,14 +39,70 @@ class ViewPlanSource final : public SeekableSource {
   absl::StatusOr<size_t> read_at(uint64_t offset, void* dst, size_t bytes) override;
 
  private:
+  struct ExecutionRun {
+    enum class Kind : uint8_t { kPad = 0, kContiguous = 1, kStrided = 2 };
+
+    Kind kind{Kind::kPad};
+    uint64_t dst_begin{0};
+    uint64_t dst_end{0};
+    uint64_t src_begin{0};
+    uint64_t src_base{0};
+    uint64_t row_len{0};
+    uint64_t stride{0};
+    uint64_t rows{0};
+    uint64_t rows_per_block{0};
+    size_t range_index{0};
+    size_t range_count{0};
+    bool strided_candidate{false};
+  };
+
+  struct Stats {
+    std::atomic<uint64_t> base_read_calls{0};
+    std::atomic<uint64_t> base_read_bytes{0};
+    std::atomic<uint64_t> output_bytes{0};
+    std::atomic<uint64_t> pack_bytes{0};
+    std::atomic<uint64_t> cache_hits{0};
+    std::atomic<uint64_t> cache_misses{0};
+    std::atomic<uint64_t> strided_runtime_fallbacks{0};
+  };
+
+  struct StridedBlockCache;
+
+  void build_runs();
+  [[nodiscard]] size_t find_run_index(uint64_t offset) const;
+  static bool should_enable_strided(const ExecutionRun& run);
+  static uint64_t compute_rows_per_block(const ExecutionRun& run);
+
+  absl::StatusOr<size_t> copy_from_strided_ranges(
+      const ExecutionRun& run,
+      uint64_t run_offset,
+      uint8_t* dst,
+      size_t bytes);
+
+  absl::StatusOr<size_t> fill_strided_run(
+      size_t run_index,
+      const ExecutionRun& run,
+      uint64_t run_offset,
+      uint8_t* dst,
+      size_t bytes);
+
+  absl::StatusOr<size_t> read_base(uint64_t offset, uint8_t* dst, size_t bytes);
+
   absl::StatusOr<size_t> copy_from_range(
       const SelectionPlan::Range& range,
       uint64_t range_offset,
       uint8_t* dst,
-      size_t bytes) const;
+      size_t bytes);
 
   gsl::not_null<SeekableSource*> base_;
   std::vector<SelectionPlan::Range> ranges_;
+  std::vector<ExecutionRun> runs_;
+  std::vector<uint64_t> run_starts_;
+  std::unique_ptr<std::atomic<uint8_t>[]> strided_disabled_;
+  std::unique_ptr<StridedBlockCache> strided_cache_;
+  Stats stats_;
+  uint64_t strided_runs_total_{0};
+  uint64_t strided_fallback_runs_total_{0};
   uint64_t total_bytes_{0};
   bool alias_eligible_{false};
   bool requires_materialization_{false};

--- a/core/store/runtime/ingestion/materialization_facade.cc
+++ b/core/store/runtime/ingestion/materialization_facade.cc
@@ -9,6 +9,7 @@
 #include <functional>
 #include <limits>
 #include <utility>
+#include <vector>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -71,7 +72,12 @@ class PlanBackedSeekableSource final : public loader::SeekableSource {
       std::unique_ptr<loader::SeekableSource> source,
       std::shared_ptr<const std::vector<loader::SegmentPiece>> plan,
       uint64_t total_size)
-      : source_(std::move(source)), plan_(std::move(plan)), total_size_(total_size) {}
+      : source_(std::move(source)), plan_(std::move(plan)), total_size_(total_size) {
+    piece_starts_.reserve(plan_->size());
+    for (const auto& piece : *plan_) {
+      piece_starts_.push_back(piece.dst_offset);
+    }
+  }
 
   absl::StatusOr<size_t> read(void* dst, size_t max_bytes) override {
     auto st = read_at(current_offset_, dst, max_bytes);
@@ -89,14 +95,17 @@ class PlanBackedSeekableSource final : public loader::SeekableSource {
     size_t remaining = static_cast<size_t>(std::min<uint64_t>(bytes, total_size_ - offset));
     auto* out = static_cast<uint8_t*>(dst);
 
-    size_t idx = 0;
-    for (; idx < plan_->size(); ++idx) {
-      const auto& p = (*plan_)[idx];
-      if (offset < p.dst_offset + p.length) {
-        break;
-      }
+    if (piece_starts_.empty()) {
+      return static_cast<size_t>(0);
     }
-    if (idx == plan_->size()) {
+    auto it = std::upper_bound(piece_starts_.begin(), piece_starts_.end(), offset);
+    size_t idx = 0;
+    if (it == piece_starts_.begin()) {
+      idx = 0;
+    } else {
+      idx = static_cast<size_t>(it - piece_starts_.begin() - 1);
+    }
+    if (idx >= plan_->size()) {
       return static_cast<size_t>(0);
     }
 
@@ -129,6 +138,7 @@ class PlanBackedSeekableSource final : public loader::SeekableSource {
  private:
   std::unique_ptr<loader::SeekableSource> source_;
   std::shared_ptr<const std::vector<loader::SegmentPiece>> plan_;
+  std::vector<uint64_t> piece_starts_;
   uint64_t total_size_{0};
   uint64_t current_offset_{0};
 };

--- a/docs/designs/0054-stride-aware-view-plan-source.md
+++ b/docs/designs/0054-stride-aware-view-plan-source.md
@@ -1,0 +1,487 @@
+---
+slug: 0054-stride-aware-view-plan-source
+title: Stride-Aware ViewPlanSource Coalescing for Efficient Narrow Loading (Design)
+areas: ["core", "daemon", "sdk"]
+status: proposed
+created: 2026-01-18
+last_updated: 2026-01-19
+related_code:
+  - docs/benchmarks/20260118-qwen2.5-32b-safetensors-loading-strategies.md
+  - docs/designs/0004-unified-runtime-config.md
+  - docs/designs/0016-artifact-view-v1.md
+  - docs/designs/0042-region-backed-tensor-dict-into.md
+  - docs/designs/0052-deferred-slice-materialization.md
+  - tensorcast/api/store/deferred_loader.py
+  - core/store/runtime/ingestion/materialization_facade.cc
+  - core/store/materialization/dataplane/contracts/{source,sink}.h
+  - core/store/materialization/dataplane/sources/file_partition_source.{h,cc}
+  - core/store/materialization/dataplane/sources/remote_key_source.{h,cc}
+  - core/store/materialization/dataplane/sources/segment_plan_source.{h,cc}
+  - core/store/materialization/dataplane/view/view_planner.{h,cc}
+  - core/store/materialization/dataplane/view/view_plan_source.{h,cc}
+  - core/store/materialization/dataplane/runtime/pump.{h,cc}
+links:
+  predecessors:
+    - ./0052-deferred-slice-materialization.md
+    - ../benchmarks/20260118-qwen2.5-32b-safetensors-loading-strategies.md
+  plan: ../plans/0054-stride-aware-view-plan-source.md
+---
+
+# Summary
+
+Make v1 `narrow` views (especially `axis=1` tensor-parallel column slices) load efficiently in the **existing**
+`MaterializeIntoTarget` data plane by upgrading core `ViewPlanSource` from “per-segment small reads” (IOPS-bound) to
+“stride-aware coalesced reads + packing” (bandwidth-bound), without adding new RPCs or changing SDK semantics.
+
+This design is intentionally aligned with the `DeferredLoader.commit()` north-star in
+`docs/designs/0052-deferred-slice-materialization.md`: deferred mode remains a thin orchestration over
+`TargetLayout + MaterializeIntoTarget`.
+
+# Problem Statement
+
+TensorCast’s deferred slice materialization (vLLM integration) uses:
+
+- SDK: `DeferredLoader.commit()` → one `MaterializeIntoTarget` RPC (`tensorcast/api/store/deferred_loader.py`).
+- Core: `ViewPlanner` creates a `SelectionPlan` for v1 `narrow`.
+- Core: `ViewPlanSource` executes the `SelectionPlan` by calling `base_->read_at(...)` for each `SelectionPlan::Range`.
+
+For tensor-parallel models, `axis=1` slices in row-major storage explode into “per-row segments”:
+
+- Example: `/tmp/vllm-loading-meta-Qwen2.5-32B-Instruct-20260117-211516/tp4/loading-meta.json`
+  - rank0 has `axis1=128` tensors; each has `shape=[5120, 27648]` and slices `axis=1, size=6912` (TP=4).
+  - `axis=1` implies **5120 segments per tensor** → `128 * 5120 = 655,360` segments, plus other tensors → `segments≈656,003`.
+- Benchmark grounding: `docs/benchmarks/20260118-qwen2.5-32b-safetensors-loading-strategies.md` shows:
+  - Strategy B (per-segment reads): TP=4 makespan ≈ **47.8s** (≈0.33 GiB/s) due to fragmented reads/IOPS overhead.
+  - Strategy C (read row-block superset + pack): TP=4 makespan ≈ **6.0s** (≈9 GiB/s), despite ~2× overall read
+    amplification (and ~4× amplification within the `axis=1`-heavy tensors for TP=4).
+
+Today, `ViewPlanSource` effectively behaves like Strategy B for `axis=1` plans. This makes deferred loads unacceptably slow for TP>1.
+
+## Mapping to benchmark strategies
+
+This design is easiest to reason about by mapping it to the benchmark report:
+
+- **Current production behavior (v1 narrow via `ViewPlanSource`)** ≈ Strategy **B**: execute the selection as many small
+  `read_at` calls against the base source (IOPS/syscall bound for `axis=1`).
+- **Proposed behavior (stride-aware coalescing in `ViewPlanSource`)** ≈ Strategy **C**, but with a different pack
+  location:
+  - Strategy C benchmark: disk → GPU staging (contiguous row-block) → `cudaMemcpy2DAsync` pack into output.
+  - This design: disk/P2P → host staging (contiguous row-block) → host pack into the pinned buffer that `pump_ranges`
+    will then ship to GPU via H2D.
+- Strategy **A** (read full payload then pack) and **D** (pre-materialize for reuse) are explicitly out of scope for this
+  change.
+
+# Goals / Non-Goals
+
+## Goals
+
+1) **Make v1 `narrow(axis=1)` bandwidth-bound** in `MaterializeIntoTarget` and thus in `DeferredLoader.commit()`.
+2) **Keep public surfaces unchanged**:
+   - No new daemon RPCs.
+   - No change to `ViewSpec` representation.
+   - No SDK changes required for correctness (though SDK integrations may still adopt plan-first packing for determinism).
+3) **Preserve byte-identical semantics** for all existing view plans:
+   - Output bytes (including PAD=0) must match the current `SelectionPlan` definition.
+   - `view_index_json` and view hashing remain stable (planner unchanged).
+4) **Remain source-agnostic**: optimization applies regardless of disk or P2P backing `SeekableSource`.
+5) **Be safe under concurrency**: `ViewPlanSource::read_at` must remain correct under concurrent calls (e.g., multi-range
+   `pump_ranges`).
+6) **Avoid shifting bottlenecks**: treat range execution as a compiled program (runs + index) and reuse the indexing
+   approach across the wrapper stack (at minimum `ViewPlanSource` and the canonical segment-plan source).
+7) **No new configuration knobs** in Phase 1; enable automatically when the plan shape matches, but gate on a small cost
+   model to avoid pathological read amplification.
+
+## Non-Goals
+
+- Supporting view ops beyond v1 `narrow` (transpose/materialization is out of scope).
+- Achieving theoretical optimality across all storage formats and transports.
+- Introducing new persistence or a new “materialized view cache” format (Strategy D is considered a follow-on workflow).
+- Changing Global Store view-aware routing or replica identity semantics.
+- Enabling direct-write pass-through for views (documented as a follow-on once coalescing is stable).
+
+# Current State (Grounding)
+
+The view path inside `MaterializeIntoTarget` (`core/store/runtime/ingestion/materialization_facade.cc`) is:
+
+1) Wrap base artifact source into `PlanBackedSeekableSource` (canonical segment plan).
+2) If a view is requested, wrap again into `ViewPlanSource` using `view_plan.selection`.
+3) Stream from source into GPU via `pump_ranges` and `TargetLayoutGpuSink`.
+
+`ViewPlanSource::read_at` (`core/store/materialization/dataplane/view/view_plan_source.cc`) currently:
+
+- Stores `SelectionPlan::ranges` and sorts by `dst_offset`.
+- For each `read_at(offset, dst, bytes)` call, scans **all ranges** and for each overlapped `DATA` range calls `base_->read_at(...)`.
+
+This creates two compounding problems for large `axis=1` plans:
+
+- **IOPS/syscall explosion**: `~655k` base reads per rank (Qwen2.5-32B TP4).
+- **CPU overhead explosion**: O(number_of_ranges) scanning per `read_at` call.
+
+There are two additional system-level constraints worth calling out early:
+
+- **Wrapper-stack CPU can become the next bottleneck**: `MaterializeIntoTarget` always wraps the base source in a
+  canonical segment-plan source (`PlanBackedSeekableSource`, implemented in
+  `core/store/runtime/ingestion/materialization_facade.cc`). Today it also uses a linear scan to find the first segment
+  piece overlapped by `read_at`. Once `ViewPlanSource` is made O(log N), this wrapper can become the next hot path for
+  large canonical plans.
+- **Direct-write capability exists, but should not be accidentally blocked long-term**:
+  - `pump_ranges` supports a direct-write fast path when the source implements `SeekableSource::supports_direct_write` /
+    `read_into` and the sink implements `DirectWriteCapable` (`core/store/materialization/dataplane/runtime/pump.{h,cc}`,
+    `core/store/materialization/dataplane/contracts/{source,sink}.h`).
+  - The `MaterializeIntoTarget` GPU sink (`TargetLayoutGpuSink`) is not `DirectWriteCapable` today, so 0054 does not
+    target an immediate “RDMA direct-to-GPU” win. However, the view execution layer should preserve capabilities where it
+    can so future pipelines (CPU VA sinks today; potential GPU direct-write sinks later) do not require a redesign.
+
+# Root Cause (Global)
+
+The `axis=1` slowdown is a structural mismatch between the *plan representation* and the *execution strategy*:
+
+1) **`SelectionPlan` is byte-accurate, not I/O-optimal**. The planner emits a scatter/gather mapping from canonical
+   ByteSpace (AVBS) to view ByteSpace. For `axis=1` narrow in row-major storage, the “minimal-byte” representation
+   naturally degenerates into “many equal-width, fixed-stride ranges” (one per row). Executing that literally is
+   minimal-bytes but maximal-IOPS.
+2) **The executor interprets the plan repeatedly**. `ViewPlanSource::read_at` currently scans all ranges per call and
+   issues base reads per overlapped segment. This compounds CPU overhead with IOPS overhead.
+3) **The wrapper stack can duplicate the same anti-pattern**. When multiple sources in the pipeline are range-driven,
+   each layer risks re-introducing O(N) scanning. Fixing `ViewPlanSource` alone can merely move the CPU bottleneck.
+
+Design principle for 0054: treat view execution as a small, compiled “execution program” (runs + index + strategy
+selection), and apply the same indexing idea to adjacent range-driven wrappers in the pipeline.
+
+# Architecture & Interfaces
+
+## Existing Data Plane (No Surface Change)
+
+```mermaid
+sequenceDiagram
+  participant SDK as SDK (DeferredLoader)
+  participant D as StoreDaemon
+  participant MF as MaterializationFacade
+  participant VP as ViewPlanner
+  participant VS as ViewPlanSource
+  participant P as pump_ranges
+  participant IO as Disk or P2P SeekableSource
+  participant GPU as TargetLayoutGpuSink
+
+  SDK->>D: MaterializeIntoTarget(view=narrow, TargetLayout)
+  D->>MF: materialize_into_target(...)
+  MF->>VP: compute_view_plan(canonical_index, view_spec)
+  MF->>IO: open_source()
+  MF->>VS: make_view_plan_source(IO, selection_plan)
+  MF->>P: pump_ranges(VS, GPU)
+  P->>VS: read_at(offset, bytes)
+  VS->>IO: read_at(...) (many small reads today)
+  P->>GPU: write_at(...)
+```
+
+## Proposed Change: Stride-Aware Execution Inside ViewPlanSource
+
+Keep the `SelectionPlan` format unchanged, but change **how it is executed**:
+
+- Preprocess `SelectionPlan::ranges` into a compact set of **execution runs**.
+- Execute each run using the most efficient strategy:
+  - `PAD` runs: `memset(0)`.
+  - `CONTIGUOUS` data runs: a single `base_->read_at(...)`.
+  - `STRIDED` data runs (axis=1-like): read **contiguous supersets** (“row blocks”) from base and **pack** into the
+    output buffer.
+    - Use a small, bounded cache to avoid redundant base reads under `pump_ranges` chunking.
+    - Enable only when a cheap cost model predicts a net win (bounded amplification, sufficient run length).
+
+This yields Strategy C-like behavior while keeping the view planner stable.
+
+## Internal Execution Model
+
+`ViewPlanSource` should behave like a compiled “execution program”, not a per-call interpreter:
+
+- Construction: `SelectionPlan` → `ExecutionRun` list → `runs_` + index tables.
+- Execution: each `read_at(offset, ...)` resolves overlapped runs via the index and executes them with the best available
+  strategy (PAD fill, contiguous read, or strided coalesced read+pack).
+
+### Execution Runs
+
+`SelectionPlan::Range` remains the canonical definition; `ViewPlanSource` derives `ExecutionRun` objects:
+
+- `PadRun`: `[dst_begin, dst_end)`; fill zeros.
+- `ContiguousRun`: `(src_begin, dst_begin, length)`; one `base_->read_at(src_begin + delta, ...)`.
+- `StridedRun`: repeated equal-length ranges where:
+  - all are `DATA`,
+  - `range[i+1].dst_offset == range[i].dst_offset + row_len`,
+  - `range[i+1].src_offset == range[i].src_offset + stride_bytes`,
+  - `stride_bytes > row_len` and `run_length` exceeds a small threshold.
+
+For a `StridedRun`, we store:
+
+- `src_base` (first `src_offset`)
+- `dst_base` (first `dst_offset`)
+- `row_len_bytes` (range length)
+- `stride_bytes` (`src_offset[i+1] - src_offset[i]`)
+- `rows` (count)
+
+### Run Indexing (CPU Scalability)
+
+The current implementation pays O(number_of_ranges) per `read_at` call by linearly scanning `ranges_`.
+This design makes `read_at` scalable by indexing the derived execution runs:
+
+- Build `runs_` sorted by `dst_begin` (the view-byte offset space).
+- Maintain a parallel `run_starts_` vector of `dst_begin` values.
+- For each `read_at(offset, ...)`, use `upper_bound(run_starts_, offset)` to locate the first run that may overlap the
+  requested interval, then walk forward while the destination cursor remains within the request.
+
+This yields `read_at` cost O(log R + M) where R is number of runs and M is the number of overlapped runs, eliminating the
+per-call full scan. (The plan in `docs/plans/0054-stride-aware-view-plan-source.md` treats this as Phase 1.)
+
+### Avoiding Shifted CPU Bottlenecks: Index the Canonical Segment Plan Too
+
+`MaterializeIntoTarget` always includes a canonical segment-plan source in the stack (currently
+`PlanBackedSeekableSource` in `core/store/runtime/ingestion/materialization_facade.cc`). It executes a
+`std::vector<loader::SegmentPiece>` produced by
+`build_segment_plan_from_canonical_index_json(...)`
+(`core/store/materialization/dataplane/sources/segment_plan_source.{h,cc}`).
+
+Today that wrapper uses a linear scan to find the first `SegmentPiece` overlapped by `read_at`. Once `ViewPlanSource`
+becomes O(log N), this wrapper can become the next CPU bottleneck.
+
+Recommendation: apply the same “range program + index” approach to the canonical segment-plan source, either by:
+
+- extracting a small reusable `RangeIndex` helper and using it in both wrappers, or
+- refactoring `PlanBackedSeekableSource` into a reusable dataplane source (sibling to `LinearizedGpuPlanSource`) to
+  avoid duplicating plan execution logic.
+
+This is a pure execution detail: it does not change canonical plan semantics (PAD=0, short reads are errors).
+
+### StridedRun Execution (Row-Block Superset + Pack)
+
+Define a row-block by `(block_first_row, block_rows)` where:
+
+- `block_first_row` is 0-based and relative to the `StridedRun`.
+- `block_rows >= 1`.
+
+The minimal contiguous superset in source space that covers the selected bytes for the block is:
+
+- `src_begin = src_base + block_first_row * stride_bytes`
+- `src_len = (block_rows - 1) * stride_bytes + row_len_bytes`
+
+This avoids reading beyond the last row’s selected bytes (important when `column_start > 0`).
+
+`ViewPlanSource::read_at` maps the requested view interval onto (row indices, within-row offsets), reads one or more
+row blocks from the base source, then copies the selected `row_len_bytes` pieces into the destination buffer.
+
+### Block Sizing and Caching
+
+To avoid redundant reads due to `pump_ranges` chunk boundaries, `ViewPlanSource` maintains a small per-instance cache for
+the current `StridedRun`:
+
+- Cache unit: a “row block” of `rows_per_block` rows.
+- Target block size: ~8–16 MiB of source bytes (heuristic), capped to a reasonable maximum.
+- Cache policy: single-block (replace-on-miss) scoped to a single `StridedRun` at a time.
+
+This is sufficient because `pump_ranges` typically performs sequential reads over a single target range for deferred
+loading (single packed CUDA arena).
+
+### Concurrency & Thread Safety
+
+`pump_ranges` may run multiple producer threads and call `SeekableSource::read_at` concurrently when multiple ranges are
+pumped (e.g., multiple target storages). Therefore:
+
+- All preprocessed execution state (`ranges_`/`runs_`/indices) must be immutable after construction.
+- Any mutable cache state must be **thread-safe**.
+  - The strided block cache is best-effort and must be correct under concurrency.
+  - Implementation guideline: protect cache state with a small mutex, and keep the lock off the hot path for PAD and
+    contiguous runs.
+
+This design does not rely on a “single-thread sequential read” assumption for correctness.
+However, the common deferred-loading path typically pumps a single large, contiguous view range into one packed arena,
+which means reads tend to be mostly sequential; the cache is designed to capture that common case without making it a
+hard requirement.
+
+### Heuristics & Cost Model (Default-On, Bounded)
+
+Stride-aware coalescing trades extra bytes for fewer IOPS / fewer syscalls / fewer P2P round-trips. To avoid pathological
+cases (tiny `row_len_bytes` with huge `stride_bytes`), enable `StridedRun` execution only when:
+
+- The run is long enough: `rows >= STRIDED_RUN_MIN_RANGES`.
+- The expected amplification is bounded: `stride_bytes / row_len_bytes <= STRIDED_MAX_AMPLIFICATION`.
+- The row width is non-trivial: `row_len_bytes >= STRIDED_MIN_ROW_LEN_BYTES`.
+
+If any gate fails, fall back to the baseline execution (range-wise reads) for that run.
+
+#### Amplification: Define It Explicitly
+
+For a `StridedRun`, the asymptotic read amplification is approximately:
+
+```
+amplification ≈ stride_bytes / row_len_bytes
+```
+
+For `axis=1` narrow in a contiguous row-major 2D tensor, `stride_bytes` is the full-row byte width and `row_len_bytes` is
+the selected column slice width. For the Qwen2.5-32B TP=4 case in the benchmark, `27648 / 6912 = 4×` amplification for
+those tensors.
+
+The design gates on this ratio to ensure we never trade “millions of extra bytes” for “saving a few syscalls”.
+
+#### Initial Heuristic Defaults (Tunable Later)
+
+This design keeps Phase 1 knob-free, but the implementation still needs concrete defaults. Reasonable initial values:
+
+- `STRIDED_RUN_MIN_RANGES = 128` (avoid paying setup overhead for short runs)
+- `STRIDED_MIN_ROW_LEN_BYTES = 4096` (don’t coalesce tiny slices; overhead dominates)
+- `STRIDED_MAX_AMPLIFICATION = 8` (covers common TP up to 8; keeps bytes bounded)
+- `STRIDED_BLOCK_TARGET_BYTES = 16 * 1024 * 1024` (target MiB-scale base reads)
+- `STRIDED_BLOCK_MAX_BYTES = 64 * 1024 * 1024` (hard cap on transient buffer size)
+
+Follow-on (post-stabilization): move these into the unified runtime config (`docs/designs/0004-unified-runtime-config.md`)
+as internal engine tuning and/or a kill-switch for safe rollback without code reverts.
+
+### Capability Preservation (Follow-on): Direct Write Pass-Through Where Possible
+
+Even though `MaterializeIntoTarget` (GPU sink) does not use the direct-write path today, range wrappers should preserve
+capabilities where they can:
+
+- For `ContiguousRun` (and potentially “single `DATA` range” cases), `ViewPlanSource` can safely pass through
+  `supports_direct_write` and `read_into` to its base source by translating view offsets into base offsets.
+- For `StridedRun` / `PadRun`, direct-write is not generally possible without adding a new “scatter direct write”
+  interface; these should remain staged.
+- For the canonical segment-plan wrapper (`PlanBackedSeekableSource`), direct-write could be supported when the requested
+  interval maps to a single `DATA` `SegmentPiece`. This keeps the door open for CPU VA sinks today and potential GPU
+  direct-write sinks later.
+
+## Naming Compliance
+
+This design introduces only **internal core implementation** artifacts (no new public RPC or SDK API). Any new C++ symbols
+introduced to support the change must follow repository naming rules:
+
+- Types: `ExecutionRun`, `StridedRun`, `StridedBlockCache` (`PascalCase`)
+- Functions: `build_runs`, `is_strided_run`, `fill_strided_run` (`snake_case`)
+- Constants: `STRIDED_RUN_MIN_RANGES`, `STRIDED_BLOCK_TARGET_BYTES` (`ALL_CAPS`)
+  - Additional constants expected: `STRIDED_MAX_AMPLIFICATION`, `STRIDED_MIN_ROW_LEN_BYTES`
+
+# Invariants & Error Model
+
+## Invariants
+
+- **Byte-identical** with existing semantics: executing a `SelectionPlan` produces the same view byte space as today.
+- PAD bytes are always **zero**.
+- Short reads from the base source are treated as errors (never silently accepted).
+- `SelectionPlan::ranges` are expected to be non-overlapping and gap-free in destination space, covering
+  `[0, total_bytes)`. `ViewPlanSource` treats any uncovered gap as an internal error to fail-fast on planner bugs.
+- Optimizations are **purely an execution detail**: planner output (`SelectionPlan`, `view_index_json`) is unchanged.
+
+## Error Model
+
+- Any base `read_at` failure propagates as the existing materialization failure (`DATA_LOSS` from the daemon’s
+  materialization path).
+- Cache allocation failures are treated as **performance degradation**, not correctness failures:
+  - First try a smaller block size (bounded retries).
+  - If allocation still fails, disable caching / strided mode for the affected run and fall back to baseline execution.
+
+# Trade-offs & Alternatives
+
+## Why not Strategy A (read full payload + GPU pack)?
+
+- It requires reading full payload and/or staging the full tensor payload, which is incompatible with the goal of
+  making TP>1 slice loads “pay only for what you need” at the workflow level, and may exceed VRAM.
+
+## Why not keep minimal-byte reads (current behavior)?
+
+- The benchmark shows it is fundamentally IOPS-bound for `axis=1` and can be ~25× slower than the sequential bandwidth
+  limit; hot cache does not rescue it.
+
+## Why not change the planner output (SelectionPlan v2 / explicit StridedRun IR)?
+
+- `SelectionPlan` is already part of the v1 view contract described in `docs/designs/0016-artifact-view-v1.md`.
+- Changing its format would risk destabilizing `view_index_json` / view hashing and require coordinated changes across
+  multiple executors (retrieval + ingestion) with much higher blast radius.
+- 0054’s objective is to keep the planner stable and improve execution. A future design may introduce an internal “view
+  execution program” IR, but it should remain an executor-internal compilation result, not a new external contract.
+
+## Why CPU pack inside ViewPlanSource (vs GPU pack)?
+
+- CPU pack keeps the change localized: `SelectionPlan` remains stable; `pump_ranges` and `TargetLayoutGpuSink` are
+  unchanged; no new GPU staging buffers or CUDA kernels are required.
+- The workload is primarily disk/P2P bandwidth-bound; a single extra host memcpy of the selected bytes is typically much
+  cheaper than IOPS overhead.
+
+**Important clarification:** this design does **not** introduce `cudaMemcpy2DAsync` or a GPU D2D pack phase.
+
+- The “pack” in this design happens **on the host** inside `ViewPlanSource::read_at(...)` by copying selected bytes from a
+  contiguous “row-block” read buffer into the destination host buffer passed by `pump_ranges`.
+- The only GPU copy in the mainline pipeline remains **H2D** (pinned host → target GPU) via `TargetLayoutGpuSink` /
+  `GpuMemorySink` (implemented through `AsyncCopyManager::submit_h2d`, i.e. `cudaMemcpyAsync` H2D).
+
+GPU-side pack (e.g., `cudaMemcpy2DAsync` D2D) remains a potential follow-on if profiling shows host CPU becomes the
+bottleneck. Implementing it cleanly would require introducing a GPU staging step (disk/P2P → pinned host → GPU staging)
+and a pack stage that can issue batched 2D copies into the final target buffer; that does not fit the current
+`SeekableSource` → `pump_ranges` → `PositionedSink` contract without additional internal interfaces.
+
+## Follow-on Workflow: Strategy D (materialize once, load many)
+
+If users repeatedly load the same `loading-meta.json` (same TP plan), pre-materializing the packed output for each rank
+into a contiguous artifact (and publishing it) can reduce total bytes read under multi-rank cold-load contention. This is
+orthogonal and can be layered on top once the default view execution is bandwidth-bound.
+
+# Risks & Mitigations
+
+- **Incorrect strided inference → silent corruption**
+  - Mitigation: keep baseline execution available per-run; add byte-identical equivalence tests that compare the new
+    executor against the current implementation for randomized plans, plus dedicated strided boundary tests.
+- **Memory pressure / fragmentation from row-block buffers**
+  - Mitigation: strict caps (`STRIDED_BLOCK_MAX_BYTES`), single-block cache per run, and graceful fallback (disable cache
+    or disable strided execution for that run).
+- **Lock contention under concurrency**
+  - Mitigation: cache is best-effort; keep mutex off PAD/contiguous hot paths; correctness must not depend on cache hits.
+- **Read amplification increases multi-rank cold-load contention**
+  - Mitigation: keep amplification bounded by policy; use metrics to observe amplification; treat Strategy D
+    (materialize-once, load-many) as the longer-term escape hatch.
+- **CPU becomes the next bottleneck after IOPS is fixed**
+  - Mitigation: measure pack bytes and CPU time; if needed, follow-on GPU pack (`cudaMemcpy2DAsync`) can be introduced as
+    an internal stage once the interface boundaries are ready.
+
+# Compatibility & Acceptance Criteria
+
+Compatibility:
+
+- No changes to protos, RPC surfaces, or SDK APIs.
+- No changes to view IDs, view hashing, or index formats.
+- Works with disk-backed and P2P-backed sources.
+
+Acceptance criteria (functional):
+
+- For any `SelectionPlan`, the new execution produces byte-identical output vs. the current implementation.
+- PAD=0 semantics are preserved.
+
+Acceptance criteria (performance, grounded by Qwen2.5-32B TP4):
+
+- `MaterializeIntoTarget(view=narrow(axis=1))` no longer performs O(650k) base `read_at` calls per rank; it should drop by
+  at least two orders of magnitude for the TP=4 Qwen2.5-32B plan shape.
+- The base-source `read_at` average size increases into the MiB range for strided-heavy plans (row-block behavior).
+- CPU overhead is no longer dominated by per-call linear scans:
+  - `ViewPlanSource::read_at` is O(log runs + overlapped runs).
+  - The canonical segment-plan wrapper is also indexed so the bottleneck does not shift.
+- End-to-end throughput trends toward Strategy C behavior in `docs/benchmarks/20260118-qwen2.5-32b-safetensors-loading-strategies.md`
+  for the same plan shape (bandwidth-bound rather than IOPS-bound).
+
+## Observability (Required for Validation)
+
+To make performance regressions diagnosable, `ViewPlanSource` should emit per-instance summary logging at `VLOG(1)` and
+optionally expose metrics counters (names illustrative):
+
+- `VLOG(1)` summary should include: output bytes, base read calls/bytes, pack bytes, strided run count, fallback run
+  count, cache hits/misses, and an observed amplification ratio.
+- `tc_view_plan_source_base_read_calls_total`
+- `tc_view_plan_source_base_read_bytes_total`
+- `tc_view_plan_source_output_bytes_total`
+- `tc_view_plan_source_strided_runs_total`
+- `tc_view_plan_source_strided_fallback_runs_total` (heuristic-gated or error fallback)
+- `tc_view_plan_source_strided_cache_hits_total` / `tc_view_plan_source_strided_cache_misses_total`
+- `tc_view_plan_source_pack_bytes_total`
+- `tc_view_plan_source_amplification_ratio` (histogram; per-run or per-instance)
+
+# References
+
+- `docs/benchmarks/20260118-qwen2.5-32b-safetensors-loading-strategies.md`
+- `docs/designs/0016-artifact-view-v1.md`
+- `docs/designs/0004-unified-runtime-config.md`
+- `docs/designs/0052-deferred-slice-materialization.md`
+- `docs/designs/0042-region-backed-tensor-dict-into.md`
+- `core/store/materialization/dataplane/view/view_planner.{h,cc}`
+- `core/store/materialization/dataplane/view/view_plan_source.{h,cc}`

--- a/docs/plans/0054-stride-aware-view-plan-source.md
+++ b/docs/plans/0054-stride-aware-view-plan-source.md
@@ -1,0 +1,104 @@
+---
+slug: 0054-stride-aware-view-plan-source
+title: Plan - Stride-Aware ViewPlanSource Coalescing for Efficient Narrow Loading
+links:
+  design: ../designs/0054-stride-aware-view-plan-source.md
+areas:
+  - core
+  - daemon
+  - sdk
+related_code:
+  - docs/benchmarks/20260118-qwen2.5-32b-safetensors-loading-strategies.md
+  - docs/designs/0004-unified-runtime-config.md
+  - docs/designs/0016-artifact-view-v1.md
+  - tensorcast/api/store/deferred_loader.py
+  - core/store/runtime/ingestion/materialization_facade.cc
+  - core/store/materialization/dataplane/contracts/{source,sink}.h
+  - core/store/materialization/dataplane/sources/segment_plan_source.{h,cc}
+  - core/store/materialization/dataplane/view/view_plan_source.{h,cc}
+  - core/store/materialization/dataplane/view/view_planner.{h,cc}
+  - core/store/materialization/dataplane/runtime/pump.{h,cc}
+  - core/store/materialization/dataplane/view/tests/view_plan_source_test.cc
+---
+
+# Objective
+
+Make `MaterializeIntoTarget` + v1 `narrow(axis=1)` views fast enough for TP>1 vLLM deferred loading by turning fragmented
+selection execution (IOPS-bound) into stride-aware coalesced reads + packing (bandwidth-bound), without introducing new
+RPCs.
+
+# Current State & Grounding
+
+- `DeferredLoader.commit()` uses a single `MaterializeIntoTarget` call (`tensorcast/api/store/deferred_loader.py`).
+- View planning emits per-row segments for `axis=1` narrow (`core/store/materialization/dataplane/view/view_planner.cc`).
+- `ViewPlanSource::read_at` executes the selection with many base `read_at` calls and an O(N) scan of `ranges`
+  (`core/store/materialization/dataplane/view/view_plan_source.cc`).
+- `MaterializeIntoTarget` wraps the base source in a canonical segment-plan source (`PlanBackedSeekableSource` in
+  `core/store/runtime/ingestion/materialization_facade.cc`), which also does a linear scan per `read_at` today.
+- Benchmark grounding (`docs/benchmarks/20260118-qwen2.5-32b-safetensors-loading-strategies.md`): TP=4 Strategy B is ~8×
+  slower than C due to fragmented reads.
+
+# Phases & Milestones
+
+- [x] Phase 1: Compile + index range execution (CPU scalability)
+  - [x] Milestone 1: Replace per-call linear scans with indexed lookup so `read_at` is O(log N + K) where K is overlapped
+        runs/pieces:
+        - `ViewPlanSource` (view selection execution).
+        - Canonical segment-plan source (`PlanBackedSeekableSource` or a refactored reusable source).
+  - [x] Milestone 2: Add unit tests covering large plans (including PAD) and multi-range `read_at` spanning many segments.
+  - [x] Milestone 3: Preserve correctness under concurrent `read_at` calls (multi-range pumping); avoid shared mutable
+        state without synchronization.
+
+- [x] Phase 2: Add stride-aware coalescing (I/O + pack)
+  - [x] Milestone 1: Detect `axis=1`-like strided runs from `SelectionPlan::ranges` (equal width, constant src stride).
+  - [x] Milestone 2: Implement row-block superset reads + pack-to-dst in `ViewPlanSource`, including partial reads that
+        start/end mid-row and span row boundaries.
+  - [x] Milestone 3: Add a small per-instance block cache to avoid redundant reads under `pump_ranges` chunking; keep it
+        bounded and thread-safe.
+  - [x] Milestone 4: Add gating heuristics (min run length, min row bytes, max amplification) + decision logging, and
+        robust fallback to baseline execution.
+
+- [ ] Phase 3: Validate, observe, and document
+  - [ ] Milestone 1: Add a reproducible benchmark run (or extend existing benchmark harness) that exercises
+        `MaterializeIntoTarget` with a view spec matching the vLLM TP=4 shape.
+  - [x] Milestone 2: Add observability (VLOG summary + counters) so base read calls/bytes, pack bytes, amplification, and
+        cache hit rates are visible in perf runs.
+  - [x] Milestone 3: Update module docs if behavior/constraints change (e.g., `core/store/materialization/README.md` or
+        `core/store/materialization/dataplane/README.md`).
+
+- [ ] Phase 4: Follow-ons (post-0054; long-term consistency)
+  - [ ] Milestone 1: Preserve direct-write capability through range wrappers where it is semantically safe (contiguous
+        runs/pieces), and add integration coverage using `pump_ranges` direct-write tests.
+  - [ ] Milestone 2: Add internal tuning / kill-switch via unified runtime config (`docs/designs/0004-unified-runtime-config.md`)
+        once the optimization is stable (no ad-hoc ENV/flags).
+  - [ ] Milestone 3: Track Strategy D (“materialize once, load many”) and view-aware routing as a separate follow-on
+        design/plan (aligned with `docs/designs/0052-deferred-slice-materialization.md`).
+
+# Tasks
+
+- [x] Implementation: `core/store/materialization/dataplane/view/view_plan_source.{h,cc}`
+- [x] Implementation: `core/store/runtime/ingestion/materialization_facade.cc` (canonical segment-plan wrapper indexing)
+- [x] Tests: add/extend view dataplane tests under `core/store/materialization/dataplane/view/tests/`
+- [ ] Benchmarks: validate against the Qwen2.5-32B TP=4 `loading-meta.json` plan shape
+- [x] Telemetry: add minimal metrics for base read calls/bytes + cache hit/miss + pack bytes + amplification
+
+# Test / Rollout / Backout
+
+- Tests:
+  - Determinism: byte-identical output vs. baseline for random `SelectionPlan` inputs.
+  - Strided correctness: synthetic plan with `stride_bytes > row_len_bytes` and partial reads crossing row boundaries.
+  - Large plan coverage: ensure no O(N) behavior remains for 600k+ ranges.
+  - Concurrency: concurrent `read_at` over disjoint offsets does not race/crash and remains correct.
+- Rollout:
+  - Default-on (heuristic-detected) inside core; no user-facing config.
+- Backout:
+  - Preserve baseline execution paths so the optimization can be removed via a simple revert if needed.
+  - Follow-on: once stable, prefer a unified-config kill-switch over a code revert.
+
+# Risks & Tracking
+
+- Heuristic false-positives: stride detection must preserve correctness; fallback must be robust.
+- Shifted bottleneck: once `ViewPlanSource` is indexed, `PlanBackedSeekableSource` (or equivalent) must not remain O(N).
+- Memory footprint: block cache size must be bounded and avoid fragmentation.
+- Concurrency: ensure thread safety for `read_at` under potential multi-range pumping.
+- Read amplification: bounded by policy; multi-rank cold-load contention should be monitored and motivates Strategy D.


### PR DESCRIPTION
…fficient narrow loading

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes view execution bandwidth-oriented and CPU-scalable.
> 
> - Compiles `SelectionPlan` into indexed `runs` (PAD/CONTIGUOUS/STRIDED) for O(log R) `read_at` and eliminates per-call linear scans
> - Adds stride-aware coalesced reads for `STRIDED` runs with row-block staging + host packing, bounded by heuristics (min rows/row bytes, max amplification); thread-safe block cache; PAD=0 preserved
> - Emits `VLOG(1)` summaries and OpenTelemetry counters (read calls/bytes, pack bytes, cache hits/misses, amplification)
> - Optimizes canonical segment-plan execution in `MaterializationFacade` via binary search over piece starts
> - Updates BUILD deps; adds tests for coalescing, partial reads across rows, and concurrent `read_at`; README + design/plan docs added
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b46da597d7a2e0ef95561676b466e1e0dfe1981. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->