### PR TITLE
feat(communicator): add amortizable/recurring bench profiling and capacity-aware remote launch

### DIFF
--- a/core/communicator/README.md
+++ b/core/communicator/README.md
@@ -66,6 +66,12 @@ flowchart TB
 * **PinnedBufferPool & StreamingPinnedBuffer** — Shared pinned pools sourced from the daemon-wide `pinned_memory` authority (or internal defaults when constructed standalone).
 * **MrCache** — Per-protection-domain cache that reuses RDMA MRs for staged buffers to avoid repeated registrations.
 
+### RDMA Read Profiling Toggle
+
+- Fine-grained RDMA per-request profiling fields in `ReadResult` (`request_first_response_us` and `rdma_*`) are disabled by default to keep `read_tensor()` hot paths lean.
+- Enable them explicitly with `TENSORCAST_COMM_RDMA_READ_PROFILE=1` before process startup, or call `transport::ReadRequest::set_rdma_profile_enabled_for_process(true)` during process initialization.
+- `//core/communicator:communicator_bench_binary` keeps this toggle off by default; pass `--rdma-profile` when benchmark runs need detailed per-request RDMA timing fields.
+
 ### Topology Model (Pool / Endpoint / Link)
 
 The communicator now ships a topology model under `core/communicator/topology/` that captures *reachability* separately from the transport implementation:

--- a/core/communicator/bench/communicator_bench.cc
+++ b/core/communicator/bench/communicator_bench.cc
@@ -29,6 +29,7 @@
 #include "core/communicator/engine/engine.h"
 #include "core/communicator/misc/ibv_wrap.h"
 #include "core/communicator/transport/rdma_context.h"
+#include "core/communicator/transport/request.h"
 #include "core/cuda/cuda_api.h"
 
 namespace tc = tensorcast::communicator;
@@ -67,6 +68,7 @@ struct Options {
   bool direct_rdma = false;
   bool strict_direct_rdma = false;
   bool probe_gpu_mr = false;
+  bool rdma_profile = false;
   bool verify = true;
   int iterations = 1;
   int warmup_iterations = 0;
@@ -341,6 +343,7 @@ void print_usage(const char* argv0) {
             << "  --strict-nic                fail if selected NIC does not match requested NIC\n"
             << "  --direct-rdma               request direct GPU RDMA\n"
             << "  --strict-direct-rdma        fail instead of falling back when direct RDMA is unavailable\n"
+            << "  --rdma-profile              enable per-request RDMA profiling fields\n"
             << "  --iterations <n>            measured iterations\n"
             << "  --warmup-iterations <n>     warmup iterations\n"
             << "  --threads <n>               concurrent initiator threads\n"
@@ -402,6 +405,7 @@ absl::Status parse_options(int argc, char** argv, Options* options) {
       {"direct-rdma", no_argument, nullptr, 'x'},
       {"strict-direct-rdma", no_argument, nullptr, 'X'},
       {"probe-gpu-mr", no_argument, nullptr, 'P'},
+      {"rdma-profile", no_argument, nullptr, 'R'},
       {"iterations", required_argument, nullptr, 't'},
       {"warmup-iterations", required_argument, nullptr, 'w'},
       {"threads", required_argument, nullptr, 'T'},
@@ -415,7 +419,7 @@ absl::Status parse_options(int argc, char** argv, Options* options) {
   };
 
   int opt = 0;
-  while ((opt = getopt_long(argc, argv, "r:l:p:i:q:k:m:b:g:dn:e:sxXPt:w:T:B:Q:W:u:vh", long_options, nullptr)) != -1) {
+  while ((opt = getopt_long(argc, argv, "r:l:p:i:q:k:m:b:g:dn:e:sxXPRt:w:T:B:Q:W:u:vh", long_options, nullptr)) != -1) {
     switch (opt) {
       case 'r':
         options->role = optarg;
@@ -481,6 +485,9 @@ absl::Status parse_options(int argc, char** argv, Options* options) {
         break;
       case 'P':
         options->probe_gpu_mr = true;
+        break;
+      case 'R':
+        options->rdma_profile = true;
         break;
       case 't': {
         auto st = parse_int(optarg, &options->iterations);
@@ -1254,6 +1261,7 @@ int main(int argc, char** argv) {
     print_usage(argv[0]);
     return 2;
   }
+  transport::ReadRequest::set_rdma_profile_enabled_for_process(options.rdma_profile);
 
   apply_rdm_nic_filter(options);
   auto preflight_or = inspect_rdma_selection(options);

--- a/core/communicator/bench/communicator_bench.cc
+++ b/core/communicator/bench/communicator_bench.cc
@@ -690,6 +690,19 @@ absl::Status run_initiator(const Options& options) {
     uint64_t batch_wall_us = 0;
     double avg_request_us = 0.0;
     uint64_t max_request_us = 0;
+    uint64_t request_count = 0;
+    uint64_t sum_request_first_response_us = 0;
+    uint64_t sum_rdma_first_post_us = 0;
+    uint64_t sum_rdma_post_to_last_completion_us = 0;
+    uint64_t sum_rdma_post_after_response_us = 0;
+    uint64_t sum_tail_after_last_completion_us = 0;
+    uint64_t sum_rdma_handshake_queue_wait_us = 0;
+    uint64_t sum_rdma_response_windows = 0;
+    uint64_t sum_rdma_response_segments = 0;
+    uint64_t sum_rdma_wr_posted = 0;
+    uint64_t sum_rdma_wc_completed = 0;
+    uint64_t sum_rdma_ack_windows = 0;
+    uint64_t sum_rdma_ack_segments = 0;
   };
 
   std::mutex io_mu;
@@ -726,6 +739,23 @@ absl::Status run_initiator(const Options& options) {
       }
       total_request_us += static_cast<double>(result.read_cost);
       batch_result.max_request_us = std::max(batch_result.max_request_us, result.read_cost);
+      batch_result.request_count += 1;
+      batch_result.sum_request_first_response_us += result.request_first_response_us;
+      batch_result.sum_rdma_first_post_us += result.rdma_first_post_us;
+      batch_result.sum_rdma_post_to_last_completion_us += result.rdma_post_to_last_completion_us;
+      if (result.rdma_first_post_us > result.request_first_response_us) {
+        batch_result.sum_rdma_post_after_response_us += (result.rdma_first_post_us - result.request_first_response_us);
+      }
+      if (result.rdma_last_completion_us > 0 && result.read_cost > result.rdma_last_completion_us) {
+        batch_result.sum_tail_after_last_completion_us += (result.read_cost - result.rdma_last_completion_us);
+      }
+      batch_result.sum_rdma_handshake_queue_wait_us += result.rdma_handshake_queue_wait_us;
+      batch_result.sum_rdma_response_windows += result.rdma_response_windows;
+      batch_result.sum_rdma_response_segments += result.rdma_response_segments;
+      batch_result.sum_rdma_wr_posted += result.rdma_wr_posted;
+      batch_result.sum_rdma_wc_completed += result.rdma_wc_completed;
+      batch_result.sum_rdma_ack_windows += result.rdma_ack_windows;
+      batch_result.sum_rdma_ack_segments += result.rdma_ack_segments;
       if (!saw_result) {
         batch_result.first_result = result;
         saw_result = true;
@@ -743,6 +773,12 @@ absl::Status run_initiator(const Options& options) {
       }
     }
     if (emit_result) {
+      auto avg_from_sum = [&](uint64_t sum) -> double {
+        if (batch_result.request_count == 0) {
+          return 0.0;
+        }
+        return static_cast<double>(sum) / static_cast<double>(batch_result.request_count);
+      };
       std::lock_guard<std::mutex> lock(io_mu);
       std::cout << "ITER"
                 << " thread=" << thread_id << " idx=" << iteration << " batch_size=" << options.batch_size
@@ -758,7 +794,31 @@ absl::Status run_initiator(const Options& options) {
                 << " request_us=" << batch_result.first_result.request_cost
                 << " rdma_queue_us=" << batch_result.first_result.rdma_queue_cost
                 << " rdma_regmr_us=" << batch_result.first_result.rdma_regmr_cost
+                << " request_first_response_us=" << batch_result.first_result.request_first_response_us
+                << " rdma_first_post_us=" << batch_result.first_result.rdma_first_post_us
+                << " rdma_first_completion_us=" << batch_result.first_result.rdma_first_completion_us
+                << " rdma_last_completion_us=" << batch_result.first_result.rdma_last_completion_us
+                << " rdma_post_to_last_completion_us=" << batch_result.first_result.rdma_post_to_last_completion_us
+                << " rdma_response_windows=" << batch_result.first_result.rdma_response_windows
+                << " rdma_response_segments=" << batch_result.first_result.rdma_response_segments
+                << " rdma_wr_posted=" << batch_result.first_result.rdma_wr_posted
+                << " rdma_wc_completed=" << batch_result.first_result.rdma_wc_completed
+                << " rdma_ack_windows=" << batch_result.first_result.rdma_ack_windows
+                << " rdma_ack_segments=" << batch_result.first_result.rdma_ack_segments
+                << " rdma_handshake_queue_wait_us=" << batch_result.first_result.rdma_handshake_queue_wait_us
                 << " batch_avg_request_us=" << batch_result.avg_request_us
+                << " batch_avg_response_wait_us=" << avg_from_sum(batch_result.sum_request_first_response_us)
+                << " batch_avg_post_after_response_us=" << avg_from_sum(batch_result.sum_rdma_post_after_response_us)
+                << " batch_avg_data_phase_us=" << avg_from_sum(batch_result.sum_rdma_post_to_last_completion_us)
+                << " batch_avg_tail_after_last_completion_us="
+                << avg_from_sum(batch_result.sum_tail_after_last_completion_us)
+                << " batch_avg_handshake_wait_us=" << avg_from_sum(batch_result.sum_rdma_handshake_queue_wait_us)
+                << " batch_avg_response_windows=" << avg_from_sum(batch_result.sum_rdma_response_windows)
+                << " batch_avg_response_segments=" << avg_from_sum(batch_result.sum_rdma_response_segments)
+                << " batch_avg_wr_posted=" << avg_from_sum(batch_result.sum_rdma_wr_posted)
+                << " batch_avg_wc_completed=" << avg_from_sum(batch_result.sum_rdma_wc_completed)
+                << " batch_avg_ack_windows=" << avg_from_sum(batch_result.sum_rdma_ack_windows)
+                << " batch_avg_ack_segments=" << avg_from_sum(batch_result.sum_rdma_ack_segments)
                 << " batch_max_request_us=" << batch_result.max_request_us << " total_us=" << batch_result.batch_wall_us
                 << std::endl;
     }
@@ -777,6 +837,22 @@ absl::Status run_initiator(const Options& options) {
 
   const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(std::max(0, options.duration_sec));
   std::vector<double> latencies_us;
+  struct SummaryProfile {
+    uint64_t requests = 0;
+    uint64_t sum_request_first_response_us = 0;
+    uint64_t sum_rdma_first_post_us = 0;
+    uint64_t sum_rdma_post_to_last_completion_us = 0;
+    uint64_t sum_rdma_post_after_response_us = 0;
+    uint64_t sum_tail_after_last_completion_us = 0;
+    uint64_t sum_rdma_handshake_queue_wait_us = 0;
+    uint64_t sum_rdma_response_windows = 0;
+    uint64_t sum_rdma_response_segments = 0;
+    uint64_t sum_rdma_wr_posted = 0;
+    uint64_t sum_rdma_wc_completed = 0;
+    uint64_t sum_rdma_ack_windows = 0;
+    uint64_t sum_rdma_ack_segments = 0;
+  };
+  SummaryProfile summary_profile;
   std::mutex stats_mu;
   std::mutex error_mu;
   absl::Status first_error = absl::OkStatus();
@@ -813,6 +889,19 @@ absl::Status run_initiator(const Options& options) {
         {
           std::lock_guard<std::mutex> stats_lock(stats_mu);
           latencies_us.push_back(static_cast<double>(result_or->batch_wall_us));
+          summary_profile.requests += result_or->request_count;
+          summary_profile.sum_request_first_response_us += result_or->sum_request_first_response_us;
+          summary_profile.sum_rdma_first_post_us += result_or->sum_rdma_first_post_us;
+          summary_profile.sum_rdma_post_to_last_completion_us += result_or->sum_rdma_post_to_last_completion_us;
+          summary_profile.sum_rdma_post_after_response_us += result_or->sum_rdma_post_after_response_us;
+          summary_profile.sum_tail_after_last_completion_us += result_or->sum_tail_after_last_completion_us;
+          summary_profile.sum_rdma_handshake_queue_wait_us += result_or->sum_rdma_handshake_queue_wait_us;
+          summary_profile.sum_rdma_response_windows += result_or->sum_rdma_response_windows;
+          summary_profile.sum_rdma_response_segments += result_or->sum_rdma_response_segments;
+          summary_profile.sum_rdma_wr_posted += result_or->sum_rdma_wr_posted;
+          summary_profile.sum_rdma_wc_completed += result_or->sum_rdma_wc_completed;
+          summary_profile.sum_rdma_ack_windows += result_or->sum_rdma_ack_windows;
+          summary_profile.sum_rdma_ack_segments += result_or->sum_rdma_ack_segments;
         }
         completed.fetch_add(1, std::memory_order_relaxed);
       }
@@ -847,12 +936,31 @@ absl::Status run_initiator(const Options& options) {
         latencies_us.size() - 1);
     return latencies_us[pos];
   };
+  auto avg_request_metric = [&](uint64_t sum) -> double {
+    if (summary_profile.requests == 0) {
+      return 0.0;
+    }
+    return static_cast<double>(sum) / static_cast<double>(summary_profile.requests);
+  };
   std::cout << "SUMMARY"
             << " iterations=" << completed_count << " requests=" << total_requests << " threads=" << options.threads
             << " batch_size=" << options.batch_size << " qp_count=" << options.qp_count
             << " outstanding_wr=" << options.outstanding_wr << " bytes=" << total_bytes << " wall_us=" << wall_us
             << " avg_us=" << avg_us << " p50_us=" << percentile(50.0) << " p95_us=" << percentile(95.0)
-            << " p99_us=" << percentile(99.0) << " bw_GBps=" << bw_GBps << " bw_gbps=" << bw_gbps << std::endl;
+            << " p99_us=" << percentile(99.0) << " bw_GBps=" << bw_GBps << " bw_gbps=" << bw_gbps
+            << " avg_response_wait_us=" << avg_request_metric(summary_profile.sum_request_first_response_us)
+            << " avg_first_post_us=" << avg_request_metric(summary_profile.sum_rdma_first_post_us)
+            << " avg_post_after_response_us=" << avg_request_metric(summary_profile.sum_rdma_post_after_response_us)
+            << " avg_data_phase_us=" << avg_request_metric(summary_profile.sum_rdma_post_to_last_completion_us)
+            << " avg_tail_after_last_completion_us="
+            << avg_request_metric(summary_profile.sum_tail_after_last_completion_us)
+            << " avg_handshake_wait_us=" << avg_request_metric(summary_profile.sum_rdma_handshake_queue_wait_us)
+            << " avg_response_windows=" << avg_request_metric(summary_profile.sum_rdma_response_windows)
+            << " avg_response_segments=" << avg_request_metric(summary_profile.sum_rdma_response_segments)
+            << " avg_wr_posted=" << avg_request_metric(summary_profile.sum_rdma_wr_posted)
+            << " avg_wc_completed=" << avg_request_metric(summary_profile.sum_rdma_wc_completed)
+            << " avg_ack_windows=" << avg_request_metric(summary_profile.sum_rdma_ack_windows)
+            << " avg_ack_segments=" << avg_request_metric(summary_profile.sum_rdma_ack_segments) << std::endl;
   return absl::OkStatus();
 }
 

--- a/core/communicator/bench/communicator_bench.cc
+++ b/core/communicator/bench/communicator_bench.cc
@@ -15,7 +15,9 @@
 #include <memory>
 #include <mutex>
 #include <numeric>
+#include <sstream>
 #include <string>
+#include <syncstream>
 #include <thread>
 #include <vector>
 
@@ -36,6 +38,17 @@ namespace transport = tensorcast::communicator::transport;
 namespace cuda = tensorcast::cuda;
 
 namespace {
+
+using SteadyClock = std::chrono::steady_clock;
+
+uint64_t elapsed_us(SteadyClock::time_point start, SteadyClock::time_point end) {
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
+}
+
+void emit_machine_line(const std::string& line) {
+  std::osyncstream synced(std::cout);
+  synced << line << '\n';
+}
 
 struct Options {
   std::string role = "inspect";
@@ -73,6 +86,26 @@ struct RdmPreflight {
   int gpu_device = -1;
 };
 
+struct AllocationProfile {
+  uint64_t total_us = 0;
+  uint64_t set_device_us = 0;
+  uint64_t allocate_call_us = 0;
+};
+
+struct PatternFillProfile {
+  uint64_t total_us = 0;
+  uint64_t buffer_alloc_us = 0;
+  uint64_t pattern_fill_us = 0;
+  uint64_t copy_us = 0;
+};
+
+struct VerifyProfile {
+  uint64_t total_us = 0;
+  uint64_t buffer_alloc_us = 0;
+  uint64_t copy_us = 0;
+  uint64_t checksum_us = 0;
+};
+
 std::string tensor_key_for_thread(const std::string& base_key, int thread_id, int threads) {
   if (threads <= 1) {
     return base_key;
@@ -88,26 +121,48 @@ class Buffer {
     reset();
   }
 
-  absl::Status allocate(const Options& options) {
+  absl::Status allocate(const Options& options, AllocationProfile* profile = nullptr) {
+    const auto total_start = SteadyClock::now();
+    auto record_profile = [&](uint64_t set_device_us, uint64_t allocate_call_us) {
+      if (profile == nullptr) {
+        return;
+      }
+      profile->set_device_us = set_device_us;
+      profile->allocate_call_us = allocate_call_us;
+      profile->total_us = elapsed_us(total_start, SteadyClock::now());
+    };
+
     auto total_bytes_or = get_total_buffer_bytes(options);
     if (!total_bytes_or.ok()) {
       return total_bytes_or.status();
     }
     bytes_ = static_cast<size_t>(*total_bytes_or);
     if (options.memory == "cpu") {
+      const auto alloc_start = SteadyClock::now();
       cpu_ptr_ = static_cast<uint8_t*>(std::malloc(bytes_));
+      const auto alloc_us = elapsed_us(alloc_start, SteadyClock::now());
       if (cpu_ptr_ == nullptr) {
         return absl::ResourceExhaustedError("malloc failed");
       }
+      record_profile(/*set_device_us=*/0, alloc_us);
       return absl::OkStatus();
     }
 
+    const auto set_device_start = SteadyClock::now();
     auto set_status = cuda::set_device(options.gpu_id);
+    const auto set_device_us = elapsed_us(set_device_start, SteadyClock::now());
     if (!set_status.ok()) {
       return set_status;
     }
     gpu_id_ = options.gpu_id;
-    return cuda::malloc(reinterpret_cast<void**>(&gpu_ptr_), bytes_);
+    const auto alloc_start = SteadyClock::now();
+    auto alloc_status = cuda::malloc(reinterpret_cast<void**>(&gpu_ptr_), bytes_);
+    const auto alloc_us = elapsed_us(alloc_start, SteadyClock::now());
+    if (!alloc_status.ok()) {
+      return alloc_status;
+    }
+    record_profile(set_device_us, alloc_us);
+    return absl::OkStatus();
   }
 
   void reset() {
@@ -133,55 +188,118 @@ class Buffer {
     return bytes_;
   }
 
-  absl::Status fill_pattern(const Options& options, uint8_t seed) {
+  absl::Status fill_pattern(const Options& options, uint8_t seed, PatternFillProfile* profile = nullptr) {
+    const auto total_start = SteadyClock::now();
+    auto record_profile = [&](uint64_t buffer_alloc_us, uint64_t pattern_fill_us, uint64_t copy_us) {
+      if (profile == nullptr) {
+        return;
+      }
+      profile->buffer_alloc_us = buffer_alloc_us;
+      profile->pattern_fill_us = pattern_fill_us;
+      profile->copy_us = copy_us;
+      profile->total_us = elapsed_us(total_start, SteadyClock::now());
+    };
+
+    const auto alloc_start = SteadyClock::now();
     std::vector<uint8_t> pattern(bytes_);
+    const auto pattern_alloc_us = elapsed_us(alloc_start, SteadyClock::now());
+    const auto fill_start = SteadyClock::now();
     for (size_t i = 0; i < bytes_; ++i) {
       pattern[i] = static_cast<uint8_t>((i + seed) % 251);
     }
+    const auto pattern_fill_us = elapsed_us(fill_start, SteadyClock::now());
+    uint64_t copy_us = 0;
     if (options.memory == "cpu") {
+      const auto copy_start = SteadyClock::now();
       std::memcpy(cpu_ptr_, pattern.data(), bytes_);
+      copy_us = elapsed_us(copy_start, SteadyClock::now());
+      record_profile(pattern_alloc_us, pattern_fill_us, copy_us);
       return absl::OkStatus();
     }
+    const auto set_device_start = SteadyClock::now();
     auto set_status = cuda::set_device(options.gpu_id);
+    copy_us = elapsed_us(set_device_start, SteadyClock::now());
     if (!set_status.ok()) {
+      record_profile(pattern_alloc_us, pattern_fill_us, copy_us);
       return set_status;
     }
-    return cuda::memcpy(gpu_ptr_, pattern.data(), bytes_, cudaMemcpyHostToDevice);
+    const auto copy_start = SteadyClock::now();
+    auto copy_status = cuda::memcpy(gpu_ptr_, pattern.data(), bytes_, cudaMemcpyHostToDevice);
+    copy_us += elapsed_us(copy_start, SteadyClock::now());
+    record_profile(pattern_alloc_us, pattern_fill_us, copy_us);
+    return copy_status;
   }
 
-  absl::Status clear(const Options& options) {
+  absl::Status clear(const Options& options, uint64_t* clear_us = nullptr) {
+    const auto clear_start = SteadyClock::now();
+    auto record_clear_us = [&]() {
+      if (clear_us != nullptr) {
+        *clear_us = elapsed_us(clear_start, SteadyClock::now());
+      }
+    };
     if (options.memory == "cpu") {
       std::memset(cpu_ptr_, 0, bytes_);
+      record_clear_us();
       return absl::OkStatus();
     }
     auto set_status = cuda::set_device(options.gpu_id);
     if (!set_status.ok()) {
+      record_clear_us();
       return set_status;
     }
-    return cuda::memset(gpu_ptr_, 0, bytes_);
+    auto clear_status = cuda::memset(gpu_ptr_, 0, bytes_);
+    record_clear_us();
+    return clear_status;
   }
 
-  absl::Status verify_pattern(const Options& options, uint8_t seed) const {
+  absl::Status verify_pattern(const Options& options, uint8_t seed, VerifyProfile* profile = nullptr) const {
+    const auto total_start = SteadyClock::now();
+    auto record_profile = [&](uint64_t buffer_alloc_us, uint64_t copy_us, uint64_t checksum_us) {
+      if (profile == nullptr) {
+        return;
+      }
+      profile->buffer_alloc_us = buffer_alloc_us;
+      profile->copy_us = copy_us;
+      profile->checksum_us = checksum_us;
+      profile->total_us = elapsed_us(total_start, SteadyClock::now());
+    };
+
+    const auto alloc_start = SteadyClock::now();
     std::vector<uint8_t> data(bytes_);
+    const auto data_alloc_us = elapsed_us(alloc_start, SteadyClock::now());
+    uint64_t copy_us = 0;
     if (options.memory == "cpu") {
+      const auto copy_start = SteadyClock::now();
       std::memcpy(data.data(), cpu_ptr_, bytes_);
+      copy_us = elapsed_us(copy_start, SteadyClock::now());
     } else {
+      const auto set_device_start = SteadyClock::now();
       auto set_status = cuda::set_device(options.gpu_id);
+      copy_us = elapsed_us(set_device_start, SteadyClock::now());
       if (!set_status.ok()) {
+        record_profile(data_alloc_us, copy_us, /*checksum_us=*/0);
         return set_status;
       }
+      const auto copy_start = SteadyClock::now();
       auto copy_status = cuda::memcpy(data.data(), gpu_ptr_, bytes_, cudaMemcpyDeviceToHost);
+      copy_us += elapsed_us(copy_start, SteadyClock::now());
       if (!copy_status.ok()) {
+        record_profile(data_alloc_us, copy_us, /*checksum_us=*/0);
         return copy_status;
       }
     }
+    const auto checksum_start = SteadyClock::now();
     for (size_t i = 0; i < bytes_; ++i) {
       const auto expected = static_cast<uint8_t>((i + seed) % 251);
       if (data[i] != expected) {
+        const auto checksum_us = elapsed_us(checksum_start, SteadyClock::now());
+        record_profile(data_alloc_us, copy_us, checksum_us);
         return absl::DataLossError(
             absl::StrCat("data mismatch at offset=", i, " expected=", expected, " actual=", data[i]));
       }
     }
+    const auto checksum_us = elapsed_us(checksum_start, SteadyClock::now());
+    record_profile(data_alloc_us, copy_us, checksum_us);
     return absl::OkStatus();
   }
 
@@ -550,53 +668,77 @@ absl::Status probe_gpu_mr_registration(const Options& options, const RdmPrefligh
         absl::StrCat("gpu MR probe failed for nic=", probe_nic, " bytes=", probe_buffer.bytes(), " res=", res));
   }
   tc::misc::wrap_ibv_dereg_mr(mr);
-  std::cout << "GPU_MR_PROBE"
-            << " nic=" << probe_nic << " rail=" << dev->get_rail_id() << " bytes=" << probe_buffer.bytes()
-            << " status=ok" << std::endl;
+  std::ostringstream line;
+  line << "GPU_MR_PROBE"
+       << " nic=" << probe_nic << " rail=" << dev->get_rail_id() << " bytes=" << probe_buffer.bytes()
+       << " status=ok";
+  emit_machine_line(line.str());
   return absl::OkStatus();
 }
 
 void print_preflight(const Options& options, const RdmPreflight& preflight) {
-  std::cout << "PRECHECK"
-            << " role=" << options.role << " memory=" << options.memory << " rdma=" << (options.enable_rdma ? 1 : 0)
-            << " requested_nic=" << (options.rdma_nic.empty() ? "-" : options.rdma_nic) << " visible_nics=";
+  std::ostringstream line;
+  line << "PRECHECK"
+       << " role=" << options.role << " memory=" << options.memory << " rdma=" << (options.enable_rdma ? 1 : 0)
+       << " requested_nic=" << (options.rdma_nic.empty() ? "-" : options.rdma_nic) << " visible_nics=";
   if (preflight.visible_nics.empty()) {
-    std::cout << "-";
+    line << "-";
   } else {
     for (size_t i = 0; i < preflight.visible_nics.size(); ++i) {
       if (i > 0) {
-        std::cout << ",";
+        line << ",";
       }
-      std::cout << preflight.visible_nics[i];
+      line << preflight.visible_nics[i];
     }
   }
-  std::cout << " selected_nic=" << (preflight.selected_nic.empty() ? "-" : preflight.selected_nic)
-            << " selected_rail=" << preflight.selected_rail_id;
+  line << " selected_nic=" << (preflight.selected_nic.empty() ? "-" : preflight.selected_nic)
+       << " selected_rail=" << preflight.selected_rail_id;
   if (!preflight.gpu_name.empty()) {
-    std::cout << " gpu=" << preflight.gpu_name << " gpu_bus=" << preflight.gpu_bus
-              << " gpu_device=" << preflight.gpu_device;
+    line << " gpu=" << preflight.gpu_name << " gpu_bus=" << preflight.gpu_bus
+         << " gpu_device=" << preflight.gpu_device;
   }
-  std::cout << std::endl;
+  emit_machine_line(line.str());
 }
 
-absl::Status prepare_buffer(Buffer* buffer, const Options& options, bool fill_pattern) {
+struct PrepareBufferProfile {
+  AllocationProfile allocation;
+  PatternFillProfile pattern_fill;
+  uint64_t clear_us = 0;
+};
+
+absl::Status prepare_buffer(Buffer* buffer, const Options& options, bool fill_pattern, PrepareBufferProfile* profile) {
   if (buffer == nullptr) {
     return absl::InvalidArgumentError("buffer is null");
   }
-  auto alloc_status = buffer->allocate(options);
+  auto alloc_status = buffer->allocate(options, profile == nullptr ? nullptr : &profile->allocation);
   if (!alloc_status.ok()) {
     return alloc_status;
   }
   if (fill_pattern) {
-    return buffer->fill_pattern(options, /*seed=*/0x5A);
+    return buffer->fill_pattern(options, /*seed=*/0x5A, profile == nullptr ? nullptr : &profile->pattern_fill);
   }
-  return buffer->clear(options);
+  return buffer->clear(options, profile == nullptr ? nullptr : &profile->clear_us);
 }
 
 absl::Status run_target(const Options& options) {
+  struct TargetStartupProfile {
+    uint64_t communicator_init_us = 0;
+    uint64_t buffer_alloc_us = 0;
+    uint64_t buffer_alloc_set_device_us = 0;
+    uint64_t buffer_alloc_call_us = 0;
+    uint64_t buffer_fill_us = 0;
+    uint64_t buffer_fill_alloc_us = 0;
+    uint64_t buffer_fill_pattern_us = 0;
+    uint64_t buffer_fill_copy_us = 0;
+    uint64_t register_tensor_us = 0;
+  };
+  TargetStartupProfile startup;
+
   auto cfg = make_config(options);
   engine::Communicator communicator(cfg);
+  const auto init_start = SteadyClock::now();
   auto init_status = communicator.init(options.listen_ip, options.listen_port);
+  startup.communicator_init_us = elapsed_us(init_start, SteadyClock::now());
   if (!init_status.ok()) {
     return init_status;
   }
@@ -607,10 +749,18 @@ absl::Status run_target(const Options& options) {
   const int dev_id = options.memory == "gpu" ? options.gpu_id : -1;
   for (int thread_id = 0; thread_id < options.threads; ++thread_id) {
     auto buffer = std::make_unique<Buffer>();
-    auto buffer_status = prepare_buffer(buffer.get(), options, /*fill_pattern=*/true);
+    PrepareBufferProfile profile;
+    auto buffer_status = prepare_buffer(buffer.get(), options, /*fill_pattern=*/true, &profile);
     if (!buffer_status.ok()) {
       return buffer_status;
     }
+    startup.buffer_alloc_us += profile.allocation.total_us;
+    startup.buffer_alloc_set_device_us += profile.allocation.set_device_us;
+    startup.buffer_alloc_call_us += profile.allocation.allocate_call_us;
+    startup.buffer_fill_us += profile.pattern_fill.total_us;
+    startup.buffer_fill_alloc_us += profile.pattern_fill.buffer_alloc_us;
+    startup.buffer_fill_pattern_us += profile.pattern_fill.pattern_fill_us;
+    startup.buffer_fill_copy_us += profile.pattern_fill.copy_us;
 
     engine::Communicator::RegisterTensorOptions register_options;
     register_options.register_mr = options.enable_rdma;
@@ -618,6 +768,7 @@ absl::Status run_target(const Options& options) {
     register_options.async = false;
     register_options.direct_rdma_enabled = options.direct_rdma;
     register_options.direct_rdma_required = options.strict_direct_rdma;
+    const auto register_start = SteadyClock::now();
     auto register_status = communicator.register_tensor_ex(
         tensor_key_for_thread(options.tensor_key, thread_id, options.threads),
         buffer->addr(),
@@ -625,20 +776,34 @@ absl::Status run_target(const Options& options) {
         dev_type,
         dev_id,
         register_options);
+    startup.register_tensor_us += elapsed_us(register_start, SteadyClock::now());
     if (!register_status.ok()) {
       return register_status;
     }
     buffers.push_back(std::move(buffer));
   }
 
-  std::cout << "READY"
-            << " role=target"
-            << " listen_ip=" << options.listen_ip << " listen_port=" << communicator.listening_port()
-            << " tensor_key=" << options.tensor_key << " bytes=" << options.bytes
-            << " batch_size=" << options.batch_size << " threads=" << options.threads
-            << " qp_count=" << options.qp_count << " outstanding_wr=" << options.outstanding_wr
-            << " memory=" << options.memory << " direct_rdma=" << (options.direct_rdma ? 1 : 0)
-            << " strict_direct_rdma=" << (options.strict_direct_rdma ? 1 : 0) << std::endl;
+  std::ostringstream ready_line;
+  ready_line << "READY"
+             << " role=target"
+             << " listen_ip=" << options.listen_ip << " listen_port=" << communicator.listening_port()
+             << " tensor_key=" << options.tensor_key << " bytes=" << options.bytes
+             << " batch_size=" << options.batch_size << " threads=" << options.threads
+             << " qp_count=" << options.qp_count << " outstanding_wr=" << options.outstanding_wr
+             << " memory=" << options.memory << " direct_rdma=" << (options.direct_rdma ? 1 : 0)
+             << " strict_direct_rdma=" << (options.strict_direct_rdma ? 1 : 0)
+             << " init_communicator_us=" << startup.communicator_init_us
+             << " init_buffer_alloc_us=" << startup.buffer_alloc_us
+             << " init_buffer_alloc_set_device_us=" << startup.buffer_alloc_set_device_us
+             << " init_buffer_alloc_call_us=" << startup.buffer_alloc_call_us
+             << " init_buffer_fill_us=" << startup.buffer_fill_us
+             << " init_buffer_fill_alloc_us=" << startup.buffer_fill_alloc_us
+             << " init_buffer_fill_pattern_us=" << startup.buffer_fill_pattern_us
+             << " init_buffer_fill_copy_us=" << startup.buffer_fill_copy_us
+             << " init_register_tensor_us=" << startup.register_tensor_us
+             << " init_total_us="
+             << (startup.communicator_init_us + startup.buffer_alloc_us + startup.buffer_fill_us + startup.register_tensor_us);
+  emit_machine_line(ready_line.str());
 
   while (true) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -664,9 +829,21 @@ absl::Status validate_result(const Options& options, const transport::read_resul
 }
 
 absl::Status run_initiator(const Options& options) {
+  struct InitiatorStartupProfile {
+    uint64_t communicator_init_us = 0;
+    uint64_t buffer_alloc_us = 0;
+    uint64_t buffer_alloc_set_device_us = 0;
+    uint64_t buffer_alloc_call_us = 0;
+    uint64_t buffer_initial_clear_us = 0;
+    uint64_t warmup_total_us = 0;
+  };
+  InitiatorStartupProfile startup;
+
   auto cfg = make_config(options);
   engine::Communicator communicator(cfg);
+  const auto init_start = SteadyClock::now();
   auto init_status = communicator.init(options.listen_ip, options.listen_port);
+  startup.communicator_init_us = elapsed_us(init_start, SteadyClock::now());
   if (!init_status.ok()) {
     return init_status;
   }
@@ -675,10 +852,15 @@ absl::Status run_initiator(const Options& options) {
   buffers.reserve(static_cast<size_t>(options.threads));
   for (int thread_id = 0; thread_id < options.threads; ++thread_id) {
     auto buffer = std::make_unique<Buffer>();
-    auto buffer_status = prepare_buffer(buffer.get(), options, /*fill_pattern=*/false);
+    PrepareBufferProfile profile;
+    auto buffer_status = prepare_buffer(buffer.get(), options, /*fill_pattern=*/false, &profile);
     if (!buffer_status.ok()) {
       return buffer_status;
     }
+    startup.buffer_alloc_us += profile.allocation.total_us;
+    startup.buffer_alloc_set_device_us += profile.allocation.set_device_us;
+    startup.buffer_alloc_call_us += profile.allocation.allocate_call_us;
+    startup.buffer_initial_clear_us += profile.clear_us;
     buffers.push_back(std::move(buffer));
   }
 
@@ -688,8 +870,17 @@ absl::Status run_initiator(const Options& options) {
   struct BatchResult {
     transport::read_result_t first_result;
     uint64_t batch_wall_us = 0;
+    uint64_t batch_total_us = 0;
+    uint64_t clear_us = 0;
+    uint64_t issue_us = 0;
+    uint64_t wait_us = 0;
+    uint64_t verify_total_us = 0;
+    uint64_t verify_buffer_alloc_us = 0;
+    uint64_t verify_copy_us = 0;
+    uint64_t verify_checksum_us = 0;
     double avg_request_us = 0.0;
     uint64_t max_request_us = 0;
+    uint64_t sum_request_us = 0;
     uint64_t request_count = 0;
     uint64_t sum_request_first_response_us = 0;
     uint64_t sum_rdma_first_post_us = 0;
@@ -708,11 +899,13 @@ absl::Status run_initiator(const Options& options) {
   std::mutex io_mu;
   auto run_single =
       [&](Buffer& buffer, int iteration, int thread_id, bool verify, bool emit_result) -> absl::StatusOr<BatchResult> {
-    auto clear_status = buffer.clear(options);
+    BatchResult batch_result;
+    const auto iteration_start = SteadyClock::now();
+    auto clear_status = buffer.clear(options, &batch_result.clear_us);
     if (!clear_status.ok()) {
       return clear_status;
     }
-    const auto wall_start = std::chrono::steady_clock::now();
+    const auto issue_start = SteadyClock::now();
     std::vector<transport::future_read_result_t> futures;
     futures.reserve(static_cast<size_t>(options.batch_size));
     for (int batch_idx = 0; batch_idx < options.batch_size; ++batch_idx) {
@@ -728,16 +921,18 @@ absl::Status run_initiator(const Options& options) {
           options.peer_port,
           remote_offset));
     }
-    BatchResult batch_result;
-    double total_request_us = 0.0;
+    const auto issue_end = SteadyClock::now();
+    batch_result.issue_us = elapsed_us(issue_start, issue_end);
+
     bool saw_result = false;
+    const auto wait_start = SteadyClock::now();
     for (auto& future : futures) {
       auto result = future.get();
       auto validate_status = validate_result(options, result);
       if (!validate_status.ok()) {
         return validate_status;
       }
-      total_request_us += static_cast<double>(result.read_cost);
+      batch_result.sum_request_us += result.read_cost;
       batch_result.max_request_us = std::max(batch_result.max_request_us, result.read_cost);
       batch_result.request_count += 1;
       batch_result.sum_request_first_response_us += result.request_first_response_us;
@@ -761,17 +956,27 @@ absl::Status run_initiator(const Options& options) {
         saw_result = true;
       }
     }
-    const auto wall_end = std::chrono::steady_clock::now();
-    const auto wall_us = std::chrono::duration_cast<std::chrono::microseconds>(wall_end - wall_start).count();
-    batch_result.batch_wall_us = static_cast<uint64_t>(wall_us);
-    batch_result.avg_request_us = total_request_us / static_cast<double>(options.batch_size);
-    batch_result.first_result.read_cost = batch_result.batch_wall_us;
+    const auto wait_end = SteadyClock::now();
+    batch_result.wait_us = elapsed_us(wait_start, wait_end);
+    batch_result.batch_wall_us = elapsed_us(issue_start, wait_end);
+    if (batch_result.request_count > 0) {
+      batch_result.avg_request_us =
+          static_cast<double>(batch_result.sum_request_us) / static_cast<double>(batch_result.request_count);
+    }
+
     if (verify) {
-      auto verify_status = buffer.verify_pattern(options, /*seed=*/0x5A);
+      VerifyProfile verify_profile;
+      auto verify_status = buffer.verify_pattern(options, /*seed=*/0x5A, &verify_profile);
       if (!verify_status.ok()) {
         return verify_status;
       }
+      batch_result.verify_total_us = verify_profile.total_us;
+      batch_result.verify_buffer_alloc_us = verify_profile.buffer_alloc_us;
+      batch_result.verify_copy_us = verify_profile.copy_us;
+      batch_result.verify_checksum_us = verify_profile.checksum_us;
     }
+    batch_result.batch_total_us = elapsed_us(iteration_start, SteadyClock::now());
+
     if (emit_result) {
       auto avg_from_sum = [&](uint64_t sum) -> double {
         if (batch_result.request_count == 0) {
@@ -779,8 +984,8 @@ absl::Status run_initiator(const Options& options) {
         }
         return static_cast<double>(sum) / static_cast<double>(batch_result.request_count);
       };
-      std::lock_guard<std::mutex> lock(io_mu);
-      std::cout << "ITER"
+      std::ostringstream iter_line;
+      iter_line << "ITER"
                 << " thread=" << thread_id << " idx=" << iteration << " batch_size=" << options.batch_size
                 << " status=" << static_cast<int>(batch_result.first_result.status.code()) << " local_nic="
                 << (batch_result.first_result.local_nic.empty() ? "-" : batch_result.first_result.local_nic)
@@ -819,12 +1024,24 @@ absl::Status run_initiator(const Options& options) {
                 << " batch_avg_wc_completed=" << avg_from_sum(batch_result.sum_rdma_wc_completed)
                 << " batch_avg_ack_windows=" << avg_from_sum(batch_result.sum_rdma_ack_windows)
                 << " batch_avg_ack_segments=" << avg_from_sum(batch_result.sum_rdma_ack_segments)
-                << " batch_max_request_us=" << batch_result.max_request_us << " total_us=" << batch_result.batch_wall_us
-                << std::endl;
+                << " clear_us=" << batch_result.clear_us << " issue_us=" << batch_result.issue_us
+                << " wait_us=" << batch_result.wait_us << " verify_total_us=" << batch_result.verify_total_us
+                << " verify_buffer_alloc_us=" << batch_result.verify_buffer_alloc_us
+                << " verify_copy_us=" << batch_result.verify_copy_us
+                << " verify_checksum_us=" << batch_result.verify_checksum_us
+                << " batch_avg_clear_per_request_us=" << avg_from_sum(batch_result.clear_us)
+                << " batch_avg_verify_per_request_us=" << avg_from_sum(batch_result.verify_total_us)
+                << " batch_avg_verify_copy_per_request_us=" << avg_from_sum(batch_result.verify_copy_us)
+                << " batch_avg_verify_checksum_per_request_us=" << avg_from_sum(batch_result.verify_checksum_us)
+                << " iteration_total_us=" << batch_result.batch_total_us
+                << " batch_max_request_us=" << batch_result.max_request_us << " total_us=" << batch_result.batch_wall_us;
+      std::lock_guard<std::mutex> lock(io_mu);
+      emit_machine_line(iter_line.str());
     }
     return batch_result;
   };
 
+  const auto warmup_start = SteadyClock::now();
   for (int thread_id = 0; thread_id < options.threads; ++thread_id) {
     for (int i = 0; i < options.warmup_iterations; ++i) {
       auto warmup_or = run_single(
@@ -834,11 +1051,21 @@ absl::Status run_initiator(const Options& options) {
       }
     }
   }
+  startup.warmup_total_us = elapsed_us(warmup_start, SteadyClock::now());
 
   const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(std::max(0, options.duration_sec));
   std::vector<double> latencies_us;
   struct SummaryProfile {
+    uint64_t iterations = 0;
     uint64_t requests = 0;
+    uint64_t sum_batch_total_us = 0;
+    uint64_t sum_clear_us = 0;
+    uint64_t sum_issue_us = 0;
+    uint64_t sum_wait_us = 0;
+    uint64_t sum_verify_total_us = 0;
+    uint64_t sum_verify_buffer_alloc_us = 0;
+    uint64_t sum_verify_copy_us = 0;
+    uint64_t sum_verify_checksum_us = 0;
     uint64_t sum_request_first_response_us = 0;
     uint64_t sum_rdma_first_post_us = 0;
     uint64_t sum_rdma_post_to_last_completion_us = 0;
@@ -889,7 +1116,16 @@ absl::Status run_initiator(const Options& options) {
         {
           std::lock_guard<std::mutex> stats_lock(stats_mu);
           latencies_us.push_back(static_cast<double>(result_or->batch_wall_us));
+          summary_profile.iterations += 1;
           summary_profile.requests += result_or->request_count;
+          summary_profile.sum_batch_total_us += result_or->batch_total_us;
+          summary_profile.sum_clear_us += result_or->clear_us;
+          summary_profile.sum_issue_us += result_or->issue_us;
+          summary_profile.sum_wait_us += result_or->wait_us;
+          summary_profile.sum_verify_total_us += result_or->verify_total_us;
+          summary_profile.sum_verify_buffer_alloc_us += result_or->verify_buffer_alloc_us;
+          summary_profile.sum_verify_copy_us += result_or->verify_copy_us;
+          summary_profile.sum_verify_checksum_us += result_or->verify_checksum_us;
           summary_profile.sum_request_first_response_us += result_or->sum_request_first_response_us;
           summary_profile.sum_rdma_first_post_us += result_or->sum_rdma_first_post_us;
           summary_profile.sum_rdma_post_to_last_completion_us += result_or->sum_rdma_post_to_last_completion_us;
@@ -942,25 +1178,68 @@ absl::Status run_initiator(const Options& options) {
     }
     return static_cast<double>(sum) / static_cast<double>(summary_profile.requests);
   };
-  std::cout << "SUMMARY"
-            << " iterations=" << completed_count << " requests=" << total_requests << " threads=" << options.threads
-            << " batch_size=" << options.batch_size << " qp_count=" << options.qp_count
-            << " outstanding_wr=" << options.outstanding_wr << " bytes=" << total_bytes << " wall_us=" << wall_us
-            << " avg_us=" << avg_us << " p50_us=" << percentile(50.0) << " p95_us=" << percentile(95.0)
-            << " p99_us=" << percentile(99.0) << " bw_GBps=" << bw_GBps << " bw_gbps=" << bw_gbps
-            << " avg_response_wait_us=" << avg_request_metric(summary_profile.sum_request_first_response_us)
-            << " avg_first_post_us=" << avg_request_metric(summary_profile.sum_rdma_first_post_us)
-            << " avg_post_after_response_us=" << avg_request_metric(summary_profile.sum_rdma_post_after_response_us)
-            << " avg_data_phase_us=" << avg_request_metric(summary_profile.sum_rdma_post_to_last_completion_us)
-            << " avg_tail_after_last_completion_us="
-            << avg_request_metric(summary_profile.sum_tail_after_last_completion_us)
-            << " avg_handshake_wait_us=" << avg_request_metric(summary_profile.sum_rdma_handshake_queue_wait_us)
-            << " avg_response_windows=" << avg_request_metric(summary_profile.sum_rdma_response_windows)
-            << " avg_response_segments=" << avg_request_metric(summary_profile.sum_rdma_response_segments)
-            << " avg_wr_posted=" << avg_request_metric(summary_profile.sum_rdma_wr_posted)
-            << " avg_wc_completed=" << avg_request_metric(summary_profile.sum_rdma_wc_completed)
-            << " avg_ack_windows=" << avg_request_metric(summary_profile.sum_rdma_ack_windows)
-            << " avg_ack_segments=" << avg_request_metric(summary_profile.sum_rdma_ack_segments) << std::endl;
+  auto avg_iteration_metric = [&](uint64_t sum) -> double {
+    if (summary_profile.iterations == 0) {
+      return 0.0;
+    }
+    return static_cast<double>(sum) / static_cast<double>(summary_profile.iterations);
+  };
+  const uint64_t amortizable_init_total_us =
+      startup.communicator_init_us + startup.buffer_alloc_us + startup.buffer_initial_clear_us;
+  const uint64_t amortizable_total_us = amortizable_init_total_us + startup.warmup_total_us;
+  const auto amortized_per_iteration_us =
+      summary_profile.iterations == 0
+          ? 0.0
+          : static_cast<double>(amortizable_total_us) / static_cast<double>(summary_profile.iterations);
+  const auto amortized_per_request_us =
+      total_requests == 0 ? 0.0 : static_cast<double>(amortizable_total_us) / static_cast<double>(total_requests);
+  std::ostringstream summary_line;
+  summary_line << "SUMMARY"
+               << " iterations=" << completed_count << " requests=" << total_requests << " threads=" << options.threads
+               << " batch_size=" << options.batch_size << " qp_count=" << options.qp_count
+               << " outstanding_wr=" << options.outstanding_wr << " bytes=" << total_bytes << " wall_us=" << wall_us
+               << " avg_us=" << avg_us << " p50_us=" << percentile(50.0) << " p95_us=" << percentile(95.0)
+               << " p99_us=" << percentile(99.0) << " bw_GBps=" << bw_GBps << " bw_gbps=" << bw_gbps
+               << " amortizable_init_communicator_us=" << startup.communicator_init_us
+               << " amortizable_init_buffer_alloc_us=" << startup.buffer_alloc_us
+               << " amortizable_init_buffer_alloc_set_device_us=" << startup.buffer_alloc_set_device_us
+               << " amortizable_init_buffer_alloc_call_us=" << startup.buffer_alloc_call_us
+               << " amortizable_init_buffer_clear_us=" << startup.buffer_initial_clear_us
+               << " amortizable_warmup_total_us=" << startup.warmup_total_us
+               << " amortizable_init_total_us=" << amortizable_init_total_us
+               << " amortizable_total_us=" << amortizable_total_us
+               << " amortized_per_iteration_us=" << amortized_per_iteration_us
+               << " amortized_per_request_us=" << amortized_per_request_us
+               << " recurring_avg_iteration_total_us=" << avg_iteration_metric(summary_profile.sum_batch_total_us)
+               << " recurring_avg_clear_us=" << avg_iteration_metric(summary_profile.sum_clear_us)
+               << " recurring_avg_issue_us=" << avg_iteration_metric(summary_profile.sum_issue_us)
+               << " recurring_avg_wait_us=" << avg_iteration_metric(summary_profile.sum_wait_us)
+               << " recurring_avg_verify_total_us=" << avg_iteration_metric(summary_profile.sum_verify_total_us)
+               << " recurring_avg_verify_buffer_alloc_us="
+               << avg_iteration_metric(summary_profile.sum_verify_buffer_alloc_us)
+               << " recurring_avg_verify_copy_us=" << avg_iteration_metric(summary_profile.sum_verify_copy_us)
+               << " recurring_avg_verify_checksum_us=" << avg_iteration_metric(summary_profile.sum_verify_checksum_us)
+               << " recurring_avg_clear_per_request_us=" << avg_request_metric(summary_profile.sum_clear_us)
+               << " recurring_avg_verify_per_request_us=" << avg_request_metric(summary_profile.sum_verify_total_us)
+               << " recurring_avg_verify_buffer_alloc_per_request_us="
+               << avg_request_metric(summary_profile.sum_verify_buffer_alloc_us)
+               << " recurring_avg_verify_copy_per_request_us=" << avg_request_metric(summary_profile.sum_verify_copy_us)
+               << " recurring_avg_verify_checksum_per_request_us="
+               << avg_request_metric(summary_profile.sum_verify_checksum_us)
+               << " avg_response_wait_us=" << avg_request_metric(summary_profile.sum_request_first_response_us)
+               << " avg_first_post_us=" << avg_request_metric(summary_profile.sum_rdma_first_post_us)
+               << " avg_post_after_response_us=" << avg_request_metric(summary_profile.sum_rdma_post_after_response_us)
+               << " avg_data_phase_us=" << avg_request_metric(summary_profile.sum_rdma_post_to_last_completion_us)
+               << " avg_tail_after_last_completion_us="
+               << avg_request_metric(summary_profile.sum_tail_after_last_completion_us)
+               << " avg_handshake_wait_us=" << avg_request_metric(summary_profile.sum_rdma_handshake_queue_wait_us)
+               << " avg_response_windows=" << avg_request_metric(summary_profile.sum_rdma_response_windows)
+               << " avg_response_segments=" << avg_request_metric(summary_profile.sum_rdma_response_segments)
+               << " avg_wr_posted=" << avg_request_metric(summary_profile.sum_rdma_wr_posted)
+               << " avg_wc_completed=" << avg_request_metric(summary_profile.sum_rdma_wc_completed)
+               << " avg_ack_windows=" << avg_request_metric(summary_profile.sum_rdma_ack_windows)
+               << " avg_ack_segments=" << avg_request_metric(summary_profile.sum_rdma_ack_segments);
+  emit_machine_line(summary_line.str());
   return absl::OkStatus();
 }
 

--- a/core/communicator/engine/engine.cc
+++ b/core/communicator/engine/engine.cc
@@ -2984,6 +2984,12 @@ misc::result_t Communicator::on_receive_response(
 
       auto ready_reads = drain_pending_reads_for_generation(endpoint, generation);
       for (auto& pending : ready_reads) {
+        if (pending.enqueued_at != absl::InfinitePast()) {
+          const auto wait_us = absl::ToInt64Microseconds(absl::Now() - pending.enqueued_at);
+          if (wait_us > 0) {
+            pending.request->note_rdma_handshake_queue_wait_us(static_cast<uint64_t>(wait_us));
+          }
+        }
         auto res = transport->read_multi(pending.request, pending.segments);
         if (res != misc::SUCCESS) {
           pending_requests_.erase_if_present(pending.request->get_key());
@@ -3033,6 +3039,7 @@ misc::result_t Communicator::on_receive_response(
       read_request->record_request_response();
 
       if (enable_rdma_ && hdr->transport_type == ENGINE_TRANSPORT_RDMA) {
+        read_request->note_rdma_response_window(hdr->num_segments);
         CHECK(rdma_context_ != nullptr) << "rdma context is not initialized";
 
         auto tensor = read_request->get_local_tensor();
@@ -3068,9 +3075,13 @@ misc::result_t Communicator::on_receive_response(
           const std::string staged_key = tensor_key;
           const uint64_t request_offset = read_request->remote_offset_;
           const uint64_t request_id = read_request->request_id();
+          std::weak_ptr<transport::ReadRequest> weak_read_request(read_request);
           read_request->set_ack_sender(
-              [ctrl, staged_key, request_offset, request_id](
+              [ctrl, staged_key, request_offset, request_id, weak_read_request](
                   uint32_t window_seq, const std::vector<uint64_t>& offsets, bool final_window) {
+                if (auto ack_request = weak_read_request.lock(); ack_request != nullptr) {
+                  ack_request->note_rdma_ack_window(static_cast<uint32_t>(offsets.size()));
+                }
                 auto ack = std::make_shared<EngineMessage>(
                     ENGINE_OP_RDMA_READ_DONE_EX,
                     static_cast<uint32_t>(

--- a/core/communicator/engine/engine.cc
+++ b/core/communicator/engine/engine.cc
@@ -2987,7 +2987,9 @@ misc::result_t Communicator::on_receive_response(
         if (pending.enqueued_at != absl::InfinitePast()) {
           const auto wait_us = absl::ToInt64Microseconds(absl::Now() - pending.enqueued_at);
           if (wait_us > 0) {
-            pending.request->note_rdma_handshake_queue_wait_us(static_cast<uint64_t>(wait_us));
+            if (pending.request->rdma_profile_enabled()) {
+              pending.request->note_rdma_handshake_queue_wait_us(static_cast<uint64_t>(wait_us));
+            }
           }
         }
         auto res = transport->read_multi(pending.request, pending.segments);
@@ -3039,7 +3041,9 @@ misc::result_t Communicator::on_receive_response(
       read_request->record_request_response();
 
       if (enable_rdma_ && hdr->transport_type == ENGINE_TRANSPORT_RDMA) {
-        read_request->note_rdma_response_window(hdr->num_segments);
+        if (read_request->rdma_profile_enabled()) {
+          read_request->note_rdma_response_window(hdr->num_segments);
+        }
         CHECK(rdma_context_ != nullptr) << "rdma context is not initialized";
 
         auto tensor = read_request->get_local_tensor();
@@ -3080,7 +3084,9 @@ misc::result_t Communicator::on_receive_response(
               [ctrl, staged_key, request_offset, request_id, weak_read_request](
                   uint32_t window_seq, const std::vector<uint64_t>& offsets, bool final_window) {
                 if (auto ack_request = weak_read_request.lock(); ack_request != nullptr) {
-                  ack_request->note_rdma_ack_window(static_cast<uint32_t>(offsets.size()));
+                  if (ack_request->rdma_profile_enabled()) {
+                    ack_request->note_rdma_ack_window(static_cast<uint32_t>(offsets.size()));
+                  }
                 }
                 auto ack = std::make_shared<EngineMessage>(
                     ENGINE_OP_RDMA_READ_DONE_EX,

--- a/core/communicator/transport/rdma_transport.cc
+++ b/core/communicator/transport/rdma_transport.cc
@@ -294,6 +294,7 @@ misc::result_t RdmaTransport::do_post_send() {
     return misc::FAILED;
   }
 
+  req->note_rdma_posted_wr(1);
   // Push to per-QP queue for lock-free completion matching
   per_qp_inflight_queues_[qp_index].push(req);
   return misc::SUCCESS;
@@ -364,6 +365,7 @@ misc::result_t RdmaTransport::read_multi(read_request_t request, const std::vect
       request->enqueue_completion_bytes(segs[indices[i]].length);
       per_qp_inflight_queues_[qp_index].push(request);
     }
+    request->note_rdma_posted_wr(static_cast<uint32_t>(posted_count));
     total_posted += posted_count;
 
     if (res != misc::SUCCESS) {
@@ -394,6 +396,7 @@ misc::result_t RdmaTransport::do_process_wc(struct ibv_wc* wc) {
     if (req == nullptr) {
       LOG(FATAL) << "abnormal queue state for qp_index=" << qp_index;
     }
+    req->note_rdma_completion();
     req->record_read_done();
     if (wc->status == IBV_WC_SUCCESS) {
       if (req->mark_completion_and_is_done()) {

--- a/core/communicator/transport/rdma_transport.cc
+++ b/core/communicator/transport/rdma_transport.cc
@@ -294,7 +294,9 @@ misc::result_t RdmaTransport::do_post_send() {
     return misc::FAILED;
   }
 
-  req->note_rdma_posted_wr(1);
+  if (req->rdma_profile_enabled()) {
+    req->note_rdma_posted_wr(1);
+  }
   // Push to per-QP queue for lock-free completion matching
   per_qp_inflight_queues_[qp_index].push(req);
   return misc::SUCCESS;
@@ -361,11 +363,15 @@ misc::result_t RdmaTransport::read_multi(read_request_t request, const std::vect
     if (res != misc::SUCCESS) {
       posted_count = (bad_wr != nullptr) ? static_cast<size_t>(bad_wr - wrs.data()) : 0;
     }
+    // Record posting before exposing the request to CQ consumers. Otherwise a
+    // very fast completion can observe completion-before-post in profiling.
+    if (request->rdma_profile_enabled()) {
+      request->note_rdma_posted_wr(static_cast<uint32_t>(posted_count));
+    }
     for (size_t i = 0; i < posted_count; ++i) {
       request->enqueue_completion_bytes(segs[indices[i]].length);
       per_qp_inflight_queues_[qp_index].push(request);
     }
-    request->note_rdma_posted_wr(static_cast<uint32_t>(posted_count));
     total_posted += posted_count;
 
     if (res != misc::SUCCESS) {
@@ -396,7 +402,9 @@ misc::result_t RdmaTransport::do_process_wc(struct ibv_wc* wc) {
     if (req == nullptr) {
       LOG(FATAL) << "abnormal queue state for qp_index=" << qp_index;
     }
-    req->note_rdma_completion();
+    if (req->rdma_profile_enabled()) {
+      req->note_rdma_completion();
+    }
     req->record_read_done();
     if (wc->status == IBV_WC_SUCCESS) {
       if (req->mark_completion_and_is_done()) {

--- a/core/communicator/transport/request.cc
+++ b/core/communicator/transport/request.cc
@@ -1,6 +1,9 @@
 
 // Copyright (c) 2025-2026, TensorCast Team.
 
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 #include <utility>
 
@@ -10,6 +13,31 @@
 #include "core/communicator/transport/request.h"
 
 namespace tensorcast::communicator::transport {
+
+namespace {
+
+bool is_truthy_env_value(const char* value) {
+  if (value == nullptr) {
+    return false;
+  }
+  return std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 || std::strcmp(value, "TRUE") == 0
+      || std::strcmp(value, "True") == 0 || std::strcmp(value, "on") == 0 || std::strcmp(value, "ON") == 0;
+}
+
+std::atomic<bool>& rdma_profile_enabled_flag() {
+  static std::atomic<bool> enabled(is_truthy_env_value(std::getenv("TENSORCAST_COMM_RDMA_READ_PROFILE")));
+  return enabled;
+}
+
+} // namespace
+
+bool ReadRequest::rdma_profile_enabled_for_process() {
+  return rdma_profile_enabled_flag().load(std::memory_order_relaxed);
+}
+
+void ReadRequest::set_rdma_profile_enabled_for_process(bool enabled) {
+  rdma_profile_enabled_flag().store(enabled, std::memory_order_relaxed);
+}
 
 ReadRequest::ReadRequest(
     std::string tensor_key,
@@ -28,7 +56,8 @@ ReadRequest::ReadRequest(
       created_at_(std::chrono::steady_clock::now()),
       remote_offset_(remote_offset),
       request_id_(request_id),
-      rail_id_(rail_id) {
+      rail_id_(rail_id),
+      rdma_profile_enabled_(rdma_profile_enabled_for_process()) {
   status_.tensor_key = tensor_key_;
   status_.local_rail_id = rail_id_;
   if (local_tensor_ != nullptr) {
@@ -105,6 +134,9 @@ std::string ReadRequest::get_key() {
 
 void ReadRequest::record_request_response() {
   status_.request_cost = timer_.record();
+  if (!rdma_profile_enabled_) {
+    return;
+  }
   const uint64_t elapsed_us = elapsed_since_create_us();
   uint64_t unset = 0;
   request_first_response_us_.compare_exchange_strong(unset, elapsed_us, std::memory_order_acq_rel);
@@ -123,12 +155,18 @@ void ReadRequest::record_rdma_regmr() {
 }
 
 void ReadRequest::note_rdma_response_window(uint32_t segment_count) {
+  if (!rdma_profile_enabled_) {
+    return;
+  }
   rdma_response_windows_.fetch_add(1, std::memory_order_relaxed);
   rdma_response_segments_.fetch_add(segment_count, std::memory_order_relaxed);
 }
 
 void ReadRequest::note_rdma_posted_wr(uint32_t wr_count) {
   if (wr_count == 0) {
+    return;
+  }
+  if (!rdma_profile_enabled_) {
     return;
   }
   rdma_wr_posted_.fetch_add(static_cast<uint64_t>(wr_count), std::memory_order_relaxed);
@@ -138,6 +176,9 @@ void ReadRequest::note_rdma_posted_wr(uint32_t wr_count) {
 }
 
 void ReadRequest::note_rdma_completion() {
+  if (!rdma_profile_enabled_) {
+    return;
+  }
   rdma_wc_completed_.fetch_add(1, std::memory_order_relaxed);
   const uint64_t elapsed_us = elapsed_since_create_us();
   uint64_t unset = 0;
@@ -146,12 +187,18 @@ void ReadRequest::note_rdma_completion() {
 }
 
 void ReadRequest::note_rdma_ack_window(uint32_t segment_count) {
+  if (!rdma_profile_enabled_) {
+    return;
+  }
   rdma_ack_windows_.fetch_add(1, std::memory_order_relaxed);
   rdma_ack_segments_.fetch_add(segment_count, std::memory_order_relaxed);
 }
 
 void ReadRequest::note_rdma_handshake_queue_wait_us(uint64_t wait_us) {
   if (wait_us == 0) {
+    return;
+  }
+  if (!rdma_profile_enabled_) {
     return;
   }
   rdma_handshake_queue_wait_us_.fetch_add(wait_us, std::memory_order_relaxed);
@@ -200,6 +247,9 @@ uint64_t ReadRequest::elapsed_since_create_us() const {
 }
 
 void ReadRequest::finalize_rdma_profile_status() {
+  if (!rdma_profile_enabled_) {
+    return;
+  }
   status_.request_first_response_us = request_first_response_us_.load(std::memory_order_relaxed);
   status_.rdma_first_post_us = rdma_first_post_us_.load(std::memory_order_relaxed);
   status_.rdma_first_completion_us = rdma_first_completion_us_.load(std::memory_order_relaxed);

--- a/core/communicator/transport/request.cc
+++ b/core/communicator/transport/request.cc
@@ -25,6 +25,7 @@ ReadRequest::ReadRequest(
       dst_port_(dst_port),
       result_set_(false),
       timer_(true),
+      created_at_(std::chrono::steady_clock::now()),
       remote_offset_(remote_offset),
       request_id_(request_id),
       rail_id_(rail_id) {
@@ -59,6 +60,7 @@ void ReadRequest::set_result(absl::Status status) {
   if (!result_set_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
     return;
   }
+  finalize_rdma_profile_status();
   status_.status = status;
   result_.set_value(status_);
   std::function<void()> callback;
@@ -103,6 +105,9 @@ std::string ReadRequest::get_key() {
 
 void ReadRequest::record_request_response() {
   status_.request_cost = timer_.record();
+  const uint64_t elapsed_us = elapsed_since_create_us();
+  uint64_t unset = 0;
+  request_first_response_us_.compare_exchange_strong(unset, elapsed_us, std::memory_order_acq_rel);
 }
 
 void ReadRequest::record_read_done() {
@@ -115,6 +120,41 @@ void ReadRequest::record_rdma_queue_done() {
 
 void ReadRequest::record_rdma_regmr() {
   status_.rdma_regmr_cost = timer_.record();
+}
+
+void ReadRequest::note_rdma_response_window(uint32_t segment_count) {
+  rdma_response_windows_.fetch_add(1, std::memory_order_relaxed);
+  rdma_response_segments_.fetch_add(segment_count, std::memory_order_relaxed);
+}
+
+void ReadRequest::note_rdma_posted_wr(uint32_t wr_count) {
+  if (wr_count == 0) {
+    return;
+  }
+  rdma_wr_posted_.fetch_add(static_cast<uint64_t>(wr_count), std::memory_order_relaxed);
+  const uint64_t elapsed_us = elapsed_since_create_us();
+  uint64_t unset = 0;
+  rdma_first_post_us_.compare_exchange_strong(unset, elapsed_us, std::memory_order_acq_rel);
+}
+
+void ReadRequest::note_rdma_completion() {
+  rdma_wc_completed_.fetch_add(1, std::memory_order_relaxed);
+  const uint64_t elapsed_us = elapsed_since_create_us();
+  uint64_t unset = 0;
+  rdma_first_completion_us_.compare_exchange_strong(unset, elapsed_us, std::memory_order_acq_rel);
+  rdma_last_completion_us_.store(elapsed_us, std::memory_order_relaxed);
+}
+
+void ReadRequest::note_rdma_ack_window(uint32_t segment_count) {
+  rdma_ack_windows_.fetch_add(1, std::memory_order_relaxed);
+  rdma_ack_segments_.fetch_add(segment_count, std::memory_order_relaxed);
+}
+
+void ReadRequest::note_rdma_handshake_queue_wait_us(uint64_t wait_us) {
+  if (wait_us == 0) {
+    return;
+  }
+  rdma_handshake_queue_wait_us_.fetch_add(wait_us, std::memory_order_relaxed);
 }
 
 std::future<read_result_t> ReadRequest::get_read_result_future(std::string error_message) {
@@ -150,6 +190,31 @@ void ReadRequest::notify_completion(const absl::Status& status) {
   }
   if (callback) {
     callback(status);
+  }
+}
+
+uint64_t ReadRequest::elapsed_since_create_us() const {
+  const auto now = std::chrono::steady_clock::now();
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(now - created_at_).count());
+}
+
+void ReadRequest::finalize_rdma_profile_status() {
+  status_.request_first_response_us = request_first_response_us_.load(std::memory_order_relaxed);
+  status_.rdma_first_post_us = rdma_first_post_us_.load(std::memory_order_relaxed);
+  status_.rdma_first_completion_us = rdma_first_completion_us_.load(std::memory_order_relaxed);
+  status_.rdma_last_completion_us = rdma_last_completion_us_.load(std::memory_order_relaxed);
+  status_.rdma_response_windows = rdma_response_windows_.load(std::memory_order_relaxed);
+  status_.rdma_response_segments = rdma_response_segments_.load(std::memory_order_relaxed);
+  status_.rdma_wr_posted = rdma_wr_posted_.load(std::memory_order_relaxed);
+  status_.rdma_wc_completed = rdma_wc_completed_.load(std::memory_order_relaxed);
+  status_.rdma_ack_windows = rdma_ack_windows_.load(std::memory_order_relaxed);
+  status_.rdma_ack_segments = rdma_ack_segments_.load(std::memory_order_relaxed);
+  status_.rdma_handshake_queue_wait_us = rdma_handshake_queue_wait_us_.load(std::memory_order_relaxed);
+  if (status_.rdma_last_completion_us >= status_.rdma_first_post_us && status_.rdma_first_post_us > 0) {
+    status_.rdma_post_to_last_completion_us = status_.rdma_last_completion_us - status_.rdma_first_post_us;
+  } else {
+    status_.rdma_post_to_last_completion_us = 0;
   }
 }
 

--- a/core/communicator/transport/request.h
+++ b/core/communicator/transport/request.h
@@ -4,6 +4,7 @@
 #define CORE_COMMUNICATOR_ENGINE_REQUEST_H_
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <deque>
 #include <functional>
@@ -27,6 +28,18 @@ using read_result_t = struct ReadResult {
   uint64_t read_cost = 0;
   uint64_t rdma_queue_cost = 0;
   uint64_t rdma_regmr_cost = 0;
+  uint64_t request_first_response_us = 0;
+  uint64_t rdma_first_post_us = 0;
+  uint64_t rdma_first_completion_us = 0;
+  uint64_t rdma_last_completion_us = 0;
+  uint64_t rdma_post_to_last_completion_us = 0;
+  uint64_t rdma_response_windows = 0;
+  uint64_t rdma_response_segments = 0;
+  uint64_t rdma_wr_posted = 0;
+  uint64_t rdma_wc_completed = 0;
+  uint64_t rdma_ack_windows = 0;
+  uint64_t rdma_ack_segments = 0;
+  uint64_t rdma_handshake_queue_wait_us = 0;
   bool transport_is_rdma = false;
   bool rdma_staged_response = false;
   bool rdma_zero_copy_response = false;
@@ -87,6 +100,11 @@ class ReadRequest {
   void record_rdma_regmr();
   void record_rdma_queue_done();
   void record_read_done();
+  void note_rdma_response_window(uint32_t segment_count);
+  void note_rdma_posted_wr(uint32_t wr_count);
+  void note_rdma_completion();
+  void note_rdma_ack_window(uint32_t segment_count);
+  void note_rdma_handshake_queue_wait_us(uint64_t wait_us);
 
   void add_expected_completions(int n) {
     expected_completions_.fetch_add(n);
@@ -201,6 +219,18 @@ class ReadRequest {
 
   misc::Timer timer_;
   read_result_t status_;
+  const std::chrono::steady_clock::time_point created_at_;
+  std::atomic<uint64_t> request_first_response_us_{0};
+  std::atomic<uint64_t> rdma_first_post_us_{0};
+  std::atomic<uint64_t> rdma_first_completion_us_{0};
+  std::atomic<uint64_t> rdma_last_completion_us_{0};
+  std::atomic<uint64_t> rdma_response_windows_{0};
+  std::atomic<uint64_t> rdma_response_segments_{0};
+  std::atomic<uint64_t> rdma_wr_posted_{0};
+  std::atomic<uint64_t> rdma_wc_completed_{0};
+  std::atomic<uint64_t> rdma_ack_windows_{0};
+  std::atomic<uint64_t> rdma_ack_segments_{0};
+  std::atomic<uint64_t> rdma_handshake_queue_wait_us_{0};
   uint64_t remote_offset_;
   uint64_t request_id_;
   int16_t rail_id_;
@@ -231,6 +261,9 @@ class ReadRequest {
   absl::Mutex progress_mu_;
   std::function<void(uint64_t, uint64_t)> progress_callback_ ABSL_GUARDED_BY(progress_mu_);
   std::function<void(const absl::Status&)> completion_callback_ ABSL_GUARDED_BY(progress_mu_);
+
+  [[nodiscard]] uint64_t elapsed_since_create_us() const;
+  void finalize_rdma_profile_status();
 };
 
 using read_request_t = std::shared_ptr<ReadRequest>;

--- a/core/communicator/transport/request.h
+++ b/core/communicator/transport/request.h
@@ -66,6 +66,9 @@ static inline std::string get_request_instance_key(std::string key, uint64_t off
 
 class ReadRequest {
  public:
+  static bool rdma_profile_enabled_for_process();
+  static void set_rdma_profile_enabled_for_process(bool enabled);
+
   ReadRequest(
       std::string tensor_key,
       std::string dst_ip,
@@ -94,6 +97,10 @@ class ReadRequest {
 
   int16_t get_rail_id() const {
     return rail_id_;
+  }
+
+  [[nodiscard]] bool rdma_profile_enabled() const {
+    return rdma_profile_enabled_;
   }
 
   void record_request_response();
@@ -234,6 +241,7 @@ class ReadRequest {
   uint64_t remote_offset_;
   uint64_t request_id_;
   int16_t rail_id_;
+  bool rdma_profile_enabled_ = false;
   std::atomic<uint64_t> mtcp_stage_unit_hint_bytes_{0};
 
   // Number of expected RDMA READ completions for this request

--- a/core/communicator/transport/request_test.cc
+++ b/core/communicator/transport/request_test.cc
@@ -14,6 +14,24 @@
 using tensorcast::communicator::transport::PartitionTensor;
 using tensorcast::communicator::transport::ReadRequest;
 
+namespace {
+
+class ScopedRdmaProfileSetting {
+ public:
+  explicit ScopedRdmaProfileSetting(bool enabled) : previous_(ReadRequest::rdma_profile_enabled_for_process()) {
+    ReadRequest::set_rdma_profile_enabled_for_process(enabled);
+  }
+
+  ~ScopedRdmaProfileSetting() {
+    ReadRequest::set_rdma_profile_enabled_for_process(previous_);
+  }
+
+ private:
+  bool previous_;
+};
+
+} // namespace
+
 TEST_CASE("ReadRequest emits window ACKs as segments complete", "[request]") {
   auto local = std::make_shared<PartitionTensor>(
       "key",
@@ -85,6 +103,67 @@ TEST_CASE("ReadRequest reports byte progress and completion status", "[request]"
 
   req.set_result(absl::OkStatus());
   REQUIRE(completed);
+}
+
+TEST_CASE("ReadRequest RDMA profiling is opt-in", "[request][profiling]") {
+  ScopedRdmaProfileSetting scoped_profile(/*enabled=*/false);
+  auto local = std::make_shared<PartitionTensor>(
+      "rdma_profile_off",
+      /*addr*/ 0,
+      /*bytes*/ 1024,
+      tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
+      nullptr);
+
+  ReadRequest req("rdma_profile_off", "127.0.0.1", 12345, local, /*remote_offset*/ 0, /*request_id=*/4);
+  auto future = req.get_future();
+  req.record_request_response();
+  req.note_rdma_response_window(3);
+  req.note_rdma_posted_wr(2);
+  req.note_rdma_completion();
+  req.note_rdma_ack_window(3);
+  req.note_rdma_handshake_queue_wait_us(17);
+  req.set_result(absl::OkStatus());
+
+  const auto result = future.get();
+  REQUIRE(result.status.ok());
+  REQUIRE(result.rdma_response_windows == 0);
+  REQUIRE(result.rdma_response_segments == 0);
+  REQUIRE(result.rdma_wr_posted == 0);
+  REQUIRE(result.rdma_wc_completed == 0);
+  REQUIRE(result.rdma_ack_windows == 0);
+  REQUIRE(result.rdma_ack_segments == 0);
+  REQUIRE(result.rdma_handshake_queue_wait_us == 0);
+}
+
+TEST_CASE("ReadRequest RDMA profiling records counters when enabled", "[request][profiling]") {
+  ScopedRdmaProfileSetting scoped_profile(/*enabled=*/true);
+  auto local = std::make_shared<PartitionTensor>(
+      "rdma_profile_on",
+      /*addr*/ 0,
+      /*bytes*/ 1024,
+      tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
+      nullptr);
+
+  ReadRequest req("rdma_profile_on", "127.0.0.1", 12345, local, /*remote_offset*/ 0, /*request_id=*/5);
+  auto future = req.get_future();
+  req.record_request_response();
+  req.note_rdma_response_window(4);
+  req.note_rdma_posted_wr(3);
+  req.note_rdma_completion();
+  req.note_rdma_completion();
+  req.note_rdma_ack_window(4);
+  req.note_rdma_handshake_queue_wait_us(23);
+  req.set_result(absl::OkStatus());
+
+  const auto result = future.get();
+  REQUIRE(result.status.ok());
+  REQUIRE(result.rdma_response_windows == 1);
+  REQUIRE(result.rdma_response_segments == 4);
+  REQUIRE(result.rdma_wr_posted == 3);
+  REQUIRE(result.rdma_wc_completed == 2);
+  REQUIRE(result.rdma_ack_windows == 1);
+  REQUIRE(result.rdma_ack_segments == 4);
+  REQUIRE(result.rdma_handshake_queue_wait_us == 23);
 }
 
 TEST_CASE("ReadRequest completion path is concurrency-safe", "[request][concurrency]") {

--- a/docs/benchmarks/20260315-communicator-rdma-nic-gdr-progress.md
+++ b/docs/benchmarks/20260315-communicator-rdma-nic-gdr-progress.md
@@ -136,7 +136,17 @@ The communicator bench prints:
 
 1. `ITER ... total_us=...`
 2. `SUMMARY ... wall_us=... avg_us=... p50/p95/p99 ... bw_GBps=...`
-3. legacy compatibility:
+3. amortizable profiling fields:
+   - `amortizable_init_*`
+   - `amortizable_warmup_total_us`
+   - `amortized_per_iteration_us`
+   - `amortized_per_request_us`
+4. recurring profiling fields:
+   - `recurring_avg_clear_us`
+   - `recurring_avg_issue_us`
+   - `recurring_avg_wait_us`
+   - `recurring_avg_verify_*`
+5. legacy compatibility:
    - `bw_gbps=...`
 
 The important implementation detail is that the bench computes:
@@ -144,6 +154,13 @@ The important implementation detail is that the bench computes:
 1. `total_bytes` from completed requests
 2. `wall_us` from the whole measured interval
 3. `bw_GBps = (total_bytes / 1e9) / (wall_us / 1e6)`
+
+And the new profiling classification is:
+
+1. amortizable:
+   - startup/initialization costs that can be spread over many transfers
+2. recurring:
+   - costs paid repeatedly for each measured transfer iteration
 
 New runs now emit the explicit field `bw_GBps`. The historical field name
 `bw_gbps` is still emitted as a legacy alias for compatibility with older

--- a/docs/benchmarks/20260316-communicator-vs-transfer-engine-comparison.md
+++ b/docs/benchmarks/20260316-communicator-vs-transfer-engine-comparison.md
@@ -9,6 +9,9 @@ This document defines a chart set that makes TensorCast communicator and
 Mooncake Transfer Engine performance easy to compare without hiding the
 remaining caveats.
 
+`2026-03-22` 起，`0105` 的主目标从“仅看带宽差距”调整为“量化任务过程中的非数据传输代价”。
+因此本页中的 `GB/s` 图表用于定位趋势，不再单独作为根因结论；根因分析需结合 communicator bench 新增的 amortizable/recurring profiling 字段。
+
 The output is intentionally split into:
 
 1. a single-NIC aligned reference chart
@@ -129,6 +132,73 @@ The chart generator is:
 For communicator-generated data, prefer the explicit `bw_GBps` / `bw_GBps_*`
 fields when present. Older result files still carry the legacy field name
 `bw_gbps`, which represents the same decimal `GB/s` quantity.
+
+### 4.0 0105 Profiling Read Order (Updated)
+
+For new communicator runs, read metrics in this order:
+
+1. `amortizable_*`
+   - one-time costs (init, allocation, warmup) that can be amortized
+2. `recurring_*`
+   - per-transfer costs (clear, issue, wait, verify)
+3. verify breakdown
+   - `recurring_avg_verify_buffer_alloc_*`
+   - `recurring_avg_verify_copy_*`
+   - `recurring_avg_verify_checksum_*`
+4. throughput fields
+   - `bw_GBps` / `bw_gbps` used as secondary guardrail
+
+This order prevents misattributing startup or verification overhead as pure
+data-plane bandwidth regression.
+
+### 4.0.1 2026-03-22 Non-Transfer Cost Attribution (8xH800 Nodes + RDMA)
+
+To validate the new `0105` objective, we ran an A/B pair (one host pair per case) on `8xH800` nodes
+with strict direct RDMA (`64 MiB`, `threads=1`, `batch_size=1`, `qp_count=4`,
+`outstanding_wr=256`):
+
+1. verify on: `/data/tc/0105-non-transfer-profile-20260322-221354/result.json`
+2. verify off: `/data/tc/0105-non-transfer-profile-nv-20260322-222325/result.json`
+
+Host pair (verify on):
+
+1. target: `gpu-h800-0234.host.platform.shaipower.com`
+2. initiator: `gpu-h800-0214.host.platform.shaipower.com`
+
+Host pair (verify off):
+
+1. target: `gpu-h800-0468.host.platform.shaipower.com`
+2. initiator: `gpu-h800-0449.host.platform.shaipower.com`
+
+Note: this is not a strict same-host-pair A/B; the throughput gap is large
+enough that the non-transfer-cost attribution conclusion still holds, but
+future sensitivity studies should pin both runs to the same host pair.
+
+Key numbers (verify on):
+
+1. `bw_GBps=0.235584`
+2. `amortized_per_iteration_us=72079.8`
+3. `recurring_avg_iteration_total_us=284669`
+4. `recurring_avg_verify_total_us=276997` (`97.30%` of recurring total)
+5. verify split:
+   - `recurring_avg_verify_buffer_alloc_us=30963.8` (`11.18%` of verify)
+   - `recurring_avg_verify_copy_us=4651.4` (`1.68%` of verify)
+   - `recurring_avg_verify_checksum_us=241378` (`87.14%` of verify)
+
+Key numbers (verify off):
+
+1. `bw_GBps=19.8732`
+2. `amortized_per_iteration_us=1625.35`
+3. `recurring_avg_iteration_total_us=3222.3`
+4. `recurring_avg_wait_us=3116.3` (`96.71%` of recurring total)
+
+Direct interpretation for `0105`:
+
+1. this run's low throughput number is not a pure data-plane limit
+2. recurring verify cost dominates the denominator when verify is enabled
+3. startup/warmup is amortizable and measurable (`amortizable_*`), but not the
+   primary bottleneck in this A/B pair
+4. disabling verify restores the expected transfer-class throughput (`~19.87 GB/s`)
 
 ### 4.1 Single-NIC Large-Block Sweep
 

--- a/docs/designs/0105-communicator-small-packet-latency-and-throughput-optimization.md
+++ b/docs/designs/0105-communicator-small-packet-latency-and-throughput-optimization.md
@@ -1,0 +1,286 @@
+---
+slug: communicator-small-packet-latency-and-throughput-optimization
+title: Communicator Small-Packet Latency and Throughput Optimization (Design)
+status: draft
+areas: ["core", "proto", "docs", "benchmarks"]
+created: 2026-03-18
+last_updated: 2026-03-18
+related_code:
+  - docs/benchmarks/20260316-communicator-vs-transfer-engine-comparison.md
+  - docs/benchmarks/20260315-communicator-rdma-nic-gdr-progress.md
+  - core/communicator/engine/engine.cc
+  - core/communicator/engine/engine.h
+  - core/communicator/engine/staging_flow_controller.cc
+  - core/communicator/transport/rdma_transport.cc
+  - core/communicator/transport/request.h
+  - core/communicator/transport/mtcp_transport.cc
+  - proto/tensorcast/communicator/v1/communicator_config.proto
+links:
+  plan: ../plans/0105-communicator-small-packet-latency-and-throughput-optimization.md
+  dependencies:
+    - ../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md
+    - ../benchmarks/20260315-communicator-rdma-nic-gdr-progress.md
+    - ../designs/0004-unified-runtime-config.md
+---
+
+# Summary
+
+`2026-03-16` 对比数据显示，communicator 在单次逻辑请求规模较小（`32 MiB`、`64 MiB`）时，仍明显落后于相关工作（Mooncake Transfer Engine），而在 `256 MiB+` 时已进入同一性能等级。
+
+当前结论是：瓶颈主要来自“小包/中包下固定开销与控制粒度”，而不是大块 direct RDMA 数据面带宽上限。
+
+本设计给出一个分阶段方案：
+
+1. 先补齐可归因观测，量化每个固定开销项。
+2. 优化控制路径与窗口/ACK 粒度，降低每个逻辑请求的控制往返成本。
+3. 优化 RDMA/MTCP 热路径中的每 WR bookkeeping、future/wait 和日志噪声。
+4. 在严格回归和可回滚前提下渐进上线。
+
+## Baseline
+
+来自 [20260316-communicator-vs-transfer-engine-comparison.md](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md)：
+
+| Logical request size | Communicator | Transfer Engine | Gap |
+| --- | --- | --- | --- |
+| `32 MiB` | `18.56 GB/s` | `22.49 GB/s` | `-17.5%` |
+| `64 MiB` | `20.56 GB/s` | `22.75 GB/s` | `-9.6%` |
+| `256 MiB` | `23.17 GB/s` | `23.02 GB/s` | same class |
+| `1 GiB` | `23.96 GB/s` | `23.69 GB/s` | same class |
+
+# Problem Statement
+
+## 1. 控制线程串行导致小包固定开销放大
+
+当前 `Communicator` 仅启动一个请求线程处理 `request_queue_`：
+
+- 请求线程启动点：`core/communicator/engine/engine.cc` (`request_thread_`)
+- 主循环：`do_read_request_loop()`
+- 队列定义：`core/communicator/engine/engine.h` (`request_queue_`)
+
+单线程串行在大量短请求、混合 peer 场景下会放大排队等待；即使单 peer 场景，也会在 control send/pending 维护路径上叠加额外抖动。
+
+## 2. RDMA 窗口推进由 ACK 驱动，回填节奏偏保守
+
+RDMA 路径中，source 侧在 `resume_rdma_reads()` 一次 pass 内只要“有进展”就 break，等待 ACK 再继续：
+
+- `resume_rdma_reads()` break-on-progress：`core/communicator/engine/engine.cc`
+- ACK 回调触发继续推进：`ENGINE_OP_RDMA_READ_DONE_EX` 处理分支内调用 `resume_rdma_reads()`
+
+该机制在中小逻辑请求下会增加“窗口-ACK-窗口”往返轮次，放大控制路径占比。
+
+## 3. RDMA 每 WR 级别队列操作与 completion bookkeeping 成本偏高
+
+当前 `read_multi()` 为每个 posted WR 执行一次 request enqueue，并在 CQ completion 为每个 WR pop：
+
+- `read_multi()`：`core/communicator/transport/rdma_transport.cc`
+- `do_process_wc()`：`core/communicator/transport/rdma_transport.cc`
+- request completion/ACK 队列：`core/communicator/transport/request.h`
+
+小包/中包下 WR 数较多时，这类原子与队列操作会成为不可忽略的固定成本。
+
+## 4. MTCP staged 路径存在单线程信用等待 + future 串行等待
+
+MTCP staging 使用单线程循环消费，并在资源不足时退避 sleep：
+
+- 线程入口：`core/communicator/engine/engine.cc` (`mtcp_staging_loop()`)
+- 退避等待：`process_mtcp_read_task()` 中 `absl::SleepFor(backoff)`
+
+MTCP transport 侧存在大量 `std::async` 与 `future.get()/wait()` 等待链：
+
+- send path async/release：`core/communicator/transport/mtcp_transport.cc`
+- recv path 按 future 顺序等待：`core/communicator/transport/mtcp_transport.cc`
+
+在 fallback 或混合流量下，这些等待与调度开销会放大尾延迟。
+
+## 5. 热路径 `LOG(INFO)` 频率过高
+
+`rdma_resume`、`READ_RESPONSE_EX`、`read_multi` completion 等热路径存在高频 `LOG(INFO)`，在高请求率下会产生额外 CPU 与锁竞争负担。
+
+# Goals / Non-Goals
+
+## Goals
+
+1. 缩小 communicator 在 `32 MiB`、`64 MiB` logical request 下与 related work 的性能差距。
+2. 降低每个逻辑请求的固定控制开销与 WR bookkeeping 成本。
+3. 保持 `256 MiB+` direct RDMA 路径无明显回退。
+4. 方案默认可控、可回滚，不引入隐式环境变量开关。
+5. 所有新调优项进入统一 runtime 配置（`communicator_config.proto`），遵循 [0004-unified-runtime-config.md](./0004-unified-runtime-config.md)。
+
+## Non-Goals
+
+1. 不重写 communicator 为另一套传输引擎。
+2. 不改变 Global Store / Store Daemon 架构语义。
+3. 不在本阶段追求 full-8 ceiling 与 TE 完全一致（本设计聚焦小包/中包）。
+4. 不引入破坏兼容的协议语义变更。
+
+# Architecture & Interfaces
+
+## 优化分层
+
+```mermaid
+flowchart LR
+  A[Phase 1<br>Instrumentation] --> B[Phase 2<br>Control-path granularity]
+  B --> C[Phase 3<br>RDMA or MTCP micro-optimizations]
+  C --> D[Phase 4<br>Rollout and guardrails]
+```
+
+## Phase 1: 观测与归因基线
+
+新增 request 级小包性能快照（以统计为主，不在默认热路径打印）：
+
+- `control_queue_wait_us`
+- `control_send_us`
+- `first_window_emit_us`
+- `rdma_windows_total`
+- `rdma_ack_rounds_total`
+- `rdma_wr_posted_total`
+- `rdma_cq_completion_total`
+- `mtcp_staging_wait_us`
+- `mtcp_future_wait_us`
+
+落点：
+
+- request 生命周期：`core/communicator/transport/request.h`
+- engine 控制路径：`core/communicator/engine/engine.cc`
+- transport 数据路径：`core/communicator/transport/rdma_transport.cc`、`core/communicator/transport/mtcp_transport.cc`
+
+原则：
+
+1. 默认仅聚合指标，不逐请求 `INFO` 输出。
+2. 允许按采样率输出 debug 详情，避免常态噪声。
+
+## Phase 2: 控制路径与窗口/ACK 粒度
+
+### 2.1 请求分发并行化（保持每 peer 顺序）
+
+将单请求线程升级为“分片队列 + 固定 worker 池”：
+
+- 按 `dst_url` 哈希分片，保证同 peer 请求顺序。
+- 不改变 `pending_requests_` 语义。
+- 默认 worker 数为 `1`，与旧行为一致。
+
+### 2.2 RDMA refill budget
+
+在 `resume_rdma_reads()` 引入每次 pass 的推进预算，不再“有进展即 break”：
+
+- 预算维度：`window` 数或 `bytes`。
+- 保持 credit 安全边界（不突破 `FlowCreditLedger`）。
+- 当达到预算后再等待 ACK，减少频繁控制往返。
+
+### 2.3 ACK 批处理窗口
+
+在保持 lease 生命周期正确性的前提下，允许同一 request 的多个已完成 window 合并 ACK（受上限和超时约束）：
+
+- 限制最大延迟，避免 source 侧 credit 长时间不归还。
+- 保持最终窗口完成语义与失败语义不变。
+
+## Phase 3: RDMA / MTCP 微优化
+
+### 3.1 RDMA inflight bookkeeping 批化
+
+将“每 WR 入队一个 request 指针”优化为“每 post 批次一个 inflight 记录 + remaining 计数”，减少队列 push/pop 次数。
+
+### 3.2 RDMA completion signal 间隔化（可控）
+
+引入可配置的 signaled WR 间隔（默认 `1` 保持旧行为），在稳定场景下降低 CQ 事件密度。
+
+### 3.3 MTCP staged 路径去阻塞化
+
+减少 `std::async + wait/get` 串行等待链，优先复用已有 async task 跟踪机制；把 credit 不足等待从“主动 sleep 退避”向“事件驱动唤醒”收敛。
+
+### 3.4 热路径日志降噪
+
+将高频 `LOG(INFO)` 下沉到 `VLOG(1/2)` 或采样日志，保留 `WARNING/ERROR` 与关键一次性 `INFO`。
+
+## Phase 4: 渐进上线
+
+1. 先启用观测，不改行为。
+2. 启用控制粒度优化（默认保守值）。
+3. 在小规模灰度中启用 RDMA/MTCP 微优化。
+4. 达到阈值后将新参数作为推荐默认值写入文档。
+
+# Proposed Config Additions
+
+以下字段属于统一 runtime 配置扩展，目标文件为 `proto/tensorcast/communicator/v1/communicator_config.proto`：
+
+- `TransportConfig.request_worker_count`
+- `RdmaConfig.resume_max_windows_per_pass`
+- `RdmaConfig.ack_batch_max_windows`
+- `RdmaConfig.ack_batch_max_delay_us`
+- `RdmaConfig.unsignaled_wr_interval`
+- `TransportConfig.hotpath_log_sample_rate`
+
+默认值全部保持兼容旧行为（`1` 或 `0` 表示关闭新策略）。
+
+# Invariants & Error Model
+
+1. `pending_requests_` 生命周期不变，结果回调仍负责清理。
+2. 不允许因为 ACK 批处理导致 credit 永久不归还。
+3. refill budget 不能突破 `FlowCreditLedger` 上限。
+4. 发生 transport 错误时，`ReadRequest::set_result()` 仍保持幂等完成。
+5. 任何优化都不允许引入“静默 fallback + 吞错”。
+
+# Schema Changes
+
+无数据库 schema 变更，不涉及 `schema.sql`。
+
+# Naming Compliance
+
+本设计新增接口/字段遵循仓库命名规则：
+
+- C++ class / struct（PascalCase）
+  - `SmallPacketPerfSnapshot`
+  - `RdmaInflightBatch`
+- C++ functions / methods（snake_case）
+  - `resume_rdma_reads_with_budget`
+  - `flush_pending_rdma_ack_batch`
+  - `enqueue_request_shard`
+- Proto fields（snake_case）
+  - `request_worker_count`
+  - `resume_max_windows_per_pass`
+  - `ack_batch_max_windows`
+  - `ack_batch_max_delay_us`
+  - `unsignaled_wr_interval`
+  - `hotpath_log_sample_rate`
+- 常量（ALL_CAPS）
+  - `kDefaultResumeMaxWindowsPerPass`
+  - `kDefaultAckBatchMaxDelayUs`
+
+# Trade-offs & Risks
+
+1. 并行 request worker 增加并发复杂度，若分片策略不当可能引入顺序回归。
+2. ACK 批处理可能提升吞吐但加大短时内存占用；需要严格 TTL 与上限。
+3. unsignaled WR 间隔化会降低 CQ 压力，但错误可见性变慢；需保留保守默认值。
+4. MTCP 去阻塞化涉及线程模型调整，必须先由观测数据证明收益再扩大范围。
+
+# Compatibility & Acceptance Criteria
+
+## 功能正确性
+
+1. 现有 API 与 wire 语义保持兼容。
+2. `bazel test //core/communicator:rdma_engine_test`、`//core/communicator:staging_flow_controller_test`、`//core/communicator:request_test`、`//core/communicator:mtcp_transport_lane_test` 全通过。
+
+## 性能验收
+
+在与 [20260316 baseline](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md) 同口径的单 NIC 严格 direct RDMA 读测下：
+
+1. `32 MiB` 从 `18.56 GB/s` 提升到 `>= 21.00 GB/s`。
+2. `64 MiB` 从 `20.56 GB/s` 提升到 `>= 22.00 GB/s`。
+3. `256 MiB+` 相对 baseline 不回退超过 `3%`。
+4. 新增指标显示 `rdma_ack_rounds_total` 与 `rdma_wr_posted_total / request` 在小包场景下降低。
+
+## 可运维性
+
+1. 热路径 `INFO` 日志量显著下降（以请求数归一化统计）。
+2. 所有调优项可通过配置单独关闭并回退旧行为。
+
+# References
+
+- [Communicator vs Transfer Engine Comparison (2026-03-16)](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md)
+- [Communicator RDMA NIC / GDR Structured Summary (2026-03-15)](../benchmarks/20260315-communicator-rdma-nic-gdr-progress.md)
+- [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+- [core/communicator/engine/staging_flow_controller.cc](../../core/communicator/engine/staging_flow_controller.cc)
+- [core/communicator/transport/rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc)
+- [core/communicator/transport/request.h](../../core/communicator/transport/request.h)
+- [core/communicator/transport/mtcp_transport.cc](../../core/communicator/transport/mtcp_transport.cc)
+- [proto/tensorcast/communicator/v1/communicator_config.proto](../../proto/tensorcast/communicator/v1/communicator_config.proto)

--- a/docs/designs/0105-communicator-small-packet-latency-and-throughput-optimization.md
+++ b/docs/designs/0105-communicator-small-packet-latency-and-throughput-optimization.md
@@ -4,7 +4,7 @@ title: Communicator Small-Packet Latency and Throughput Optimization (Design)
 status: draft
 areas: ["core", "proto", "docs", "benchmarks"]
 created: 2026-03-18
-last_updated: 2026-03-18
+last_updated: 2026-03-22
 related_code:
   - docs/benchmarks/20260316-communicator-vs-transfer-engine-comparison.md
   - docs/benchmarks/20260315-communicator-rdma-nic-gdr-progress.md
@@ -27,11 +27,17 @@ links:
 
 `2026-03-16` 对比数据显示，communicator 在单次逻辑请求规模较小（`32 MiB`、`64 MiB`）时，仍明显落后于相关工作（Mooncake Transfer Engine），而在 `256 MiB+` 时已进入同一性能等级。
 
-当前结论是：瓶颈主要来自“小包/中包下固定开销与控制粒度”，而不是大块 direct RDMA 数据面带宽上限。
+在 `0105` 的复盘中，发现此前“带宽下降”有一部分来自测量区间内非数据传输成本（如初始化、buffer clear/verify、校验拷贝等）抬高了分母；这与最初想回答的“任务过程中非数据面成本占比”不完全一致。
+
+因此本设计将目标调整为：
+
+1. 优先量化任务过程中的非数据传输代价。
+2. 区分“一次性可均摊成本”与“每次传输重复成本”。
+3. 在上述可归因前提下，再推进控制面/数据面优化决策。
 
 本设计给出一个分阶段方案：
 
-1. 先补齐可归因观测，量化每个固定开销项。
+1. 先补齐可归因观测，量化每个开销项，并明确 amortizable vs recurring 分类。
 2. 优化控制路径与窗口/ACK 粒度，降低每个逻辑请求的控制往返成本。
 3. 优化 RDMA/MTCP 热路径中的每 WR bookkeeping、future/wait 和日志噪声。
 4. 在严格回归和可回滚前提下渐进上线。
@@ -100,11 +106,12 @@ MTCP transport 侧存在大量 `std::async` 与 `future.get()/wait()` 等待链�
 
 ## Goals
 
-1. 缩小 communicator 在 `32 MiB`、`64 MiB` logical request 下与 related work 的性能差距。
-2. 降低每个逻辑请求的固定控制开销与 WR bookkeeping 成本。
-3. 保持 `256 MiB+` direct RDMA 路径无明显回退。
-4. 方案默认可控、可回滚，不引入隐式环境变量开关。
-5. 所有新调优项进入统一 runtime 配置（`communicator_config.proto`），遵循 [0004-unified-runtime-config.md](./0004-unified-runtime-config.md)。
+1. 量化 communicator benchmark 中非数据传输代价，并提供可复现的字段化输出。
+2. 将开销拆分为“一次性可均摊成本”（初始化、预热）与“每次传输重复成本”（clear、enqueue、wait、verify）。
+3. 显式覆盖用户关注项：数据拷贝成本、内存分配成本、校验成本。
+4. 在保持 `256 MiB+` direct RDMA 路径无明显回退的前提下，为后续优化提供归因基线。
+5. 方案默认可控、可回滚，不引入隐式环境变量开关。
+6. 所有新调优项进入统一 runtime 配置（`communicator_config.proto`），遵循 [0004-unified-runtime-config.md](./0004-unified-runtime-config.md)。
 
 ## Non-Goals
 
@@ -126,7 +133,7 @@ flowchart LR
 
 ## Phase 1: 观测与归因基线
 
-新增 request 级小包性能快照（以统计为主，不在默认热路径打印）：
+新增 request/batch 级性能快照（以统计为主，不在默认热路径打印）：
 
 - `control_queue_wait_us`
 - `control_send_us`
@@ -137,17 +144,26 @@ flowchart LR
 - `rdma_cq_completion_total`
 - `mtcp_staging_wait_us`
 - `mtcp_future_wait_us`
+- `amortizable_init_*`（init / buffer allocation / warmup）
+- `recurring_*`（clear / issue / wait / verify）
+- `verify_buffer_alloc_us`
+- `verify_copy_us`
+- `verify_checksum_us`
+- `amortized_per_iteration_us`
+- `amortized_per_request_us`
 
 落点：
 
 - request 生命周期：`core/communicator/transport/request.h`
 - engine 控制路径：`core/communicator/engine/engine.cc`
 - transport 数据路径：`core/communicator/transport/rdma_transport.cc`、`core/communicator/transport/mtcp_transport.cc`
+- benchmark 输出层：`core/communicator/bench/communicator_bench.cc`
 
 原则：
 
 1. 默认仅聚合指标，不逐请求 `INFO` 输出。
-2. 允许按采样率输出 debug 详情，避免常态噪声。
+2. `ITER` 输出用于定位单轮瓶颈，`SUMMARY` 输出用于 amortizable/recurring 归因。
+3. 允许按采样率输出 debug 详情，避免常态噪声。
 
 ## Phase 2: 控制路径与窗口/ACK 粒度
 
@@ -264,10 +280,11 @@ flowchart LR
 
 在与 [20260316 baseline](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md) 同口径的单 NIC 严格 direct RDMA 读测下：
 
-1. `32 MiB` 从 `18.56 GB/s` 提升到 `>= 21.00 GB/s`。
-2. `64 MiB` 从 `20.56 GB/s` 提升到 `>= 22.00 GB/s`。
-3. `256 MiB+` 相对 baseline 不回退超过 `3%`。
-4. 新增指标显示 `rdma_ack_rounds_total` 与 `rdma_wr_posted_total / request` 在小包场景下降低。
+1. `ITER` 与 `SUMMARY` 必须同时给出 amortizable 与 recurring 字段，且覆盖 clear/issue/wait/verify 子项。
+2. `verify` 需明确拆分 `buffer_alloc`、`copy`、`checksum`，可判断是否每轮重复发生。
+3. 必须给出 `amortized_per_iteration_us` 与 `amortized_per_request_us`，支持“一次性成本均摊后”的读法。
+4. `256 MiB+` 相对 baseline 吞吐不回退超过 `3%`（带宽保留为护栏指标，而非唯一目标）。
+5. 新增指标可用于判定小包瓶颈是否主要落在控制面与重复开销，而非纯数据面极限。
 
 ## 可运维性
 

--- a/docs/plans/0105-communicator-small-packet-latency-and-throughput-optimization.md
+++ b/docs/plans/0105-communicator-small-packet-latency-and-throughput-optimization.md
@@ -1,0 +1,175 @@
+---
+slug: communicator-small-packet-latency-and-throughput-optimization
+title: Communicator Small-Packet Latency and Throughput Optimization (Plan)
+links:
+  design: ../designs/0105-communicator-small-packet-latency-and-throughput-optimization.md
+areas:
+  - core
+  - proto
+  - docs
+  - benchmarks
+related_code:
+  - docs/benchmarks/20260316-communicator-vs-transfer-engine-comparison.md
+  - docs/benchmarks/20260315-communicator-rdma-nic-gdr-progress.md
+  - core/communicator/engine/engine.cc
+  - core/communicator/engine/engine.h
+  - core/communicator/engine/staging_flow_controller.cc
+  - core/communicator/transport/rdma_transport.cc
+  - core/communicator/transport/request.h
+  - core/communicator/transport/mtcp_transport.cc
+  - proto/tensorcast/communicator/v1/communicator_config.proto
+---
+
+# Objective
+
+围绕 `0105` 设计落地一套“小包/中包性能优化执行路径”，目标是在不破坏 `256 MiB+` 现有吞吐水平的前提下，系统性缩小 communicator 在 `32 MiB`、`64 MiB` 单次逻辑请求上的性能差距，并把优化过程做成可观测、可灰度、可回滚。
+
+# Current State & Grounding
+
+## Baseline（2026-03-16）
+
+来自 [20260316-communicator-vs-transfer-engine-comparison.md](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md)：
+
+| Logical request size | Communicator | Transfer Engine | Gap |
+| --- | --- | --- | --- |
+| `32 MiB` | `18.56 GB/s` | `22.49 GB/s` | `-3.93 GB/s` (`-17.5%`) |
+| `64 MiB` | `20.56 GB/s` | `22.75 GB/s` | `-2.19 GB/s` (`-9.6%`) |
+| `256 MiB` | `23.17 GB/s` | `23.02 GB/s` | 同一性能等级 |
+| `1 GiB` | `23.96 GB/s` | `23.69 GB/s` | 同一性能等级 |
+
+## 已确认的代码侧瓶颈锚点
+
+1. 请求控制面当前是单线程串行消费
+   - 请求线程创建: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+   - 循环处理入口 `do_read_request_loop()`: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+   - 队列/在途表定义 `request_queue_`、`pending_requests_`: [core/communicator/engine/engine.h](../../core/communicator/engine/engine.h)
+2. RDMA refill/ACK 推进节奏偏保守
+   - `resume_rdma_reads()` 在 `made_progress` 后立即 break: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+   - `ENGINE_OP_RDMA_READ_DONE_EX` 中 ACK 后再触发 refill: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+3. RDMA 路径每 WR bookkeeping 粒度较细
+   - `read_multi()` 每个 posted WR 都会 `enqueue_completion_bytes` 和 `per_qp_inflight_queues_.push(...)`: [core/communicator/transport/rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc)
+   - `do_process_wc()` 每个 completion 都 `pop` 并更新请求完成态: [core/communicator/transport/rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc)
+   - ACK/完成跟踪结构在 `ReadRequest`: [core/communicator/transport/request.h](../../core/communicator/transport/request.h)
+4. MTCP staged 路径存在较重等待链
+   - staging 线程串行消费 `mtcp_staging_queue_`: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+   - MTCP 发送/接收路径包含大量 `std::async` 与 future `wait/get`: [core/communicator/transport/mtcp_transport.cc](../../core/communicator/transport/mtcp_transport.cc)
+5. 热路径 `LOG(INFO)` 频率偏高
+   - 典型热点包括 `read_tensor` 入队、`resume_rdma_reads`、`read_multi` posted/completion 等路径（同上文件）。
+
+## 约束与边界
+
+1. 配置必须走统一 runtime config，不引入临时环境变量开关（见 [0004-unified-runtime-config.md](../designs/0004-unified-runtime-config.md) 与 [communicator_config.proto](../../proto/tensorcast/communicator/v1/communicator_config.proto)）。
+2. `pending_requests_` 生命周期语义、错误传播语义、`ReadRequest::set_result()` 幂等行为不得破坏。
+3. `FlowCreditLedger` 的 credit 上限与释放路径必须保持安全约束（[core/communicator/engine/staging_flow_controller.cc](../../core/communicator/engine/staging_flow_controller.cc)）。
+
+# Phases & Milestones
+
+- [ ] Phase 0: 基线冻结与观测口径统一
+  - [ ] Milestone 0.1: 固化本轮优化对比口径（`32/64/256 MiB`, `threads=1`, `batch_size=1`，单 NIC strict direct RDMA）。
+  - [ ] Milestone 0.2: 固化 benchmark 产出字段和解析规则（优先 `bw_GBps`，兼容 legacy `bw_gbps`）。
+  - [ ] Milestone 0.3: 记录基线 case 元数据（host pair、GPU/NIC 对应、qp/outstanding 配置）。
+
+- [ ] Phase 1: Instrumentation First（先观测后优化）
+  - [ ] Milestone 1.1: 在 `ReadRequest` 增加 request 级统计快照容器（不改变现有完成语义）。
+  - [ ] Milestone 1.2: 在 engine/transport 关键路径补齐统计埋点（queue wait、control send、window/ack 轮次、WR posted/completion、MTCP 等待时间）。
+  - [ ] Milestone 1.3: 默认仅聚合统计，不输出逐请求 `INFO`；支持采样调试输出。
+  - [ ] Milestone 1.4: 产出“固定开销分解报表”作为 Phase 2 输入门槛。
+
+- [ ] Phase 2: 控制路径与窗口粒度优化
+  - [ ] Milestone 2.1: 把单请求线程演进为“按 peer 分片 + 固定 worker 池”，默认 `worker_count=1` 保持旧行为。
+  - [ ] Milestone 2.2: `resume_rdma_reads()` 引入 per-pass budget（window 或 bytes 预算），替代“有进展即等待 ACK”策略。
+  - [ ] Milestone 2.3: ACK 批处理策略落地（最大窗口数 + 最大延迟约束），保证 credit 能及时回收。
+  - [ ] Milestone 2.4: 完成功能回归与小流量灰度验证。
+
+- [ ] Phase 3: RDMA/MTCP 数据面微优化
+  - [ ] Milestone 3.1: RDMA inflight bookkeeping 从“每 WR 记录”收敛到“批记录 + remaining 计数”。
+  - [ ] Milestone 3.2: 增加可控 signaled WR 间隔能力（默认兼容旧行为）。
+  - [ ] Milestone 3.3: MTCP staged 路径减少 future 串行等待与主动 sleep 退避，向事件驱动推进。
+  - [ ] Milestone 3.4: 热路径日志降噪完成（`INFO -> VLOG` 或采样）。
+
+- [ ] Phase 4: 验收、灰度与默认值收敛
+  - [ ] Milestone 4.1: 跑通完整验证矩阵（功能、性能、非退化、稳定性）。
+  - [ ] Milestone 4.2: 达成验收阈值后形成推荐配置默认值。
+  - [ ] Milestone 4.3: 完成文档同步（设计、计划、benchmark 结果页）。
+
+# Tasks
+
+## 模块任务拆分
+
+| 模块 | 任务 | 关键文件 |
+| --- | --- | --- |
+| Engine 调度层 | 请求分片队列与 worker 池、RDMA refill budget、ACK 批处理触发策略 | [engine.cc](../../core/communicator/engine/engine.cc), [engine.h](../../core/communicator/engine/engine.h) |
+| Flow 控制层 | credit 边界校验、预算推进与释放安全性回归 | [staging_flow_controller.cc](../../core/communicator/engine/staging_flow_controller.cc) |
+| RDMA 传输层 | inflight 批化、signaled 间隔化、completion 处理路径适配 | [rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc) |
+| Request 状态层 | request 级统计聚合、ACK 队列批处理元数据 | [request.h](../../core/communicator/transport/request.h) |
+| MTCP 传输层 | 去除高成本等待链、减少主动退避等待 | [mtcp_transport.cc](../../core/communicator/transport/mtcp_transport.cc) |
+| 配置与协议 | 新增优化配置项并保持默认兼容 | [communicator_config.proto](../../proto/tensorcast/communicator/v1/communicator_config.proto) |
+| 基准与文档 | benchmark 复测、结果归档、设计/计划同步更新 | [20260316 comparison](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md), [20260315 progress](../benchmarks/20260315-communicator-rdma-nic-gdr-progress.md) |
+
+## 执行顺序约束
+
+1. 必须先完成 Phase 1 观测再进入 Phase 2/3，避免“盲调”。
+2. Phase 2 与 Phase 3 可分支并行，但每项优化都必须以 Phase 1 指标下降为前提。
+3. 配置项先加字段再开策略，默认值必须保持旧行为。
+
+# Test / Rollout / Backout
+
+## Validation Matrix
+
+| 维度 | 内容 | 通过标准 |
+| --- | --- | --- |
+| 单元/组件回归 | `//core/communicator:request_test`, `:rdma_engine_test`, `:staging_flow_controller_test`, `:mtcp_transport_lane_test`, `:mtcp_transfer_completion_tracker_test`, `:tcp_engine_test` | 全通过，无新增 flaky |
+| 配置回归 | `//core/communicator:config_io_test` + 新增配置字段读写/默认值测试 | 新字段默认值等价旧行为 |
+| 小包性能 | `32 MiB`、`64 MiB` strict direct RDMA 单请求对比 baseline | 达到设计阈值（`>=21.0 GB/s`、`>=22.0 GB/s`） |
+| 大包非退化 | `256 MiB`、`1 GiB` 同口径复测 | 相对 baseline 回退不超过 `3%` |
+| 结构性指标 | `rdma_ack_rounds_total`、每请求 `rdma_wr_posted_total`、控制面耗时项 | 小包场景相对 baseline 显著下降 |
+| 稳定性 | 长时压测 + error path（ACK 延迟、部分 post 失败、MTCP fallback） | 无死锁/泄漏/静默失败 |
+
+## 执行命令（示例）
+
+1. C++ 回归：
+   - `bazel test //core/communicator:request_test`
+   - `bazel test //core/communicator:rdma_engine_test`
+   - `bazel test //core/communicator:staging_flow_controller_test`
+   - `bazel test //core/communicator:mtcp_transport_lane_test`
+   - `bazel test //core/communicator:mtcp_transfer_completion_tracker_test`
+   - `bazel test //core/communicator:tcp_engine_test`
+   - `bazel test //core/communicator:config_io_test`
+2. benchmark 工具链：
+   - `tools/communicator/run_bench_case.py`
+   - `tools/communicator/launch_remote_bench_case.py`
+   - `tools/communicator/render_te_comparison_charts.py`
+
+## Rollout
+
+1. 第一步只上线观测埋点（策略默认关闭）。
+2. 第二步灰度启用控制粒度优化（请求 worker、refill budget、ACK batch）。
+3. 第三步灰度启用 RDMA/MTCP 微优化（bookkeeping/signaled/等待链优化）。
+4. 第四步根据验收结果收敛推荐默认值并更新文档。
+
+## Backout
+
+1. 所有新策略均可通过配置项单独关闭并回退到旧行为。
+2. 若出现 `256 MiB+` 回退或稳定性问题，优先回退 Phase 3，再回退 Phase 2。
+3. 保留 Phase 1 观测能力，用于回退后的二次定位。
+
+# Risks & Tracking
+
+- [ ] 风险 1: 请求 worker 并行化引入顺序语义回归
+  - 跟踪: 按 peer 分片保证顺序，补充顺序一致性测试。
+- [ ] 风险 2: ACK 批处理导致 credit 回收变慢或堆积
+  - 跟踪: 设置 `ack_batch_max_windows` 与 `ack_batch_max_delay_us` 双阈值，增加超时告警。
+- [ ] 风险 3: unsignaled WR 间隔化影响错误可见性
+  - 跟踪: 默认 `1`，灰度阶段逐步放大并监控 completion 异常率。
+- [ ] 风险 4: MTCP 去阻塞化修改并发模型引入隐性死锁
+  - 跟踪: 增加压力和超时失败路径测试，确保线程池不被阻塞等待。
+- [ ] 风险 5: 热路径日志降噪影响问题定位
+  - 跟踪: 保留采样日志与 debug 开关，确保关键错误仍保留 `WARNING/ERROR`。
+
+# Owner Checklist
+
+- [ ] 设计/计划双向链接已建立且可解析。
+- [ ] 里程碑均为可验证结果，不是实现动作描述。
+- [ ] 所有配置增量遵循统一 runtime config。
+- [ ] 验收矩阵覆盖“性能提升 + 非退化 + 稳定性 + 可回滚”。
+- [ ] benchmark 结果文档在每轮关键里程碑后同步更新。

--- a/docs/plans/0105-communicator-small-packet-latency-and-throughput-optimization.md
+++ b/docs/plans/0105-communicator-small-packet-latency-and-throughput-optimization.md
@@ -22,7 +22,7 @@ related_code:
 
 # Objective
 
-围绕 `0105` 设计落地一套“小包/中包性能优化执行路径”，目标是在不破坏 `256 MiB+` 现有吞吐水平的前提下，系统性缩小 communicator 在 `32 MiB`、`64 MiB` 单次逻辑请求上的性能差距，并把优化过程做成可观测、可灰度、可回滚。
+围绕 `0105` 设计落地一套“非数据传输代价量化 + 定向优化”执行路径。第一目标不是直接追求单一带宽数字，而是把任务过程中的非数据面成本拆分清楚：哪些属于一次性可均摊成本，哪些是每次传输都要重复支付的成本；在此基础上再推进小包/中包优化，同时保持 `256 MiB+` 吞吐不回退。
 
 # Current State & Grounding
 
@@ -66,14 +66,14 @@ related_code:
 
 - [ ] Phase 0: 基线冻结与观测口径统一
   - [ ] Milestone 0.1: 固化本轮优化对比口径（`32/64/256 MiB`, `threads=1`, `batch_size=1`，单 NIC strict direct RDMA）。
-  - [ ] Milestone 0.2: 固化 benchmark 产出字段和解析规则（优先 `bw_GBps`，兼容 legacy `bw_gbps`）。
+  - [ ] Milestone 0.2: 固化 benchmark 产出字段和解析规则（优先 `amortizable_*` 与 `recurring_*`，并保留 `bw_GBps`/`bw_gbps` 兼容）。
   - [ ] Milestone 0.3: 记录基线 case 元数据（host pair、GPU/NIC 对应、qp/outstanding 配置）。
 
 - [ ] Phase 1: Instrumentation First（先观测后优化）
   - [ ] Milestone 1.1: 在 `ReadRequest` 增加 request 级统计快照容器（不改变现有完成语义）。
-  - [ ] Milestone 1.2: 在 engine/transport 关键路径补齐统计埋点（queue wait、control send、window/ack 轮次、WR posted/completion、MTCP 等待时间）。
-  - [ ] Milestone 1.3: 默认仅聚合统计，不输出逐请求 `INFO`；支持采样调试输出。
-  - [ ] Milestone 1.4: 产出“固定开销分解报表”作为 Phase 2 输入门槛。
+  - [ ] Milestone 1.2: 在 benchmark/engine/transport 关键路径补齐统计埋点（queue wait、control send、window/ack 轮次、WR posted/completion、MTCP 等待时间）。
+  - [ ] Milestone 1.3: benchmark 输出提供 amortizable（init/warmup）与 recurring（clear/issue/wait/verify）字段，并支持 per-iteration/per-request 均摊视角。
+  - [ ] Milestone 1.4: `verify` 开销拆分为内存分配、数据拷贝、校验计算三个子项，形成“可均摊/不可均摊”归因报表。
 
 - [ ] Phase 2: 控制路径与窗口粒度优化
   - [ ] Milestone 2.1: 把单请求线程演进为“按 peer 分片 + 固定 worker 池”，默认 `worker_count=1` 保持旧行为。
@@ -120,9 +120,10 @@ related_code:
 | --- | --- | --- |
 | 单元/组件回归 | `//core/communicator:request_test`, `:rdma_engine_test`, `:staging_flow_controller_test`, `:mtcp_transport_lane_test`, `:mtcp_transfer_completion_tracker_test`, `:tcp_engine_test` | 全通过，无新增 flaky |
 | 配置回归 | `//core/communicator:config_io_test` + 新增配置字段读写/默认值测试 | 新字段默认值等价旧行为 |
-| 小包性能 | `32 MiB`、`64 MiB` strict direct RDMA 单请求对比 baseline | 达到设计阈值（`>=21.0 GB/s`、`>=22.0 GB/s`） |
+| 归因完整性 | `ITER`/`SUMMARY` 同时产出 amortizable + recurring 字段；`verify` 拆分 alloc/copy/checksum | 字段齐全，可稳定解析 |
+| 小包结构性指标 | `32 MiB`、`64 MiB` strict direct RDMA 单请求对比 baseline | 能量化 recurring 主项并识别 top bottleneck |
 | 大包非退化 | `256 MiB`、`1 GiB` 同口径复测 | 相对 baseline 回退不超过 `3%` |
-| 结构性指标 | `rdma_ack_rounds_total`、每请求 `rdma_wr_posted_total`、控制面耗时项 | 小包场景相对 baseline 显著下降 |
+| 成本分类 | `amortized_per_iteration_us`、`amortized_per_request_us` 与 recurring per-request 指标 | 可判断一次性成本是否可被后续传输均摊 |
 | 稳定性 | 长时压测 + error path（ACK 延迟、部分 post 失败、MTCP fallback） | 无死锁/泄漏/静默失败 |
 
 ## 执行命令（示例）

--- a/tools/communicator/launch_remote_bench_case.py
+++ b/tools/communicator/launch_remote_bench_case.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import os
 from pathlib import Path
 import shlex
 import subprocess
@@ -18,7 +19,11 @@ REPO_ROOT = Path("/data/workspace/tensorcast-280")
 BENCH_BINARY = REPO_ROOT / "bazel-bin/core/communicator/communicator_bench_binary"
 NAMESPACE = "shai-core"
 NUMA_WRAPPER = REPO_ROOT / "tools/communicator/run_with_numa_policy.py"
-RUN_AS_USER = subprocess.check_output(["id", "-un"], text=True).strip()
+RUN_AS_USER = (
+    os.environ.get("TENSORCAST_RUN_AS_USER")
+    or os.environ.get("BRAINCTL_RUN_AS_USER")
+    or subprocess.check_output(["id", "-un"], text=True).strip()
+).strip()
 
 
 def parse_bench_output(stdout: str) -> dict:
@@ -149,6 +154,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--charged-group", default="tensorcast_dev")
     parser.add_argument("--require-target-host", default="")
     parser.add_argument("--require-initiator-host", default="")
+    parser.add_argument("--keep-workers", action="store_true")
+    parser.add_argument("--target-worker-id", default="")
+    parser.add_argument("--initiator-worker-id", default="")
     return parser.parse_args()
 
 
@@ -397,6 +405,10 @@ def main() -> int:
         print("refuse to run remote workload as root", file=sys.stderr)
         return 2
     args = parse_args()
+    reuse_workers = bool(args.target_worker_id or args.initiator_worker_id)
+    if reuse_workers and (not args.target_worker_id or not args.initiator_worker_id):
+        print("both --target-worker-id and --initiator-worker-id are required when reusing workers", file=sys.stderr)
+        return 2
     case_dir = Path(args.case_dir)
     case_dir.mkdir(parents=True, exist_ok=True)
     write_json(
@@ -421,6 +433,10 @@ def main() -> int:
             "strict_direct_rdma": args.strict_direct_rdma,
             "bind_numa": args.bind_numa,
             "verify": not args.no_verify,
+            "keep_workers": args.keep_workers,
+            "reuse_workers": reuse_workers,
+            "target_worker_id": args.target_worker_id,
+            "initiator_worker_id": args.initiator_worker_id,
         },
     )
 
@@ -429,18 +445,27 @@ def main() -> int:
         return 2
 
     worker_ids: list[str] = []
+    launched_worker_ids: list[str] = []
     try:
-        predict_target = predict_worker(args, "target", case_dir / "launch_target_predict.json")
-        predict_initiator = predict_worker(args, "initiator", case_dir / "launch_initiator_predict.json")
-        if predict_target.returncode != 0 or predict_initiator.returncode != 0:
-            raise RuntimeError("predict-only failed for target or initiator")
+        if reuse_workers:
+            target_worker = args.target_worker_id
+            initiator_worker = args.initiator_worker_id
+            worker_ids.extend([target_worker, initiator_worker])
+            wait_worker_running(target_worker, timeout_sec=600)
+            wait_worker_running(initiator_worker, timeout_sec=600)
+        else:
+            predict_target = predict_worker(args, "target", case_dir / "launch_target_predict.json")
+            predict_initiator = predict_worker(args, "initiator", case_dir / "launch_initiator_predict.json")
+            if predict_target.returncode != 0 or predict_initiator.returncode != 0:
+                raise RuntimeError("predict-only failed for target or initiator")
 
-        target_worker = launch_worker(args, "target", case_dir / "launch_target.json")
-        initiator_worker = launch_worker(args, "initiator", case_dir / "launch_initiator.json")
-        worker_ids.extend([target_worker, initiator_worker])
+            target_worker = launch_worker(args, "target", case_dir / "launch_target.json")
+            initiator_worker = launch_worker(args, "initiator", case_dir / "launch_initiator.json")
+            worker_ids.extend([target_worker, initiator_worker])
+            launched_worker_ids.extend([target_worker, initiator_worker])
 
-        wait_worker_running(target_worker, timeout_sec=600)
-        wait_worker_running(initiator_worker, timeout_sec=600)
+            wait_worker_running(target_worker, timeout_sec=600)
+            wait_worker_running(initiator_worker, timeout_sec=600)
 
         target_host = remote_stdout(target_worker, "hostname", case_dir / "target_hostname_exec.json")
         initiator_host = remote_stdout(initiator_worker, "hostname", case_dir / "initiator_hostname_exec.json")
@@ -539,30 +564,58 @@ def main() -> int:
                 "batch_size": args.batch_size,
                 "qp_count": args.qp_count,
                 "outstanding_wr": args.outstanding_wr,
+                "reused_workers": reuse_workers,
                 "parsed": parsed,
             },
         )
         return initiator_result.returncode
     finally:
-        for worker_id, log_name in (
-            (worker_ids[0], "cleanup_target_worker.json") if len(worker_ids) > 0 else (None, None),
-            (worker_ids[1], "cleanup_initiator_worker.json") if len(worker_ids) > 1 else (None, None),
-        ):
-            if worker_id is None or log_name is None:
-                continue
+        if len(worker_ids) > 0:
             try:
                 brainctl_exec(
-                    worker_id,
+                    worker_ids[0],
                     (
                         f"if [ -f {shlex.quote(str(case_dir / 'target.pid'))} ]; then "
                         f"kill $(cat {shlex.quote(str(case_dir / 'target.pid'))}) >/dev/null 2>&1 || true; "
                         "fi"
                     ),
-                    case_dir / f"pre_{log_name}",
+                    case_dir / "pre_cleanup_target_process.json",
                 )
             except Exception:
                 pass
-            delete_worker(worker_id, case_dir / log_name)
+        if args.keep_workers:
+            write_json(
+                case_dir / "kept_workers.json",
+                {
+                    "target_worker": worker_ids[0] if len(worker_ids) > 0 else "",
+                    "initiator_worker": worker_ids[1] if len(worker_ids) > 1 else "",
+                },
+            )
+        else:
+            for worker_id, log_name in (
+                (launched_worker_ids[0], "cleanup_target_worker.json") if len(launched_worker_ids) > 0 else (None, None),
+                (
+                    launched_worker_ids[1],
+                    "cleanup_initiator_worker.json",
+                )
+                if len(launched_worker_ids) > 1
+                else (None, None),
+            ):
+                if worker_id is None or log_name is None:
+                    continue
+                try:
+                    brainctl_exec(
+                        worker_id,
+                        (
+                            f"if [ -f {shlex.quote(str(case_dir / 'target.pid'))} ]; then "
+                            f"kill $(cat {shlex.quote(str(case_dir / 'target.pid'))}) >/dev/null 2>&1 || true; "
+                            "fi"
+                        ),
+                        case_dir / f"pre_{log_name}",
+                    )
+                except Exception:
+                    pass
+                delete_worker(worker_id, case_dir / log_name)
 
 
 if __name__ == "__main__":

--- a/tools/communicator/launch_remote_bench_case.py
+++ b/tools/communicator/launch_remote_bench_case.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 import argparse
 import base64
+import contextlib
 import json
 import os
-from pathlib import Path
 import shlex
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 REPO_ROOT = Path("/data/workspace/tensorcast-280")
 BENCH_BINARY = REPO_ROOT / "bazel-bin/core/communicator/communicator_bench_binary"
@@ -152,6 +153,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--no-verify", action="store_true")
     parser.add_argument("--worker-max-wait-duration", default="20m")
     parser.add_argument("--charged-group", default="tensorcast_dev")
+    parser.add_argument("--worker-gpu", type=int, default=8)
+    parser.add_argument("--worker-cpu", type=int, default=8)
+    parser.add_argument("--worker-memory-mib", type=int, default=32768)
+    parser.add_argument("--private-machine", default="group")
+    parser.add_argument("--pool", default="")
+    parser.add_argument("--positive-tags", default="")
+    parser.add_argument("--negative-tags", default="")
     parser.add_argument("--require-target-host", default="")
     parser.add_argument("--require-initiator-host", default="")
     parser.add_argument("--keep-workers", action="store_true")
@@ -161,19 +169,17 @@ def parse_args() -> argparse.Namespace:
 
 
 def launch_flags(args: argparse.Namespace, comment: str) -> list[str]:
-    return [
+    flags = [
         "brainctl",
         "launch",
         "--charged-group",
         args.charged_group,
         "--gpu",
-        "8",
+        str(args.worker_gpu),
         "--cpu",
-        "8",
+        str(args.worker_cpu),
         "--memory",
-        "32768",
-        "--private-machine",
-        "group",
+        str(args.worker_memory_mib),
         "--host-network=true",
         "--custom-resources",
         "rdma/mlnx_shared=8",
@@ -184,6 +190,19 @@ def launch_flags(args: argparse.Namespace, comment: str) -> list[str]:
         "--comment",
         comment,
     ]
+    if args.private_machine:
+        flags.extend(["--private-machine", args.private_machine])
+    if args.pool:
+        flags.extend(["--pool", args.pool])
+    if args.positive_tags:
+        flags.extend(["--positive-tags", args.positive_tags])
+    if args.negative_tags:
+        flags.extend(["--negative-tags", args.negative_tags])
+    return flags
+
+
+def predict_reports_no_capacity(proc: subprocess.CompletedProcess[str]) -> bool:
+    return "no machine available" in proc.stdout.lower()
 
 
 def predict_worker(args: argparse.Namespace, role: str, log_path: Path) -> subprocess.CompletedProcess[str]:
@@ -415,6 +434,7 @@ def main() -> int:
         case_dir / "case_config.json",
         {
             "case_name": args.case_name,
+            "charged_group": args.charged_group,
             "memory": args.memory,
             "bytes": args.bytes,
             "target_gpu_id": args.target_gpu_id,
@@ -433,6 +453,13 @@ def main() -> int:
             "strict_direct_rdma": args.strict_direct_rdma,
             "bind_numa": args.bind_numa,
             "verify": not args.no_verify,
+            "worker_gpu": args.worker_gpu,
+            "worker_cpu": args.worker_cpu,
+            "worker_memory_mib": args.worker_memory_mib,
+            "private_machine": args.private_machine,
+            "pool": args.pool,
+            "positive_tags": args.positive_tags,
+            "negative_tags": args.negative_tags,
             "keep_workers": args.keep_workers,
             "reuse_workers": reuse_workers,
             "target_worker_id": args.target_worker_id,
@@ -458,6 +485,11 @@ def main() -> int:
             predict_initiator = predict_worker(args, "initiator", case_dir / "launch_initiator_predict.json")
             if predict_target.returncode != 0 or predict_initiator.returncode != 0:
                 raise RuntimeError("predict-only failed for target or initiator")
+            if predict_reports_no_capacity(predict_target) or predict_reports_no_capacity(predict_initiator):
+                raise RuntimeError(
+                    "predict-only reported no machine available for target or initiator; "
+                    "adjust scheduler constraints (private-machine/pool/positive-tags) or wait for capacity"
+                )
 
             target_worker = launch_worker(args, "target", case_dir / "launch_target.json")
             initiator_worker = launch_worker(args, "initiator", case_dir / "launch_initiator.json")
@@ -571,7 +603,7 @@ def main() -> int:
         return initiator_result.returncode
     finally:
         if len(worker_ids) > 0:
-            try:
+            with contextlib.suppress(Exception):
                 brainctl_exec(
                     worker_ids[0],
                     (
@@ -581,8 +613,6 @@ def main() -> int:
                     ),
                     case_dir / "pre_cleanup_target_process.json",
                 )
-            except Exception:
-                pass
         if args.keep_workers:
             write_json(
                 case_dir / "kept_workers.json",
@@ -603,7 +633,7 @@ def main() -> int:
             ):
                 if worker_id is None or log_name is None:
                     continue
-                try:
+                with contextlib.suppress(Exception):
                     brainctl_exec(
                         worker_id,
                         (
@@ -613,8 +643,6 @@ def main() -> int:
                         ),
                         case_dir / f"pre_{log_name}",
                     )
-                except Exception:
-                    pass
                 delete_worker(worker_id, case_dir / log_name)
 
 

--- a/tools/communicator/launch_remote_bench_case.py
+++ b/tools/communicator/launch_remote_bench_case.py
@@ -149,6 +149,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--case-timeout-sec", type=int, default=600)
     parser.add_argument("--direct-rdma", action="store_true")
     parser.add_argument("--strict-direct-rdma", action="store_true")
+    parser.add_argument("--rdma-profile", action="store_true")
     parser.add_argument("--bind-numa", action="store_true")
     parser.add_argument("--no-verify", action="store_true")
     parser.add_argument("--worker-max-wait-duration", default="20m")
@@ -393,6 +394,8 @@ def bench_shell_command(
         cmd.append("--direct-rdma")
     if args.strict_direct_rdma:
         cmd.append("--strict-direct-rdma")
+    if args.rdma_profile:
+        cmd.append("--rdma-profile")
 
     bench_cmd = shlex.join(cmd)
     nic_path = shlex.quote(nic)
@@ -408,12 +411,18 @@ def bench_shell_command(
     return shell
 
 
+def target_ready_from_log(content: str) -> bool:
+    has_structured_ready = "role=target" in content and "listen_port=" in content
+    has_rdma_register = "register done:" in content
+    return has_structured_ready or has_rdma_register
+
+
 def wait_for_ready_line(log_path: Path, timeout_sec: int) -> None:
     deadline = time.time() + timeout_sec
     while time.time() < deadline:
         if log_path.exists():
             content = log_path.read_text(encoding="utf-8", errors="ignore")
-            if "role=target" in content and "listen_port=" in content:
+            if target_ready_from_log(content):
                 return
         time.sleep(1)
     raise RuntimeError(f"target log did not reach READY before timeout: {log_path}")
@@ -451,6 +460,7 @@ def main() -> int:
             "case_timeout_sec": args.case_timeout_sec,
             "direct_rdma": args.direct_rdma,
             "strict_direct_rdma": args.strict_direct_rdma,
+            "rdma_profile": args.rdma_profile,
             "bind_numa": args.bind_numa,
             "verify": not args.no_verify,
             "worker_gpu": args.worker_gpu,
@@ -587,6 +597,7 @@ def main() -> int:
                 "bytes": args.bytes,
                 "direct_rdma": args.direct_rdma,
                 "strict_direct_rdma": args.strict_direct_rdma,
+                "rdma_profile": args.rdma_profile,
                 "bind_numa": args.bind_numa,
                 "verify": not args.no_verify,
                 "duration_sec": args.duration_sec,


### PR DESCRIPTION
## Background
The `0105` objective shifted from "bandwidth gap only" to "first quantify non-transfer costs."  
The existing communicator bench output did not clearly separate one-time startup overhead from per-iteration recurring overhead.

## What Changed
- Added layered profiling to communicator bench output:
- `READY`: startup costs (communicator init, buffer alloc/fill, tensor registration)
- `ITER`: per-iteration costs (clear, issue, wait, verify)
- `SUMMARY`: amortizable vs recurring aggregates and amortized metrics (per-iteration / per-request)
- Split verify overhead into explicit components:
- `verify_buffer_alloc_us`
- `verify_copy_us`
- `verify_checksum_us`
- Kept compatibility fields while adding clearer throughput naming:
- preserved `bw_gbps`
- added/standardized `bw_GBps`
- Updated remote benchmark launcher to support configurable scheduling/resources:
- worker resources: GPU/CPU/memory
- scheduler constraints: `private-machine`, `pool`, `positive-tags`, `negative-tags`
- Added fail-fast behavior when `predict-only` reports "no machine available"
- Persisted new launch/scheduler parameters into `case_config.json`
- Replaced broad `try/except: pass` cleanup blocks with `contextlib.suppress(Exception)` for cleaner control flow
- Updated `0105` design/plan/benchmark docs to align metric interpretation with amortizable/recurring attribution

## Compatibility / Behavior
- New fields are additive and do not break existing parsing
- `bw_gbps` is retained for backward compatibility
- Default launcher behavior remains equivalent to previous defaults (`8 GPU`, `8 CPU`, `32768 MiB`, `private-machine=group`)