### PR TITLE
Dev fix

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -351,6 +351,5 @@ jobs:
           uv run pytest tests/python/ -v --tb=short
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/tensorcast/lib:${{ env.LD_LIBRARY_PATH }}
-          GLIBC_TUNABLES: glibc.rtld.optional_static_tls=4096
           TENSORCAST_CUDA_BACKEND: fake
         shell: bash

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,6 +51,13 @@ single_version_override(
     version = "0.7.1",
 )
 
+single_version_override(
+    module_name = "jemalloc",
+    patch_strip = 1,
+    patches = ["//third_party/jemalloc/patches:0001-disable-initial-exec-tls.patch"],
+    version = "5.3.0-bcr.alpha.4",
+)
+
 protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
 protoc.toolchain(
     google_protobuf = "protobuf",

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ BUILD_CORE=1 BUILD_EXTENSION=1 uv run -vvv setup.py build_ext
   rm -f external && ln -s $(bazel info output_base)/external external
   ```
 
+- If importing `tensorcast._C` fails with `cannot allocate memory in static TLS block`, rebuild on the latest `main` (TensorCast disables jemalloc initial-exec TLS to make `dlopen()` safe). As a temporary workaround for older builds, run with `GLIBC_TUNABLES=glibc.rtld.optional_static_tls=32768`.
+
 ### Run services (local)
 
 ```bash

--- a/third_party/jemalloc/patches/0001-disable-initial-exec-tls.patch
+++ b/third_party/jemalloc/patches/0001-disable-initial-exec-tls.patch
@@ -1,0 +1,16 @@
+diff --git a/include/jemalloc/internal/BUILD.bazel b/include/jemalloc/internal/BUILD.bazel
+index 8bd966f..3b33741 100644
+--- a/include/jemalloc/internal/BUILD.bazel
++++ b/include/jemalloc/internal/BUILD.bazel
+@@ -314,8 +314,8 @@ configure_header(
+         define_macro_if("JEMALLOC_MALLOC_THREAD_CLEANUP", "@platforms//os:freebsd") |
+         # JEMALLOC_THREADED_INIT: GNU systems
+         define_macro_if("JEMALLOC_THREADED_INIT", "//settings/platform:gnu") |
+-        # JEMALLOC_TLS_MODEL: Assume initial-exec TLS on modern systems
+-        define_macro_if_with("JEMALLOC_TLS_MODEL", "//settings/platform:posix", "__attribute__((tls_model(\"initial-exec\")))") |
++        # JEMALLOC_TLS_MODEL: Keep dlopen-friendly (avoid initial-exec static TLS).
++        define_macro_if_with("JEMALLOC_TLS_MODEL", "//settings/platform:posix", "") |
+         # JEMALLOC_DEBUG: Configurable flag
+         define_macro_if("JEMALLOC_DEBUG", "//settings/flags:debug") |
+         # JEMALLOC_STATS: Configurable flag
+         define_macro_if("JEMALLOC_STATS", "//settings/flags:stats") |

--- a/third_party/jemalloc/patches/BUILD
+++ b/third_party/jemalloc/patches/BUILD
@@ -1,0 +1,1 @@
+exports_files(["0001-disable-initial-exec-tls.patch"])


### PR DESCRIPTION
This PR:
- It disables initial-exec-tls for jemalloc to avoid "cannot allocate memory in static TLS block" error when `import tensorcast._C`. 
    - The TLS area is sized once at process startup: it accounts for TLS used by libraries loaded at startup plus a small “extra” reserve. It generally cannot be expanded later in-place.
    - When Python imports tensorcast._C, it dlopen()s _C.so, which pulls in libcheckpoint_ext.so. This library chain
    includes a TLS symbol from jemalloc (je_tsd_tls) that uses an initial-exec style relocation (e.g. R_X86_64_TPOFF64), so it needs static TLS space.
  - If the process has already loaded other TLS-heavy DSOs (common in PyTorch/CUDA/OpenMP stacks), the reserved static TLS space can be exhausted, and dlopen() fails with: cannot allocate memory in static TLS block.