### PR TITLE
style: fix clang-format code style issues and unify docs language to English

### DIFF
--- a/core/checkpoint/tensor_writer.h
+++ b/core/checkpoint/tensor_writer.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "aligned_buffer.h"
+
 namespace tensorcast::checkpoint {
 
 [[maybe_unused]] constexpr size_t kPartitionMaxSize = 10L << 30; // 10GB

--- a/core/common/trace/trace_manager.h
+++ b/core/common/trace/trace_manager.h
@@ -124,6 +124,7 @@ class TraceManager {
   static void set_current_artifact_id(const std::string& artifact_id) {
     tls_artifact_id_ = artifact_id;
   }
+
   static const std::string& current_artifact_id() {
     return tls_artifact_id_;
   }
@@ -133,6 +134,7 @@ class TraceManager {
     explicit ArtifactIdGuard(const std::string& artifact_id) : previous_id_(TraceManager::current_artifact_id()) {
       TraceManager::set_current_artifact_id(artifact_id);
     }
+
     ~ArtifactIdGuard() {
       TraceManager::set_current_artifact_id(previous_id_);
     }
@@ -180,6 +182,7 @@ class TraceSummaryGuard {
       const std::string& artifact_id,
       const std::string& request_id = TraceManager::current_request_id())
       : artifact_id_(artifact_id), request_id_(request_id) {}
+
   ~TraceSummaryGuard() {
     std::ostringstream oss;
     TraceManager::instance().dump_summary(artifact_id_, request_id_, oss);

--- a/core/communicator/bench/communicator_bench.cc
+++ b/core/communicator/bench/communicator_bench.cc
@@ -677,8 +677,7 @@ absl::Status probe_gpu_mr_registration(const Options& options, const RdmPrefligh
   tc::misc::wrap_ibv_dereg_mr(mr);
   std::ostringstream line;
   line << "GPU_MR_PROBE"
-       << " nic=" << probe_nic << " rail=" << dev->get_rail_id() << " bytes=" << probe_buffer.bytes()
-       << " status=ok";
+       << " nic=" << probe_nic << " rail=" << dev->get_rail_id() << " bytes=" << probe_buffer.bytes() << " status=ok";
   emit_machine_line(line.str());
   return absl::OkStatus();
 }
@@ -701,8 +700,7 @@ void print_preflight(const Options& options, const RdmPreflight& preflight) {
   line << " selected_nic=" << (preflight.selected_nic.empty() ? "-" : preflight.selected_nic)
        << " selected_rail=" << preflight.selected_rail_id;
   if (!preflight.gpu_name.empty()) {
-    line << " gpu=" << preflight.gpu_name << " gpu_bus=" << preflight.gpu_bus
-         << " gpu_device=" << preflight.gpu_device;
+    line << " gpu=" << preflight.gpu_name << " gpu_bus=" << preflight.gpu_bus << " gpu_device=" << preflight.gpu_device;
   }
   emit_machine_line(line.str());
 }
@@ -739,6 +737,7 @@ absl::Status run_target(const Options& options) {
     uint64_t buffer_fill_copy_us = 0;
     uint64_t register_tensor_us = 0;
   };
+
   TargetStartupProfile startup;
 
   auto cfg = make_config(options);
@@ -807,9 +806,9 @@ absl::Status run_target(const Options& options) {
              << " init_buffer_fill_alloc_us=" << startup.buffer_fill_alloc_us
              << " init_buffer_fill_pattern_us=" << startup.buffer_fill_pattern_us
              << " init_buffer_fill_copy_us=" << startup.buffer_fill_copy_us
-             << " init_register_tensor_us=" << startup.register_tensor_us
-             << " init_total_us="
-             << (startup.communicator_init_us + startup.buffer_alloc_us + startup.buffer_fill_us + startup.register_tensor_us);
+             << " init_register_tensor_us=" << startup.register_tensor_us << " init_total_us="
+             << (startup.communicator_init_us + startup.buffer_alloc_us + startup.buffer_fill_us +
+                 startup.register_tensor_us);
   emit_machine_line(ready_line.str());
 
   while (true) {
@@ -844,6 +843,7 @@ absl::Status run_initiator(const Options& options) {
     uint64_t buffer_initial_clear_us = 0;
     uint64_t warmup_total_us = 0;
   };
+
   InitiatorStartupProfile startup;
 
   auto cfg = make_config(options);
@@ -1041,7 +1041,8 @@ absl::Status run_initiator(const Options& options) {
                 << " batch_avg_verify_copy_per_request_us=" << avg_from_sum(batch_result.verify_copy_us)
                 << " batch_avg_verify_checksum_per_request_us=" << avg_from_sum(batch_result.verify_checksum_us)
                 << " iteration_total_us=" << batch_result.batch_total_us
-                << " batch_max_request_us=" << batch_result.max_request_us << " total_us=" << batch_result.batch_wall_us;
+                << " batch_max_request_us=" << batch_result.max_request_us
+                << " total_us=" << batch_result.batch_wall_us;
       std::lock_guard<std::mutex> lock(io_mu);
       emit_machine_line(iter_line.str());
     }
@@ -1062,6 +1063,7 @@ absl::Status run_initiator(const Options& options) {
 
   const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(std::max(0, options.duration_sec));
   std::vector<double> latencies_us;
+
   struct SummaryProfile {
     uint64_t iterations = 0;
     uint64_t requests = 0;
@@ -1086,6 +1088,7 @@ absl::Status run_initiator(const Options& options) {
     uint64_t sum_rdma_ack_windows = 0;
     uint64_t sum_rdma_ack_segments = 0;
   };
+
   SummaryProfile summary_profile;
   std::mutex stats_mu;
   std::mutex error_mu;
@@ -1194,58 +1197,54 @@ absl::Status run_initiator(const Options& options) {
   const uint64_t amortizable_init_total_us =
       startup.communicator_init_us + startup.buffer_alloc_us + startup.buffer_initial_clear_us;
   const uint64_t amortizable_total_us = amortizable_init_total_us + startup.warmup_total_us;
-  const auto amortized_per_iteration_us =
-      summary_profile.iterations == 0
-          ? 0.0
-          : static_cast<double>(amortizable_total_us) / static_cast<double>(summary_profile.iterations);
+  const auto amortized_per_iteration_us = summary_profile.iterations == 0
+      ? 0.0
+      : static_cast<double>(amortizable_total_us) / static_cast<double>(summary_profile.iterations);
   const auto amortized_per_request_us =
       total_requests == 0 ? 0.0 : static_cast<double>(amortizable_total_us) / static_cast<double>(total_requests);
   std::ostringstream summary_line;
-  summary_line << "SUMMARY"
-               << " iterations=" << completed_count << " requests=" << total_requests << " threads=" << options.threads
-               << " batch_size=" << options.batch_size << " qp_count=" << options.qp_count
-               << " outstanding_wr=" << options.outstanding_wr << " bytes=" << total_bytes << " wall_us=" << wall_us
-               << " avg_us=" << avg_us << " p50_us=" << percentile(50.0) << " p95_us=" << percentile(95.0)
-               << " p99_us=" << percentile(99.0) << " bw_GBps=" << bw_GBps << " bw_gbps=" << bw_gbps
-               << " amortizable_init_communicator_us=" << startup.communicator_init_us
-               << " amortizable_init_buffer_alloc_us=" << startup.buffer_alloc_us
-               << " amortizable_init_buffer_alloc_set_device_us=" << startup.buffer_alloc_set_device_us
-               << " amortizable_init_buffer_alloc_call_us=" << startup.buffer_alloc_call_us
-               << " amortizable_init_buffer_clear_us=" << startup.buffer_initial_clear_us
-               << " amortizable_warmup_total_us=" << startup.warmup_total_us
-               << " amortizable_init_total_us=" << amortizable_init_total_us
-               << " amortizable_total_us=" << amortizable_total_us
-               << " amortized_per_iteration_us=" << amortized_per_iteration_us
-               << " amortized_per_request_us=" << amortized_per_request_us
-               << " recurring_avg_iteration_total_us=" << avg_iteration_metric(summary_profile.sum_batch_total_us)
-               << " recurring_avg_clear_us=" << avg_iteration_metric(summary_profile.sum_clear_us)
-               << " recurring_avg_issue_us=" << avg_iteration_metric(summary_profile.sum_issue_us)
-               << " recurring_avg_wait_us=" << avg_iteration_metric(summary_profile.sum_wait_us)
-               << " recurring_avg_verify_total_us=" << avg_iteration_metric(summary_profile.sum_verify_total_us)
-               << " recurring_avg_verify_buffer_alloc_us="
-               << avg_iteration_metric(summary_profile.sum_verify_buffer_alloc_us)
-               << " recurring_avg_verify_copy_us=" << avg_iteration_metric(summary_profile.sum_verify_copy_us)
-               << " recurring_avg_verify_checksum_us=" << avg_iteration_metric(summary_profile.sum_verify_checksum_us)
-               << " recurring_avg_clear_per_request_us=" << avg_request_metric(summary_profile.sum_clear_us)
-               << " recurring_avg_verify_per_request_us=" << avg_request_metric(summary_profile.sum_verify_total_us)
-               << " recurring_avg_verify_buffer_alloc_per_request_us="
-               << avg_request_metric(summary_profile.sum_verify_buffer_alloc_us)
-               << " recurring_avg_verify_copy_per_request_us=" << avg_request_metric(summary_profile.sum_verify_copy_us)
-               << " recurring_avg_verify_checksum_per_request_us="
-               << avg_request_metric(summary_profile.sum_verify_checksum_us)
-               << " avg_response_wait_us=" << avg_request_metric(summary_profile.sum_request_first_response_us)
-               << " avg_first_post_us=" << avg_request_metric(summary_profile.sum_rdma_first_post_us)
-               << " avg_post_after_response_us=" << avg_request_metric(summary_profile.sum_rdma_post_after_response_us)
-               << " avg_data_phase_us=" << avg_request_metric(summary_profile.sum_rdma_post_to_last_completion_us)
-               << " avg_tail_after_last_completion_us="
-               << avg_request_metric(summary_profile.sum_tail_after_last_completion_us)
-               << " avg_handshake_wait_us=" << avg_request_metric(summary_profile.sum_rdma_handshake_queue_wait_us)
-               << " avg_response_windows=" << avg_request_metric(summary_profile.sum_rdma_response_windows)
-               << " avg_response_segments=" << avg_request_metric(summary_profile.sum_rdma_response_segments)
-               << " avg_wr_posted=" << avg_request_metric(summary_profile.sum_rdma_wr_posted)
-               << " avg_wc_completed=" << avg_request_metric(summary_profile.sum_rdma_wc_completed)
-               << " avg_ack_windows=" << avg_request_metric(summary_profile.sum_rdma_ack_windows)
-               << " avg_ack_segments=" << avg_request_metric(summary_profile.sum_rdma_ack_segments);
+  summary_line
+      << "SUMMARY"
+      << " iterations=" << completed_count << " requests=" << total_requests << " threads=" << options.threads
+      << " batch_size=" << options.batch_size << " qp_count=" << options.qp_count
+      << " outstanding_wr=" << options.outstanding_wr << " bytes=" << total_bytes << " wall_us=" << wall_us
+      << " avg_us=" << avg_us << " p50_us=" << percentile(50.0) << " p95_us=" << percentile(95.0)
+      << " p99_us=" << percentile(99.0) << " bw_GBps=" << bw_GBps << " bw_gbps=" << bw_gbps
+      << " amortizable_init_communicator_us=" << startup.communicator_init_us
+      << " amortizable_init_buffer_alloc_us=" << startup.buffer_alloc_us
+      << " amortizable_init_buffer_alloc_set_device_us=" << startup.buffer_alloc_set_device_us
+      << " amortizable_init_buffer_alloc_call_us=" << startup.buffer_alloc_call_us
+      << " amortizable_init_buffer_clear_us=" << startup.buffer_initial_clear_us
+      << " amortizable_warmup_total_us=" << startup.warmup_total_us
+      << " amortizable_init_total_us=" << amortizable_init_total_us << " amortizable_total_us=" << amortizable_total_us
+      << " amortized_per_iteration_us=" << amortized_per_iteration_us
+      << " amortized_per_request_us=" << amortized_per_request_us
+      << " recurring_avg_iteration_total_us=" << avg_iteration_metric(summary_profile.sum_batch_total_us)
+      << " recurring_avg_clear_us=" << avg_iteration_metric(summary_profile.sum_clear_us)
+      << " recurring_avg_issue_us=" << avg_iteration_metric(summary_profile.sum_issue_us)
+      << " recurring_avg_wait_us=" << avg_iteration_metric(summary_profile.sum_wait_us)
+      << " recurring_avg_verify_total_us=" << avg_iteration_metric(summary_profile.sum_verify_total_us)
+      << " recurring_avg_verify_buffer_alloc_us=" << avg_iteration_metric(summary_profile.sum_verify_buffer_alloc_us)
+      << " recurring_avg_verify_copy_us=" << avg_iteration_metric(summary_profile.sum_verify_copy_us)
+      << " recurring_avg_verify_checksum_us=" << avg_iteration_metric(summary_profile.sum_verify_checksum_us)
+      << " recurring_avg_clear_per_request_us=" << avg_request_metric(summary_profile.sum_clear_us)
+      << " recurring_avg_verify_per_request_us=" << avg_request_metric(summary_profile.sum_verify_total_us)
+      << " recurring_avg_verify_buffer_alloc_per_request_us="
+      << avg_request_metric(summary_profile.sum_verify_buffer_alloc_us)
+      << " recurring_avg_verify_copy_per_request_us=" << avg_request_metric(summary_profile.sum_verify_copy_us)
+      << " recurring_avg_verify_checksum_per_request_us=" << avg_request_metric(summary_profile.sum_verify_checksum_us)
+      << " avg_response_wait_us=" << avg_request_metric(summary_profile.sum_request_first_response_us)
+      << " avg_first_post_us=" << avg_request_metric(summary_profile.sum_rdma_first_post_us)
+      << " avg_post_after_response_us=" << avg_request_metric(summary_profile.sum_rdma_post_after_response_us)
+      << " avg_data_phase_us=" << avg_request_metric(summary_profile.sum_rdma_post_to_last_completion_us)
+      << " avg_tail_after_last_completion_us=" << avg_request_metric(summary_profile.sum_tail_after_last_completion_us)
+      << " avg_handshake_wait_us=" << avg_request_metric(summary_profile.sum_rdma_handshake_queue_wait_us)
+      << " avg_response_windows=" << avg_request_metric(summary_profile.sum_rdma_response_windows)
+      << " avg_response_segments=" << avg_request_metric(summary_profile.sum_rdma_response_segments)
+      << " avg_wr_posted=" << avg_request_metric(summary_profile.sum_rdma_wr_posted)
+      << " avg_wc_completed=" << avg_request_metric(summary_profile.sum_rdma_wc_completed)
+      << " avg_ack_windows=" << avg_request_metric(summary_profile.sum_rdma_ack_windows)
+      << " avg_ack_segments=" << avg_request_metric(summary_profile.sum_rdma_ack_segments);
   emit_machine_line(summary_line.str());
   return absl::OkStatus();
 }

--- a/core/communicator/config_io.cc
+++ b/core/communicator/config_io.cc
@@ -177,16 +177,15 @@ absl::StatusOr<tc::CommunicatorConfig> LoadCommunicatorConfigFromFile(const std:
   }
 
   // Handle boolean defaults that require presence checks on the original JSON
-  if (!(config_json->is_object()
-        && config_json->contains("stager") && (*config_json)["stager"].contains("stage_cpu_for_rdma"))) {
+  if (!(config_json->is_object() && config_json->contains("stager") &&
+        (*config_json)["stager"].contains("stage_cpu_for_rdma"))) {
     cfg.mutable_stager()->set_stage_cpu_for_rdma(true);
   }
-  if (!(config_json->is_object()
-        && config_json->contains("topology_discovery")
-        && (*config_json)["topology_discovery"].is_object()
-        && (*config_json)["topology_discovery"].contains("merge_policy")
-        && (*config_json)["topology_discovery"]["merge_policy"].is_object()
-        && (*config_json)["topology_discovery"]["merge_policy"].contains("emit_rail_switch_endpoints"))) {
+  if (!(config_json->is_object() && config_json->contains("topology_discovery") &&
+        (*config_json)["topology_discovery"].is_object() &&
+        (*config_json)["topology_discovery"].contains("merge_policy") &&
+        (*config_json)["topology_discovery"]["merge_policy"].is_object() &&
+        (*config_json)["topology_discovery"]["merge_policy"].contains("emit_rail_switch_endpoints"))) {
     cfg.mutable_topology_discovery()->mutable_merge_policy()->set_emit_rail_switch_endpoints(true);
   }
 

--- a/core/communicator/config_io_test.cc
+++ b/core/communicator/config_io_test.cc
@@ -46,8 +46,7 @@ transport:
   REQUIRE(cfg.transport().connect_timeout_sec() == 10);
   REQUIRE(cfg.transport().so_reuseport() == false);
   REQUIRE(cfg.topology_discovery().lldp().file_path() == "/host-config/lldp-info.txt");
-  REQUIRE(
-      cfg.topology_discovery().merge_policy().emit_rail_switch_endpoints() == true);
+  REQUIRE(cfg.topology_discovery().merge_policy().emit_rail_switch_endpoints() == true);
 }
 
 TEST_CASE("config_io JSON parse + defaults", "[communicator][config]") {
@@ -121,7 +120,6 @@ communicator:
       tensorcast::communicator::v1::NvlinkDiscoveryConfig::SOURCE_SNAPSHOT_FILE);
   REQUIRE(cfg.topology_discovery().nvlink().snapshot_file_path() == "/tmp/nvlink.txt");
   REQUIRE(cfg.topology_discovery().nvlink().required() == true);
-  REQUIRE(
-      cfg.topology_discovery().merge_policy().emit_rail_switch_endpoints() == false);
+  REQUIRE(cfg.topology_discovery().merge_policy().emit_rail_switch_endpoints() == false);
   REQUIRE(cfg.topology_discovery().merge_policy().require_connected() == true);
 }

--- a/core/communicator/engine/engine.cc
+++ b/core/communicator/engine/engine.cc
@@ -4,8 +4,8 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <cstring>
 #include <cstdlib>
+#include <cstring>
 #include <format>
 #include <limits>
 #include <map>
@@ -1705,15 +1705,16 @@ future_read_result_t Communicator::read_tensor_local(
 
   const uint64_t tensor_bytes = local_tensor->get_bytes();
   if (remote_offset > tensor_bytes || bytes > tensor_bytes - remote_offset) {
-    result.status = absl::OutOfRangeError(absl::StrCat(
-        "local read range out of bounds: key=",
-        key,
-        " offset=",
-        remote_offset,
-        " bytes=",
-        bytes,
-        " tensor_bytes=",
-        tensor_bytes));
+    result.status = absl::OutOfRangeError(
+        absl::StrCat(
+            "local read range out of bounds: key=",
+            key,
+            " offset=",
+            remote_offset,
+            " bytes=",
+            bytes,
+            " tensor_bytes=",
+            tensor_bytes));
     promise.set_value(std::move(result));
     return future;
   }
@@ -1750,8 +1751,7 @@ future_read_result_t Communicator::read_tensor_local(
       return status;
     }
     return absl::Status(
-        status.code(),
-        absl::StrCat("local tensor copy ", op, " failed for key=", key, ": ", status.message()));
+        status.code(), absl::StrCat("local tensor copy ", op, " failed for key=", key, ": ", status.message()));
   };
 
   absl::Status copy_status = absl::OkStatus();
@@ -1786,7 +1786,8 @@ future_read_result_t Communicator::read_tensor_local(
       }
     } else {
       int can_access = 0;
-      copy_status = wrap_cuda_status("device_can_access_peer", cuda::device_can_access_peer(&can_access, dev_id, src_dev_id));
+      copy_status =
+          wrap_cuda_status("device_can_access_peer", cuda::device_can_access_peer(&can_access, dev_id, src_dev_id));
       if (copy_status.ok() && can_access == 0) {
         copy_status = absl::FailedPreconditionError(
             absl::StrCat("peer access unavailable between dst_device=", dev_id, " and src_device=", src_dev_id));
@@ -1795,17 +1796,16 @@ future_read_result_t Communicator::read_tensor_local(
         copy_status = wrap_cuda_status("enable_peer_access", cuda::enable_peer_access(dev_id, src_dev_id));
       }
       if (copy_status.ok()) {
-        copy_status = wrap_cuda_status(
-            "memcpy_peer_async",
-            cuda::memcpy_peer_async(dst_ptr, dev_id, src_ptr, src_dev_id, bytes));
+        copy_status =
+            wrap_cuda_status("memcpy_peer_async", cuda::memcpy_peer_async(dst_ptr, dev_id, src_ptr, src_dev_id, bytes));
       }
       if (copy_status.ok()) {
         copy_status = wrap_cuda_status("device_synchronize", cuda::device_synchronize());
       }
     }
   } else {
-    copy_status = absl::InvalidArgumentError(absl::StrCat(
-        "unsupported local copy matrix: src_dev_type=", src_dev_type, " dst_dev_type=", dev_type));
+    copy_status = absl::InvalidArgumentError(
+        absl::StrCat("unsupported local copy matrix: src_dev_type=", src_dev_type, " dst_dev_type=", dev_type));
   }
 
   result.status = copy_status;
@@ -2820,48 +2820,47 @@ misc::result_t Communicator::on_receive_response(
     const engine_message_t& msg) {
   LOG(INFO) << "[on_receive_response] Received response op=" << msg->get_op() << " from " << t->get_remote_url();
 
-  auto handle_rdma_connect_failure = [&](const std::string& local_dev_name,
-                                         const std::string& peer_dev_name,
-                                         const char* failure_reason) {
-    LOG(ERROR) << "[on_receive_response] RDMA_CONNECT_FAILED: local=" << local_dev_name
-               << " peer=" << peer_dev_name << " reason=" << failure_reason;
+  auto handle_rdma_connect_failure =
+      [&](const std::string& local_dev_name, const std::string& peer_dev_name, const char* failure_reason) {
+        LOG(ERROR) << "[on_receive_response] RDMA_CONNECT_FAILED: local=" << local_dev_name << " peer=" << peer_dev_name
+                   << " reason=" << failure_reason;
 
-    auto endpoint = channel->get_rdma_endpoint(local_dev_name, peer_dev_name);
-    if (endpoint == nullptr) {
-      return;
-    }
+        auto endpoint = channel->get_rdma_endpoint(local_dev_name, peer_dev_name);
+        if (endpoint == nullptr) {
+          return;
+        }
 
-    uint64_t generation = 0;
-    Channel::HandshakeState from_state = Channel::HandshakeState::kIdle;
-    {
-      absl::MutexLock lock(&endpoint->mu);
-      generation = endpoint->generation;
-      from_state = endpoint->state;
-    }
+        uint64_t generation = 0;
+        Channel::HandshakeState from_state = Channel::HandshakeState::kIdle;
+        {
+          absl::MutexLock lock(&endpoint->mu);
+          generation = endpoint->generation;
+          from_state = endpoint->state;
+        }
 
-    auto failed_reads = drain_pending_reads_for_generation(endpoint, generation);
-    const absl::Status status = absl::UnavailableError(failure_reason);
-    for (auto& pending : failed_reads) {
-      pending_requests_.erase_if_present(pending.request->get_key());
-      pending.request->set_result(status);
-    }
+        auto failed_reads = drain_pending_reads_for_generation(endpoint, generation);
+        const absl::Status status = absl::UnavailableError(failure_reason);
+        for (auto& pending : failed_reads) {
+          pending_requests_.erase_if_present(pending.request->get_key());
+          pending.request->set_result(status);
+        }
 
-    {
-      absl::MutexLock lock(&endpoint->mu);
-      log_handshake_transition(
-          local_dev_name,
-          peer_dev_name,
-          from_state,
-          Channel::HandshakeState::kFailed,
-          endpoint->generation,
-          endpoint->pending_reads.size());
-      endpoint->state = Channel::HandshakeState::kFailed;
-      endpoint->transport.reset();
-      endpoint->failure_count += 1;
-      endpoint->next_retry_at = absl::Now() + compute_handshake_backoff(endpoint->failure_count);
-      endpoint->retry_scheduled = false;
-    }
-  };
+        {
+          absl::MutexLock lock(&endpoint->mu);
+          log_handshake_transition(
+              local_dev_name,
+              peer_dev_name,
+              from_state,
+              Channel::HandshakeState::kFailed,
+              endpoint->generation,
+              endpoint->pending_reads.size());
+          endpoint->state = Channel::HandshakeState::kFailed;
+          endpoint->transport.reset();
+          endpoint->failure_count += 1;
+          endpoint->next_retry_at = absl::Now() + compute_handshake_backoff(endpoint->failure_count);
+          endpoint->retry_scheduled = false;
+        }
+      };
 
   switch (msg->get_op()) {
     case ENGINE_OP_RDMA_CONNECT_RESPONSE: {
@@ -2875,8 +2874,8 @@ misc::result_t Communicator::on_receive_response(
         break;
       }
       if (msg->get_payload_size() < sizeof(ProtoRdmaConnectResponse)) {
-        LOG(ERROR) << "[on_receive_response] RDMA_CONNECT_RESPONSE payload too small: got="
-                   << msg->get_payload_size() << " expected=" << sizeof(ProtoRdmaConnectResponse);
+        LOG(ERROR) << "[on_receive_response] RDMA_CONNECT_RESPONSE payload too small: got=" << msg->get_payload_size()
+                   << " expected=" << sizeof(ProtoRdmaConnectResponse);
         break;
       }
 
@@ -3342,8 +3341,8 @@ misc::result_t Communicator::on_receive_response(
     }
     case ENGINE_OP_RDMA_CONNECT_FAILED: {
       if (msg->get_payload_size() < sizeof(ProtoRdmaConnectFailed)) {
-        LOG(ERROR) << "[on_receive_response] RDMA_CONNECT_FAILED payload too small: got="
-                   << msg->get_payload_size() << " expected=" << sizeof(ProtoRdmaConnectFailed);
+        LOG(ERROR) << "[on_receive_response] RDMA_CONNECT_FAILED payload too small: got=" << msg->get_payload_size()
+                   << " expected=" << sizeof(ProtoRdmaConnectFailed);
         break;
       }
 

--- a/core/communicator/engine/rdma_engine_test.cc
+++ b/core/communicator/engine/rdma_engine_test.cc
@@ -846,7 +846,12 @@ TEST_CASE("RDMA connect failure cleanup tolerates missing pending request", "[rd
   local_tensor->set_read_ready();
 
   auto read_request = std::make_shared<tensorcast::communicator::transport::ReadRequest>(
-      "rdma_cleanup_tensor", "127.0.0.1", 65002, local_tensor, /*remote_offset=*/0, /*request_id=*/17,
+      "rdma_cleanup_tensor",
+      "127.0.0.1",
+      65002,
+      local_tensor,
+      /*remote_offset=*/0,
+      /*request_id=*/17,
       net_dev->get_rail_id());
   auto remote_tensor = std::make_shared<tensorcast::communicator::transport::RemotePartitionTensor>(
       "rdma_cleanup_tensor", remote_dev_name, /*addr=*/0xBEE0, local_tensor->get_bytes(), /*rkey=*/0xBEEF);

--- a/core/communicator/misc/epoll_wrap.h
+++ b/core/communicator/misc/epoll_wrap.h
@@ -8,6 +8,7 @@
 #ifdef __APPLE__
 enum EPOLL_EVENTS {
   EPOLLIN = 0x001,
+
 #define EPOLLIN EPOLLIN
   EPOLLPRI = 0x002,
 #define EPOLLPRI EPOLLPRI

--- a/core/communicator/misc/ibv_mock.h
+++ b/core/communicator/misc/ibv_mock.h
@@ -20,6 +20,7 @@
 
 union ibv_gid {
   uint8_t raw[16];
+
   struct {
     uint64_t subnet_prefix;
     uint64_t interface_id;
@@ -268,6 +269,7 @@ enum ibv_wc_status {
   IBV_WC_RESP_TIMEOUT_ERR,
   IBV_WC_GENERAL_ERR
 };
+
 const char* ibv_wc_status_str(enum ibv_wc_status status);
 
 enum ibv_wc_opcode {
@@ -639,23 +641,27 @@ struct ibv_send_wr {
   enum ibv_wr_opcode opcode;
   int send_flags;
   uint32_t imm_data; /* in network byte order */
+
   union {
     struct {
       uint64_t remote_addr;
       uint32_t rkey;
     } rdma;
+
     struct {
       uint64_t remote_addr;
       uint64_t compare_add;
       uint64_t swap;
       uint32_t rkey;
     } atomic;
+
     struct {
       struct ibv_ah* ah;
       uint32_t remote_qpn;
       uint32_t remote_qkey;
     } ud;
   } wr;
+
   union {
     union {
       struct {

--- a/core/communicator/routing/adapter.cc
+++ b/core/communicator/routing/adapter.cc
@@ -9,22 +9,18 @@
 
 namespace tensorcast::communicator::routing {
 
-EngineAdapter::EngineAdapter(std::shared_ptr<engine::Communicator> engine)
-    : engine_(std::move(engine)) {}
+EngineAdapter::EngineAdapter(std::shared_ptr<engine::Communicator> engine) : engine_(std::move(engine)) {}
 
 transport::future_read_result_t EngineAdapter::read_tensor(
     const ReadRequest& request,
     const EndpointBinding& /*local*/,
     const EndpointBinding& remote) {
   if (engine_ == nullptr) {
-    return make_failed_read_future(
-        absl::FailedPreconditionError("engine adapter missing engine"),
-        request.tensor_key);
+    return make_failed_read_future(absl::FailedPreconditionError("engine adapter missing engine"), request.tensor_key);
   }
   if (!remote.has_network_address()) {
     return make_failed_read_future(
-        absl::InvalidArgumentError(
-            std::format("missing network address for endpoint: {}", remote.endpoint_id)),
+        absl::InvalidArgumentError(std::format("missing network address for endpoint: {}", remote.endpoint_id)),
         request.tensor_key);
   }
 
@@ -44,31 +40,22 @@ absl::Status EngineAdapter::close(const EndpointBinding& remote) {
     return absl::FailedPreconditionError("engine adapter missing engine");
   }
   if (!remote.has_network_address()) {
-    return absl::InvalidArgumentError(
-        std::format("missing network address for endpoint: {}", remote.endpoint_id));
+    return absl::InvalidArgumentError(std::format("missing network address for endpoint: {}", remote.endpoint_id));
   }
   return engine_->close_connection(remote.ip, remote.port);
 }
 
-NvlinkAdapter::NvlinkAdapter(std::shared_ptr<engine::Communicator> engine)
-    : engine_(std::move(engine)) {}
+NvlinkAdapter::NvlinkAdapter(std::shared_ptr<engine::Communicator> engine) : engine_(std::move(engine)) {}
 
 transport::future_read_result_t NvlinkAdapter::read_tensor(
     const ReadRequest& request,
     const EndpointBinding& /*local*/,
     const EndpointBinding& /*remote*/) {
   if (engine_ == nullptr) {
-    return make_failed_read_future(
-        absl::FailedPreconditionError("nvlink adapter missing engine"),
-        request.tensor_key);
+    return make_failed_read_future(absl::FailedPreconditionError("nvlink adapter missing engine"), request.tensor_key);
   }
   return engine_->read_tensor_local(
-      request.tensor_key,
-      request.addr,
-      request.bytes,
-      request.dev_type,
-      request.dev_id,
-      request.remote_offset);
+      request.tensor_key, request.addr, request.bytes, request.dev_type, request.dev_id, request.remote_offset);
 }
 
 absl::Status NvlinkAdapter::close(const EndpointBinding& /*remote*/) {
@@ -78,22 +65,18 @@ absl::Status NvlinkAdapter::close(const EndpointBinding& /*remote*/) {
   return absl::OkStatus();
 }
 
-PcieAdapter::PcieAdapter(std::shared_ptr<engine::Communicator> engine)
-    : engine_(std::move(engine)) {}
+PcieAdapter::PcieAdapter(std::shared_ptr<engine::Communicator> engine) : engine_(std::move(engine)) {}
 
 transport::future_read_result_t PcieAdapter::read_tensor(
     const ReadRequest& request,
     const EndpointBinding& /*local*/,
     const EndpointBinding& remote) {
   if (engine_ == nullptr) {
-    return make_failed_read_future(
-        absl::FailedPreconditionError("pcie adapter missing engine"),
-        request.tensor_key);
+    return make_failed_read_future(absl::FailedPreconditionError("pcie adapter missing engine"), request.tensor_key);
   }
   if (!remote.has_network_address()) {
     return make_failed_read_future(
-        absl::InvalidArgumentError(
-            std::format("missing network address for endpoint: {}", remote.endpoint_id)),
+        absl::InvalidArgumentError(std::format("missing network address for endpoint: {}", remote.endpoint_id)),
         request.tensor_key);
   }
 
@@ -113,8 +96,7 @@ absl::Status PcieAdapter::close(const EndpointBinding& remote) {
     return absl::FailedPreconditionError("pcie adapter missing engine");
   }
   if (!remote.has_network_address()) {
-    return absl::InvalidArgumentError(
-        std::format("missing network address for endpoint: {}", remote.endpoint_id));
+    return absl::InvalidArgumentError(std::format("missing network address for endpoint: {}", remote.endpoint_id));
   }
   return engine_->close_connection(remote.ip, remote.port);
 }

--- a/core/communicator/routing/adapter_test.cc
+++ b/core/communicator/routing/adapter_test.cc
@@ -154,12 +154,7 @@ TEST_CASE("NvlinkAdapter copies local GPU tensor across devices", "[communicator
   REQUIRE(tensorcast::cuda::memcpy(src_gpu, host_source.data(), bytes, cudaMemcpyHostToDevice).ok());
 
   auto register_status = engine->register_tensor_ex(
-      "gpu_tensor",
-      reinterpret_cast<uint64_t>(src_gpu),
-      bytes,
-      COMMUNICATE_ENGINE_DEV_GPU,
-      0,
-      no_mr_opts());
+      "gpu_tensor", reinterpret_cast<uint64_t>(src_gpu), bytes, COMMUNICATE_ENGINE_DEV_GPU, 0, no_mr_opts());
   REQUIRE(register_status.ok());
 
   ReadRequest request;

--- a/core/communicator/routing/connection.cc
+++ b/core/communicator/routing/connection.cc
@@ -18,8 +18,7 @@ constexpr absl::Duration kReadResultTimeout = absl::Seconds(60);
 
 } // namespace
 
-LinkState::LinkState(std::string link_id)
-    : link_id_(std::move(link_id)) {}
+LinkState::LinkState(std::string link_id) : link_id_(std::move(link_id)) {}
 
 void LinkState::record_success(absl::Duration latency) {
   absl::MutexLock lock(&mu_);
@@ -45,15 +44,16 @@ HealthState LinkState::health() const {
   return derive_health(stats_);
 }
 
-Connection::Connection(ConnectionKey key,
-                       ConnectionType type,
-                       std::shared_ptr<const topology::Topology> topology,
-                       const topology::Link* link,
-                       EndpointBinding local_binding,
-                       EndpointBinding remote_binding,
-                       std::shared_ptr<ConnectionAdapter> adapter,
-                       std::shared_ptr<LinkState> link_state,
-                       std::shared_ptr<common::AsyncRuntime> async_runtime)
+Connection::Connection(
+    ConnectionKey key,
+    ConnectionType type,
+    std::shared_ptr<const topology::Topology> topology,
+    const topology::Link* link,
+    EndpointBinding local_binding,
+    EndpointBinding remote_binding,
+    std::shared_ptr<ConnectionAdapter> adapter,
+    std::shared_ptr<LinkState> link_state,
+    std::shared_ptr<common::AsyncRuntime> async_runtime)
     : key_(std::move(key)),
       type_(type),
       topology_ref_(std::move(topology)),
@@ -82,44 +82,37 @@ transport::future_read_result_t Connection::read_tensor(const ReadRequest& reque
   auto promise = std::make_shared<std::promise<transport::read_result_t>>();
   auto future = promise->get_future();
   const std::string tensor_key = request.tensor_key;
-  folly::via(async_runtime_->blocking_executor(),
-             [self,
-              start_time,
-              tensor_key,
-              promise,
-              future = std::move(inner_future)]() mutable {
-               transport::read_result_t result;
-               const auto wait_status =
-                   future.wait_for(absl::ToChronoMilliseconds(kReadResultTimeout));
-               if (wait_status == std::future_status::ready) {
-                 try {
-                   result = future.get();
-                 } catch (const std::exception& ex) {
-                   result.status = absl::UnknownError(ex.what());
-                   result.tensor_key = tensor_key;
-                 } catch (...) {
-                   result.status = absl::UnknownError(
-                       "read result future raised non-standard exception");
-                   result.tensor_key = tensor_key;
-                 }
-               } else if (wait_status == std::future_status::timeout) {
-                 result.status = absl::DeadlineExceededError(std::format(
-                     "read result future not ready after {}",
-                     absl::FormatDuration(kReadResultTimeout)));
-                 result.tensor_key = tensor_key;
-               } else {
-                 result.status = absl::FailedPreconditionError(
-                     "read result future is deferred; bounded wait required");
-                 result.tensor_key = tensor_key;
-               }
-               const absl::Duration latency = absl::Now() - start_time;
-               if (result.status.ok()) {
-                 self->record_success(latency);
-               } else {
-                 self->record_failure(result.status);
-               }
-               promise->set_value(std::move(result));
-             });
+  folly::via(
+      async_runtime_->blocking_executor(),
+      [self, start_time, tensor_key, promise, future = std::move(inner_future)]() mutable {
+        transport::read_result_t result;
+        const auto wait_status = future.wait_for(absl::ToChronoMilliseconds(kReadResultTimeout));
+        if (wait_status == std::future_status::ready) {
+          try {
+            result = future.get();
+          } catch (const std::exception& ex) {
+            result.status = absl::UnknownError(ex.what());
+            result.tensor_key = tensor_key;
+          } catch (...) {
+            result.status = absl::UnknownError("read result future raised non-standard exception");
+            result.tensor_key = tensor_key;
+          }
+        } else if (wait_status == std::future_status::timeout) {
+          result.status = absl::DeadlineExceededError(
+              std::format("read result future not ready after {}", absl::FormatDuration(kReadResultTimeout)));
+          result.tensor_key = tensor_key;
+        } else {
+          result.status = absl::FailedPreconditionError("read result future is deferred; bounded wait required");
+          result.tensor_key = tensor_key;
+        }
+        const absl::Duration latency = absl::Now() - start_time;
+        if (result.status.ok()) {
+          self->record_success(latency);
+        } else {
+          self->record_failure(result.status);
+        }
+        promise->set_value(std::move(result));
+      });
   return future;
 }
 

--- a/core/communicator/routing/connection.h
+++ b/core/communicator/routing/connection.h
@@ -28,6 +28,7 @@ class LinkState {
 
   LinkStats snapshot() const;
   HealthState health() const;
+
   const std::string& link_id() const {
     return link_id_;
   }
@@ -40,15 +41,16 @@ class LinkState {
 
 class Connection : public std::enable_shared_from_this<Connection> {
  public:
-  Connection(ConnectionKey key,
-             ConnectionType type,
-             std::shared_ptr<const topology::Topology> topology,
-             const topology::Link* link,
-             EndpointBinding local_binding,
-             EndpointBinding remote_binding,
-             std::shared_ptr<ConnectionAdapter> adapter,
-             std::shared_ptr<LinkState> link_state,
-             std::shared_ptr<common::AsyncRuntime> async_runtime);
+  Connection(
+      ConnectionKey key,
+      ConnectionType type,
+      std::shared_ptr<const topology::Topology> topology,
+      const topology::Link* link,
+      EndpointBinding local_binding,
+      EndpointBinding remote_binding,
+      std::shared_ptr<ConnectionAdapter> adapter,
+      std::shared_ptr<LinkState> link_state,
+      std::shared_ptr<common::AsyncRuntime> async_runtime);
 
   const ConnectionKey& key() const {
     return key_;

--- a/core/communicator/routing/read_helpers.h
+++ b/core/communicator/routing/read_helpers.h
@@ -12,9 +12,7 @@
 
 namespace tensorcast::communicator::routing {
 
-inline transport::future_read_result_t make_failed_read_future(
-    absl::Status status,
-    std::string tensor_key = {}) {
+inline transport::future_read_result_t make_failed_read_future(absl::Status status, std::string tensor_key = {}) {
   std::promise<transport::read_result_t> promise;
   auto future = promise.get_future();
   transport::read_result_t result;

--- a/core/communicator/routing/route_channel.cc
+++ b/core/communicator/routing/route_channel.cc
@@ -20,13 +20,11 @@ RouteChannel::RouteChannel(
 
 transport::future_read_result_t RouteChannel::read_tensor(const ReadRequest& request) {
   if (hops_.empty()) {
-    return make_failed_read_future(
-        absl::FailedPreconditionError("route channel has no hops"),
-        request.tensor_key);
+    return make_failed_read_future(absl::FailedPreconditionError("route channel has no hops"), request.tensor_key);
   }
   if (hops_.size() != 1) {
-    return make_failed_read_future(absl::UnimplementedError(
-        std::format("multi-hop read not implemented (hops={})", hops_.size())),
+    return make_failed_read_future(
+        absl::UnimplementedError(std::format("multi-hop read not implemented (hops={})", hops_.size())),
         request.tensor_key);
   }
   return hops_.front()->read_tensor(request);

--- a/core/communicator/routing/routing_context.cc
+++ b/core/communicator/routing/routing_context.cc
@@ -116,9 +116,7 @@ std::string describe_binding(const EndpointBinding& binding) {
       binding.has_network_address() ? std::format("{}:{}", binding.ip, binding.port) : "none");
 }
 
-DevicePoolHint infer_device_pool_hint(
-    std::string_view endpoint_id,
-    const EndpointBinding& binding) {
+DevicePoolHint infer_device_pool_hint(std::string_view endpoint_id, const EndpointBinding& binding) {
   DevicePoolHint hint;
 
   if (const auto gpu_id = parse_gpu_dev_id_from_endpoint_id(endpoint_id); gpu_id.has_value() && *gpu_id >= 0) {
@@ -183,8 +181,7 @@ absl::StatusOr<std::shared_ptr<RouteChannel>> RoutingContext::Communicator::prim
     return primary_channel_;
   }
   primary_channel_.reset();
-  auto channel_or = context_->build_direct_channel_with_generation(
-      src_endpoint_id_, dst_endpoint_id_);
+  auto channel_or = context_->build_direct_channel_with_generation(src_endpoint_id_, dst_endpoint_id_);
   if (!channel_or.ok()) {
     return channel_or.status();
   }
@@ -251,8 +248,7 @@ absl::Status RoutingContext::update_endpoint_binding(EndpointBinding binding) {
   if (binding.endpoint_id.empty()) {
     return absl::InvalidArgumentError("endpoint binding id must be non-empty");
   }
-  return absl::FailedPreconditionError(
-      "endpoint bindings are immutable; update_endpoint_binding is not supported");
+  return absl::FailedPreconditionError("endpoint bindings are immutable; update_endpoint_binding is not supported");
 }
 
 absl::StatusOr<std::shared_ptr<RoutingContext::Communicator>> RoutingContext::get_communicator(
@@ -270,8 +266,8 @@ absl::StatusOr<std::shared_ptr<RoutingContext::Communicator>> RoutingContext::ge
       return existing;
     }
   }
-  auto communicator = std::shared_ptr<Communicator>(
-      new Communicator(src_endpoint_id, dst_endpoint_id, shared_from_this()));
+  auto communicator =
+      std::shared_ptr<Communicator>(new Communicator(src_endpoint_id, dst_endpoint_id, shared_from_this()));
   communicators_[key] = communicator;
   return communicator;
 }
@@ -308,8 +304,7 @@ absl::StatusOr<std::shared_ptr<RouteChannel>> RoutingContext::build_direct_chann
   return build_direct_channel_locked(src_endpoint_id, dst_endpoint_id);
 }
 
-absl::StatusOr<RoutingContext::ChannelBuildResult>
-RoutingContext::build_direct_channel_with_generation(
+absl::StatusOr<RoutingContext::ChannelBuildResult> RoutingContext::build_direct_channel_with_generation(
     const std::string& src_endpoint_id,
     const std::string& dst_endpoint_id) {
   absl::MutexLock lock(&mu_);
@@ -329,13 +324,11 @@ absl::StatusOr<std::shared_ptr<RouteChannel>> RoutingContext::build_direct_chann
 
   auto src_binding_it = bindings_.find(src_endpoint_id);
   if (src_binding_it == bindings_.end()) {
-    return absl::NotFoundError(
-        std::format("missing endpoint binding for source: {}", src_endpoint_id));
+    return absl::NotFoundError(std::format("missing endpoint binding for source: {}", src_endpoint_id));
   }
   auto dst_binding_it = bindings_.find(dst_endpoint_id);
   if (dst_binding_it == bindings_.end()) {
-    return absl::NotFoundError(
-        std::format("missing endpoint binding for destination: {}", dst_endpoint_id));
+    return absl::NotFoundError(std::format("missing endpoint binding for destination: {}", dst_endpoint_id));
   }
 
   const topology::Endpoint* src_endpoint = topology_->find_endpoint(src_endpoint_id);
@@ -352,27 +345,24 @@ absl::StatusOr<std::shared_ptr<RouteChannel>> RoutingContext::build_direct_chann
   }
 
   if (!link) {
-    auto rail_path_or = resolve_rail_matched_path_locked(
-        src_endpoint_id,
-        dst_endpoint_id,
-        local_binding,
-        remote_binding);
+    auto rail_path_or =
+        resolve_rail_matched_path_locked(src_endpoint_id, dst_endpoint_id, local_binding, remote_binding);
     if (!rail_path_or.ok()) {
       if (!src_endpoint) {
-        return absl::NotFoundError(std::format(
-            "source endpoint not found in topology and no rail-matched fallback: {}",
-            src_endpoint_id));
+        return absl::NotFoundError(
+            std::format("source endpoint not found in topology and no rail-matched fallback: {}", src_endpoint_id));
       }
       if (!dst_endpoint) {
-        return absl::NotFoundError(std::format(
-            "destination endpoint not found in topology and no rail-matched fallback: {}",
-            dst_endpoint_id));
+        return absl::NotFoundError(
+            std::format(
+                "destination endpoint not found in topology and no rail-matched fallback: {}", dst_endpoint_id));
       }
-      return absl::NotFoundError(std::format(
-          "no direct link or rail-matched fallback between endpoints: {} -> {} ({})",
-          src_endpoint_id,
-          dst_endpoint_id,
-          rail_path_or.status().message()));
+      return absl::NotFoundError(
+          std::format(
+              "no direct link or rail-matched fallback between endpoints: {} -> {} ({})",
+              src_endpoint_id,
+              dst_endpoint_id,
+              rail_path_or.status().message()));
     }
 
     RailMatchedPath rail_path = std::move(rail_path_or).value();
@@ -389,48 +379,26 @@ absl::StatusOr<std::shared_ptr<RouteChannel>> RoutingContext::build_direct_chann
 
   ConnectionProtocol protocol = ConnectionProtocol::kAuto;
   if (protocol_src_endpoint != nullptr && protocol_dst_endpoint != nullptr) {
-    protocol = select_protocol_locked(
-        *protocol_src_endpoint,
-        *protocol_dst_endpoint,
-        local_binding,
-        remote_binding);
+    protocol = select_protocol_locked(*protocol_src_endpoint, *protocol_dst_endpoint, local_binding, remote_binding);
   }
 
-  auto connection = get_or_create_connection_locked(
-      src_endpoint_id,
-      dst_endpoint_id,
-      link,
-      protocol,
-      local_binding,
-      remote_binding);
+  auto connection =
+      get_or_create_connection_locked(src_endpoint_id, dst_endpoint_id, link, protocol, local_binding, remote_binding);
   const bool same_node = !local_binding.node_id.empty() && local_binding.node_id == remote_binding.node_id;
-  const std::string_view path_kind =
-      used_rail_fallback
+  const std::string_view path_kind = used_rail_fallback
       ? "cross_node_rail_fallback"
       : (same_node ? (src_endpoint_id == dst_endpoint_id ? "same_node_loopback" : "local_fanout")
                    : "cross_node_direct");
-  LOG(INFO) << "[routing] route resolved: src=" << src_endpoint_id
-            << " dst=" << dst_endpoint_id
-            << " path=" << path_kind
-            << " protocol=" << to_string(protocol)
-            << " adapter=" << protocol_adapter_name(protocol)
-            << " link=" << (link == nullptr ? "none" : link->id)
-            << " link_type=" << to_string(connection->type())
-            << " local={" << describe_binding(local_binding) << "}"
+  LOG(INFO) << "[routing] route resolved: src=" << src_endpoint_id << " dst=" << dst_endpoint_id
+            << " path=" << path_kind << " protocol=" << to_string(protocol)
+            << " adapter=" << protocol_adapter_name(protocol) << " link=" << (link == nullptr ? "none" : link->id)
+            << " link_type=" << to_string(connection->type()) << " local={" << describe_binding(local_binding) << "}"
             << " remote={" << describe_binding(remote_binding) << "}";
   std::vector<std::shared_ptr<Connection>> hops;
   hops.push_back(connection);
 
-  std::string channel_id = std::format(
-      "{}->{}:{}",
-      src_endpoint_id,
-      dst_endpoint_id,
-      to_string(protocol));
-  return std::make_shared<RouteChannel>(
-      std::move(channel_id),
-      src_endpoint_id,
-      dst_endpoint_id,
-      std::move(hops));
+  std::string channel_id = std::format("{}->{}:{}", src_endpoint_id, dst_endpoint_id, to_string(protocol));
+  return std::make_shared<RouteChannel>(std::move(channel_id), src_endpoint_id, dst_endpoint_id, std::move(hops));
 }
 
 std::shared_ptr<Connection> RoutingContext::get_or_create_connection_locked(
@@ -443,8 +411,7 @@ std::shared_ptr<Connection> RoutingContext::get_or_create_connection_locked(
   ConnectionKey key{src_endpoint_id, dst_endpoint_id, protocol};
   auto it = connections_.find(key);
   if (it != connections_.end()) {
-    VLOG(1) << "[routing] reusing cached connection: src=" << src_endpoint_id
-            << " dst=" << dst_endpoint_id
+    VLOG(1) << "[routing] reusing cached connection: src=" << src_endpoint_id << " dst=" << dst_endpoint_id
             << " protocol=" << to_string(protocol);
     return it->second;
   }
@@ -467,12 +434,9 @@ std::shared_ptr<Connection> RoutingContext::get_or_create_connection_locked(
       std::move(link_state),
       async_runtime_);
   connections_.emplace(std::move(key), connection);
-  LOG(INFO) << "[routing] connection created: src=" << src_endpoint_id
-            << " dst=" << dst_endpoint_id
-            << " protocol=" << to_string(protocol)
-            << " adapter=" << protocol_adapter_name(protocol)
-            << " type=" << to_string(type)
-            << " link=" << (link == nullptr ? "none" : link->id);
+  LOG(INFO) << "[routing] connection created: src=" << src_endpoint_id << " dst=" << dst_endpoint_id
+            << " protocol=" << to_string(protocol) << " adapter=" << protocol_adapter_name(protocol)
+            << " type=" << to_string(type) << " link=" << (link == nullptr ? "none" : link->id);
   return connection;
 }
 
@@ -487,8 +451,7 @@ const topology::Link* RoutingContext::find_link_locked(
   return nullptr;
 }
 
-const topology::Link* RoutingContext::find_any_link_for_endpoint_locked(
-    const std::string& endpoint_id) const {
+const topology::Link* RoutingContext::find_any_link_for_endpoint_locked(const std::string& endpoint_id) const {
   const topology::Link* best = nullptr;
   for (const auto& [link_id, link] : topology_->links()) {
     if (link.src_endpoint_id != endpoint_id && link.dst_endpoint_id != endpoint_id) {
@@ -528,13 +491,11 @@ int RoutingContext::infer_nic_rail_id_locked(const std::string& nic_endpoint_id)
   return inferred_rail_id;
 }
 
-absl::StatusOr<RoutingContext::LocalNicSelection>
-RoutingContext::select_local_nic_for_source_locked(
+absl::StatusOr<RoutingContext::LocalNicSelection> RoutingContext::select_local_nic_for_source_locked(
     const std::string& src_endpoint_id,
     const EndpointBinding& src_binding) const {
   const topology::Endpoint* direct_endpoint = topology_->find_endpoint(src_endpoint_id);
-  if (direct_endpoint != nullptr &&
-      direct_endpoint->kind == topology::EndpointKind::kClient &&
+  if (direct_endpoint != nullptr && direct_endpoint->kind == topology::EndpointKind::kClient &&
       direct_endpoint->type == topology::EndpointType::kNic) {
     return LocalNicSelection{
         .endpoint = direct_endpoint,
@@ -545,8 +506,7 @@ RoutingContext::select_local_nic_for_source_locked(
   std::vector<const topology::Endpoint*> nic_candidates;
   nic_candidates.reserve(topology_->endpoints().size());
   for (const auto& [endpoint_id, endpoint] : topology_->endpoints()) {
-    if (endpoint.kind != topology::EndpointKind::kClient ||
-        endpoint.type != topology::EndpointType::kNic) {
+    if (endpoint.kind != topology::EndpointKind::kClient || endpoint.type != topology::EndpointType::kNic) {
       continue;
     }
     nic_candidates.push_back(&endpoint);
@@ -556,9 +516,7 @@ RoutingContext::select_local_nic_for_source_locked(
   }
 
   std::sort(
-      nic_candidates.begin(),
-      nic_candidates.end(),
-      [](const topology::Endpoint* lhs, const topology::Endpoint* rhs) {
+      nic_candidates.begin(), nic_candidates.end(), [](const topology::Endpoint* lhs, const topology::Endpoint* rhs) {
         return lhs->id < rhs->id;
       });
 
@@ -615,8 +573,7 @@ RoutingContext::select_local_nic_for_source_locked(
   }
 
   if (best_endpoint == nullptr) {
-    return absl::NotFoundError(
-        std::format("failed to resolve local NIC endpoint for source: {}", src_endpoint_id));
+    return absl::NotFoundError(std::format("failed to resolve local NIC endpoint for source: {}", src_endpoint_id));
   }
   return LocalNicSelection{
       .endpoint = best_endpoint,
@@ -649,8 +606,7 @@ absl::StatusOr<EndpointBinding> RoutingContext::select_remote_binding_for_rail_l
 
     const topology::Endpoint* candidate_endpoint = topology_->find_endpoint(binding.endpoint_id);
     int candidate_rail_id = binding.rail_id;
-    if (candidate_rail_id < 0 &&
-        candidate_endpoint != nullptr &&
+    if (candidate_rail_id < 0 && candidate_endpoint != nullptr &&
         candidate_endpoint->kind == topology::EndpointKind::kClient &&
         candidate_endpoint->type == topology::EndpointType::kNic) {
       candidate_rail_id = infer_nic_rail_id_locked(candidate_endpoint->id);
@@ -699,30 +655,26 @@ absl::StatusOr<EndpointBinding> RoutingContext::select_remote_binding_for_rail_l
       score += 5;
     }
 
-    candidates.push_back(RemoteCandidate{
-        .binding = &binding,
-        .score = score,
-    });
+    candidates.push_back(
+        RemoteCandidate{
+            .binding = &binding,
+            .score = score,
+        });
   }
 
   if (candidates.empty()) {
     if (dst_binding.has_network_address()) {
       return dst_binding;
     }
-    return absl::NotFoundError(std::format(
-        "no remote binding with network address for node: {}",
-        dst_binding.node_id));
+    return absl::NotFoundError(std::format("no remote binding with network address for node: {}", dst_binding.node_id));
   }
 
-  std::sort(
-      candidates.begin(),
-      candidates.end(),
-      [](const RemoteCandidate& lhs, const RemoteCandidate& rhs) {
-        if (lhs.score != rhs.score) {
-          return lhs.score > rhs.score;
-        }
-        return lhs.binding->endpoint_id < rhs.binding->endpoint_id;
-      });
+  std::sort(candidates.begin(), candidates.end(), [](const RemoteCandidate& lhs, const RemoteCandidate& rhs) {
+    if (lhs.score != rhs.score) {
+      return lhs.score > rhs.score;
+    }
+    return lhs.binding->endpoint_id < rhs.binding->endpoint_id;
+  });
   return *candidates.front().binding;
 }
 
@@ -732,12 +684,10 @@ absl::StatusOr<RoutingContext::RailMatchedPath> RoutingContext::resolve_rail_mat
     const EndpointBinding& src_binding,
     const EndpointBinding& dst_binding) const {
   if (src_binding.node_id.empty() || dst_binding.node_id.empty()) {
-    return absl::FailedPreconditionError(
-        "rail-matched routing requires node_id in both endpoint bindings");
+    return absl::FailedPreconditionError("rail-matched routing requires node_id in both endpoint bindings");
   }
   if (src_binding.node_id == dst_binding.node_id) {
-    return absl::FailedPreconditionError(
-        "rail-matched routing only applies to cross-node communication");
+    return absl::FailedPreconditionError("rail-matched routing only applies to cross-node communication");
   }
 
   auto local_nic_or = select_local_nic_for_source_locked(src_endpoint_id, src_binding);
@@ -746,9 +696,7 @@ absl::StatusOr<RoutingContext::RailMatchedPath> RoutingContext::resolve_rail_mat
   }
   const LocalNicSelection local_nic = std::move(local_nic_or).value();
   if (local_nic.endpoint == nullptr) {
-    return absl::NotFoundError(std::format(
-        "failed to resolve local NIC endpoint for source: {}",
-        src_endpoint_id));
+    return absl::NotFoundError(std::format("failed to resolve local NIC endpoint for source: {}", src_endpoint_id));
   }
 
   int preferred_rail_id = local_nic.rail_id;
@@ -774,12 +722,9 @@ absl::StatusOr<RoutingContext::RailMatchedPath> RoutingContext::resolve_rail_mat
     selected_link = find_any_link_for_endpoint_locked(local_nic.endpoint->id);
   }
 
-  LOG(INFO) << "[routing] rail fallback selected: src=" << src_endpoint_id
-            << " dst=" << dst_endpoint_id
-            << " local_nic=" << local_nic.endpoint->id
-            << " local_rail=" << local_nic.rail_id
-            << " preferred_rail=" << preferred_rail_id
-            << " remote_endpoint=" << remote_binding.endpoint_id
+  LOG(INFO) << "[routing] rail fallback selected: src=" << src_endpoint_id << " dst=" << dst_endpoint_id
+            << " local_nic=" << local_nic.endpoint->id << " local_rail=" << local_nic.rail_id
+            << " preferred_rail=" << preferred_rail_id << " remote_endpoint=" << remote_binding.endpoint_id
             << " remote_rail=" << remote_binding.rail_id
             << " link=" << (selected_link == nullptr ? "none" : selected_link->id);
   return RailMatchedPath{
@@ -802,27 +747,20 @@ ConnectionProtocol RoutingContext::select_protocol_locked(
     return ConnectionProtocol::kAuto;
   }
 
-  if (src_endpoint.type == topology::EndpointType::kNvlink &&
-      dst_endpoint.type == topology::EndpointType::kNvlink &&
-      options_.prefer_nvlink &&
-      nvlink_adapter_ &&
-      nvlink_adapter_->is_available()) {
+  if (src_endpoint.type == topology::EndpointType::kNvlink && dst_endpoint.type == topology::EndpointType::kNvlink &&
+      options_.prefer_nvlink && nvlink_adapter_ && nvlink_adapter_->is_available()) {
     return ConnectionProtocol::kNvlink;
   }
 
-  if (src_endpoint.type == topology::EndpointType::kPcie &&
-      dst_endpoint.type == topology::EndpointType::kPcie &&
-      options_.prefer_pcie &&
-      pcie_adapter_ &&
-      pcie_adapter_->is_available()) {
+  if (src_endpoint.type == topology::EndpointType::kPcie && dst_endpoint.type == topology::EndpointType::kPcie &&
+      options_.prefer_pcie && pcie_adapter_ && pcie_adapter_->is_available()) {
     return ConnectionProtocol::kPcie;
   }
 
   return ConnectionProtocol::kAuto;
 }
 
-std::shared_ptr<LinkState> RoutingContext::get_or_create_link_state_locked(
-    const topology::Link* link) {
+std::shared_ptr<LinkState> RoutingContext::get_or_create_link_state_locked(const topology::Link* link) {
   if (!link) {
     return nullptr;
   }
@@ -835,9 +773,7 @@ std::shared_ptr<LinkState> RoutingContext::get_or_create_link_state_locked(
   return state;
 }
 
-std::string RoutingContext::make_peer_key(
-    const std::string& src_endpoint_id,
-    const std::string& dst_endpoint_id) {
+std::string RoutingContext::make_peer_key(const std::string& src_endpoint_id, const std::string& dst_endpoint_id) {
   return std::format("{}->{}", src_endpoint_id, dst_endpoint_id);
 }
 

--- a/core/communicator/routing/routing_context.h
+++ b/core/communicator/routing/routing_context.h
@@ -45,10 +45,7 @@ class RoutingContext : public std::enable_shared_from_this<RoutingContext> {
    private:
     friend class RoutingContext;
 
-    Communicator(
-        std::string src_endpoint_id,
-        std::string dst_endpoint_id,
-        std::shared_ptr<RoutingContext> context);
+    Communicator(std::string src_endpoint_id, std::string dst_endpoint_id, std::shared_ptr<RoutingContext> context);
 
     std::string src_endpoint_id_;
     std::string dst_endpoint_id_;
@@ -128,19 +125,17 @@ class RoutingContext : public std::enable_shared_from_this<RoutingContext> {
       const EndpointBinding& local_binding,
       const EndpointBinding& remote_binding) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
-  const topology::Link* find_link_locked(
-      const std::string& src_endpoint_id,
-      const std::string& dst_endpoint_id) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  const topology::Link* find_link_locked(const std::string& src_endpoint_id, const std::string& dst_endpoint_id) const
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
-  const topology::Link* find_any_link_for_endpoint_locked(
-      const std::string& endpoint_id) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  const topology::Link* find_any_link_for_endpoint_locked(const std::string& endpoint_id) const
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   absl::StatusOr<LocalNicSelection> select_local_nic_for_source_locked(
       const std::string& src_endpoint_id,
       const EndpointBinding& src_binding) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
-  int infer_nic_rail_id_locked(
-      const std::string& nic_endpoint_id) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  int infer_nic_rail_id_locked(const std::string& nic_endpoint_id) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   absl::StatusOr<EndpointBinding> select_remote_binding_for_rail_locked(
       const EndpointBinding& dst_binding,
@@ -158,12 +153,10 @@ class RoutingContext : public std::enable_shared_from_this<RoutingContext> {
       const EndpointBinding& local_binding,
       const EndpointBinding& remote_binding) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
-  std::shared_ptr<LinkState> get_or_create_link_state_locked(
-      const topology::Link* link) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  std::shared_ptr<LinkState> get_or_create_link_state_locked(const topology::Link* link)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
-  static std::string make_peer_key(
-      const std::string& src_endpoint_id,
-      const std::string& dst_endpoint_id);
+  static std::string make_peer_key(const std::string& src_endpoint_id, const std::string& dst_endpoint_id);
 
   Options options_;
   std::shared_ptr<engine::Communicator> engine_;

--- a/core/communicator/routing/routing_context_test.cc
+++ b/core/communicator/routing/routing_context_test.cc
@@ -35,8 +35,7 @@ using tensorcast::communicator::topology::Topology;
 
 class FakeAdapter final : public ConnectionAdapter {
  public:
-  explicit FakeAdapter(absl::Status status)
-      : status_(std::move(status)) {}
+  explicit FakeAdapter(absl::Status status) : status_(std::move(status)) {}
 
   tensorcast::communicator::routing::ConnectionProtocol protocol() const override {
     return tensorcast::communicator::routing::ConnectionProtocol::kAuto;
@@ -68,8 +67,7 @@ class FakeAdapter final : public ConnectionAdapter {
 
 class ProtocolAdapterStub final : public ConnectionAdapter {
  public:
-  ProtocolAdapterStub(ConnectionProtocol protocol, bool available)
-      : protocol_(protocol), available_(available) {}
+  ProtocolAdapterStub(ConnectionProtocol protocol, bool available) : protocol_(protocol), available_(available) {}
 
   ConnectionProtocol protocol() const override {
     return protocol_;
@@ -273,11 +271,12 @@ Topology build_eight_rail_switch_topology() {
   pools.push_back(Pool{"cpu0", "cpu0", PoolType::kCpu});
   pools.push_back(Pool{"cpu1", "cpu1", PoolType::kCpu});
   for (int gpu_id = 0; gpu_id < 8; ++gpu_id) {
-    pools.push_back(Pool{
-        "gpu" + std::to_string(gpu_id),
-        "gpu" + std::to_string(gpu_id),
-        PoolType::kGpu,
-    });
+    pools.push_back(
+        Pool{
+            "gpu" + std::to_string(gpu_id),
+            "gpu" + std::to_string(gpu_id),
+            PoolType::kGpu,
+        });
   }
 
   std::vector<Endpoint> endpoints;
@@ -304,8 +303,7 @@ Topology build_eight_rail_switch_topology() {
   std::vector<Link> links;
   for (int rail_id = 0; rail_id < 8; ++rail_id) {
     Link link;
-    link.id =
-        "nic_" + std::to_string(rail_id) + "_to_netsw_rail_" + std::to_string(rail_id);
+    link.id = "nic_" + std::to_string(rail_id) + "_to_netsw_rail_" + std::to_string(rail_id);
     link.name = link.id;
     link.type = LinkType::kSwitch;
     link.src_endpoint_id = "nic_" + std::to_string(rail_id);
@@ -327,11 +325,12 @@ Topology build_two_node_transfer_and_fanout_topology() {
   pools.push_back(Pool{"cpu0", "cpu0", PoolType::kCpu});
   pools.push_back(Pool{"cpu1", "cpu1", PoolType::kCpu});
   for (int gpu_id = 0; gpu_id < 8; ++gpu_id) {
-    pools.push_back(Pool{
-        "gpu" + std::to_string(gpu_id),
-        "gpu" + std::to_string(gpu_id),
-        PoolType::kGpu,
-    });
+    pools.push_back(
+        Pool{
+            "gpu" + std::to_string(gpu_id),
+            "gpu" + std::to_string(gpu_id),
+            PoolType::kGpu,
+        });
   }
 
   std::vector<Endpoint> endpoints;
@@ -379,8 +378,7 @@ Topology build_two_node_transfer_and_fanout_topology() {
   std::vector<Link> links;
   for (int rail_id = 0; rail_id < 8; ++rail_id) {
     Link link;
-    link.id =
-        "nic_" + std::to_string(rail_id) + "_to_netsw_rail_" + std::to_string(rail_id);
+    link.id = "nic_" + std::to_string(rail_id) + "_to_netsw_rail_" + std::to_string(rail_id);
     link.name = link.id;
     link.type = LinkType::kSwitch;
     link.src_endpoint_id = "nic_" + std::to_string(rail_id);
@@ -465,8 +463,7 @@ TEST_CASE("Connection records success and failure", "[communicator][routing]") {
 }
 
 TEST_CASE("RoutingContext caches communicators and builds direct channels", "[communicator][routing]") {
-  auto context = std::make_shared<RoutingContext>(
-      RoutingContext::Options{}, /*engine=*/nullptr);
+  auto context = std::make_shared<RoutingContext>(RoutingContext::Options{}, /*engine=*/nullptr);
   REQUIRE(context->set_topology(build_minimal_topology()).ok());
 
   std::vector<EndpointBinding> bindings;
@@ -493,8 +490,7 @@ TEST_CASE("RoutingContext caches communicators and builds direct channels", "[co
 }
 
 TEST_CASE("RoutingContext rejects topology and binding mutation", "[communicator][routing]") {
-  auto context = std::make_shared<RoutingContext>(
-      RoutingContext::Options{}, /*engine=*/nullptr);
+  auto context = std::make_shared<RoutingContext>(RoutingContext::Options{}, /*engine=*/nullptr);
   REQUIRE(context->set_topology(build_minimal_topology()).ok());
   auto second_topology = context->set_topology(build_minimal_topology());
   CHECK(second_topology.code() == absl::StatusCode::kFailedPrecondition);
@@ -542,9 +538,7 @@ TEST_CASE(
   CHECK(channel_or.value()->hops().front()->protocol() == ConnectionProtocol::kNvlink);
 }
 
-TEST_CASE(
-    "RoutingContext falls back to AUTO protocol when NVLINK adapter is unavailable",
-    "[communicator][routing]") {
+TEST_CASE("RoutingContext falls back to AUTO protocol when NVLINK adapter is unavailable", "[communicator][routing]") {
   auto nvlink_adapter = std::make_shared<ProtocolAdapterStub>(ConnectionProtocol::kNvlink, false);
   auto pcie_adapter = std::make_shared<ProtocolAdapterStub>(ConnectionProtocol::kPcie, true);
 
@@ -596,9 +590,7 @@ TEST_CASE(
   CHECK(channel_or.value()->hops().front()->protocol() == ConnectionProtocol::kPcie);
 }
 
-TEST_CASE(
-    "RoutingContext falls back to AUTO protocol when PCIE adapter is unavailable",
-    "[communicator][routing]") {
+TEST_CASE("RoutingContext falls back to AUTO protocol when PCIE adapter is unavailable", "[communicator][routing]") {
   auto options = RoutingContext::Options{};
   options.prefer_nvlink = true;
   options.prefer_pcie = true;
@@ -626,38 +618,39 @@ TEST_CASE(
   CHECK(channel_or.value()->hops().front()->protocol() == ConnectionProtocol::kAuto);
 }
 
-TEST_CASE(
-    "RoutingContext rail-matched fallback selects remote NIC by source rail",
-    "[communicator][routing]") {
-  auto context = std::make_shared<RoutingContext>(
-      RoutingContext::Options{}, /*engine=*/nullptr);
+TEST_CASE("RoutingContext rail-matched fallback selects remote NIC by source rail", "[communicator][routing]") {
+  auto context = std::make_shared<RoutingContext>(RoutingContext::Options{}, /*engine=*/nullptr);
   REQUIRE(context->set_topology(build_rail_switch_topology()).ok());
 
   std::vector<EndpointBinding> bindings;
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node_a/dev/gpu/0",
-      .node_id = "node_a",
-      .rail_id = 0,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node_b/dev/gpu/0",
-      .node_id = "node_b",
-      .rail_id = 1,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_remote_0",
-      .node_id = "node_b",
-      .ip = "10.0.0.10",
-      .port = 4010,
-      .rail_id = 0,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_remote_1",
-      .node_id = "node_b",
-      .ip = "10.0.0.11",
-      .port = 4011,
-      .rail_id = 1,
-  });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node_a/dev/gpu/0",
+          .node_id = "node_a",
+          .rail_id = 0,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node_b/dev/gpu/0",
+          .node_id = "node_b",
+          .rail_id = 1,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_remote_0",
+          .node_id = "node_b",
+          .ip = "10.0.0.10",
+          .port = 4010,
+          .rail_id = 0,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_remote_1",
+          .node_id = "node_b",
+          .ip = "10.0.0.11",
+          .port = 4011,
+          .rail_id = 1,
+      });
   REQUIRE(context->set_endpoint_bindings(std::move(bindings)).ok());
 
   auto comm_or = context->get_communicator("node_a/dev/gpu/0", "node_b/dev/gpu/0");
@@ -678,35 +671,38 @@ TEST_CASE(
 TEST_CASE(
     "RoutingContext rail-matched fallback uses destination rail when preferred rail missing",
     "[communicator][routing]") {
-  auto context = std::make_shared<RoutingContext>(
-      RoutingContext::Options{}, /*engine=*/nullptr);
+  auto context = std::make_shared<RoutingContext>(RoutingContext::Options{}, /*engine=*/nullptr);
   REQUIRE(context->set_topology(build_rail_switch_topology()).ok());
 
   std::vector<EndpointBinding> bindings;
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node_a/dev/gpu/0",
-      .node_id = "node_a",
-      .rail_id = 0,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node_b/dev/gpu/1",
-      .node_id = "node_b",
-      .rail_id = 1,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_remote_1",
-      .node_id = "node_b",
-      .ip = "10.0.0.21",
-      .port = 4021,
-      .rail_id = 1,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_remote_2",
-      .node_id = "node_b",
-      .ip = "10.0.0.22",
-      .port = 4022,
-      .rail_id = 2,
-  });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node_a/dev/gpu/0",
+          .node_id = "node_a",
+          .rail_id = 0,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node_b/dev/gpu/1",
+          .node_id = "node_b",
+          .rail_id = 1,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_remote_1",
+          .node_id = "node_b",
+          .ip = "10.0.0.21",
+          .port = 4021,
+          .rail_id = 1,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_remote_2",
+          .node_id = "node_b",
+          .ip = "10.0.0.22",
+          .port = 4022,
+          .rail_id = 2,
+      });
   REQUIRE(context->set_endpoint_bindings(std::move(bindings)).ok());
 
   auto comm_or = context->get_communicator("node_a/dev/gpu/0", "node_b/dev/gpu/1");
@@ -723,37 +719,38 @@ TEST_CASE(
 TEST_CASE(
     "RoutingContext rail-matched fallback maps GPU-GPU traffic across eight rails by affinity",
     "[communicator][routing]") {
-  auto context = std::make_shared<RoutingContext>(
-      RoutingContext::Options{}, /*engine=*/nullptr);
+  auto context = std::make_shared<RoutingContext>(RoutingContext::Options{}, /*engine=*/nullptr);
   REQUIRE(context->set_topology(build_eight_rail_switch_topology()).ok());
 
   std::vector<EndpointBinding> bindings;
   for (int idx = 0; idx < 8; ++idx) {
-    bindings.push_back(EndpointBinding{
-        .endpoint_id = "node_a/dev/gpu/" + std::to_string(idx),
-        .node_id = "node_a",
-        .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
-        .dev_id = idx,
-    });
-    bindings.push_back(EndpointBinding{
-        .endpoint_id = "node_b/dev/gpu/" + std::to_string(idx),
-        .node_id = "node_b",
-        .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
-        .dev_id = idx,
-    });
-    bindings.push_back(EndpointBinding{
-        .endpoint_id = "nic_" + std::to_string(idx),
-        .node_id = "node_b",
-        .ip = "10.0.1." + std::to_string(10 + idx),
-        .port = static_cast<uint16_t>(4100 + idx),
-    });
+    bindings.push_back(
+        EndpointBinding{
+            .endpoint_id = "node_a/dev/gpu/" + std::to_string(idx),
+            .node_id = "node_a",
+            .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+            .dev_id = idx,
+        });
+    bindings.push_back(
+        EndpointBinding{
+            .endpoint_id = "node_b/dev/gpu/" + std::to_string(idx),
+            .node_id = "node_b",
+            .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+            .dev_id = idx,
+        });
+    bindings.push_back(
+        EndpointBinding{
+            .endpoint_id = "nic_" + std::to_string(idx),
+            .node_id = "node_b",
+            .ip = "10.0.1." + std::to_string(10 + idx),
+            .port = static_cast<uint16_t>(4100 + idx),
+        });
   }
   REQUIRE(context->set_endpoint_bindings(std::move(bindings)).ok());
 
   for (int idx = 0; idx < 8; ++idx) {
-    auto comm_or = context->get_communicator(
-        "node_a/dev/gpu/" + std::to_string(idx),
-        "node_b/dev/gpu/" + std::to_string(idx));
+    auto comm_or =
+        context->get_communicator("node_a/dev/gpu/" + std::to_string(idx), "node_b/dev/gpu/" + std::to_string(idx));
     REQUIRE(comm_or.ok());
 
     auto channel_or = comm_or.value()->primary_channel();
@@ -764,50 +761,52 @@ TEST_CASE(
     CHECK(connection->type() == ConnectionType::kSwitch);
     CHECK(connection->remote_binding().endpoint_id == "nic_" + std::to_string(idx));
     REQUIRE(connection->link() != nullptr);
-    CHECK(
-        connection->link()->id ==
-        "nic_" + std::to_string(idx) + "_to_netsw_rail_" + std::to_string(idx));
+    CHECK(connection->link()->id == "nic_" + std::to_string(idx) + "_to_netsw_rail_" + std::to_string(idx));
   }
 }
 
 TEST_CASE(
     "RoutingContext rail-matched fallback picks CPU-affine remote NIC for GPU-to-CPU traffic when preferred rail is absent",
     "[communicator][routing]") {
-  auto context = std::make_shared<RoutingContext>(
-      RoutingContext::Options{}, /*engine=*/nullptr);
+  auto context = std::make_shared<RoutingContext>(RoutingContext::Options{}, /*engine=*/nullptr);
   REQUIRE(context->set_topology(build_eight_rail_switch_topology()).ok());
 
   std::vector<EndpointBinding> bindings;
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node_a/dev/gpu/3",
-      .node_id = "node_a",
-      .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
-      .dev_id = 3,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node_b/dev/cpu/1",
-      .node_id = "node_b",
-      .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
-      .dev_id = 1,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_1",
-      .node_id = "node_b",
-      .ip = "10.0.2.11",
-      .port = 4201,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_5",
-      .node_id = "node_b",
-      .ip = "10.0.2.15",
-      .port = 4205,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_7",
-      .node_id = "node_b",
-      .ip = "10.0.2.17",
-      .port = 4207,
-  });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node_a/dev/gpu/3",
+          .node_id = "node_a",
+          .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+          .dev_id = 3,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node_b/dev/cpu/1",
+          .node_id = "node_b",
+          .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
+          .dev_id = 1,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_1",
+          .node_id = "node_b",
+          .ip = "10.0.2.11",
+          .port = 4201,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_5",
+          .node_id = "node_b",
+          .ip = "10.0.2.15",
+          .port = 4205,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_7",
+          .node_id = "node_b",
+          .ip = "10.0.2.17",
+          .port = 4207,
+      });
   REQUIRE(context->set_endpoint_bindings(std::move(bindings)).ok());
 
   auto comm_or = context->get_communicator("node_a/dev/gpu/3", "node_b/dev/cpu/1");
@@ -826,41 +825,45 @@ TEST_CASE(
 TEST_CASE(
     "RoutingContext rail-matched fallback keeps CPU affinity for CPU-to-CPU traffic on both nodes",
     "[communicator][routing]") {
-  auto context = std::make_shared<RoutingContext>(
-      RoutingContext::Options{}, /*engine=*/nullptr);
+  auto context = std::make_shared<RoutingContext>(RoutingContext::Options{}, /*engine=*/nullptr);
   REQUIRE(context->set_topology(build_eight_rail_switch_topology()).ok());
 
   std::vector<EndpointBinding> bindings;
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node_a/dev/cpu/1",
-      .node_id = "node_a",
-      .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
-      .dev_id = 1,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node_b/dev/cpu/0",
-      .node_id = "node_b",
-      .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
-      .dev_id = 0,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_0",
-      .node_id = "node_b",
-      .ip = "10.0.3.10",
-      .port = 4300,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_1",
-      .node_id = "node_b",
-      .ip = "10.0.3.11",
-      .port = 4301,
-  });
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "nic_5",
-      .node_id = "node_b",
-      .ip = "10.0.3.15",
-      .port = 4305,
-  });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node_a/dev/cpu/1",
+          .node_id = "node_a",
+          .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
+          .dev_id = 1,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node_b/dev/cpu/0",
+          .node_id = "node_b",
+          .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
+          .dev_id = 0,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_0",
+          .node_id = "node_b",
+          .ip = "10.0.3.10",
+          .port = 4300,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_1",
+          .node_id = "node_b",
+          .ip = "10.0.3.11",
+          .port = 4301,
+      });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "nic_5",
+          .node_id = "node_b",
+          .ip = "10.0.3.15",
+          .port = 4305,
+      });
   REQUIRE(context->set_endpoint_bindings(std::move(bindings)).ok());
 
   auto comm_or = context->get_communicator("node_a/dev/cpu/1", "node_b/dev/cpu/0");
@@ -879,38 +882,41 @@ TEST_CASE(
 TEST_CASE(
     "RoutingContext supports cross-node GPU bootstrap then same-node GPU and memory fanout",
     "[communicator][routing]") {
-  auto context = std::make_shared<RoutingContext>(
-      RoutingContext::Options{}, /*engine=*/nullptr);
+  auto context = std::make_shared<RoutingContext>(RoutingContext::Options{}, /*engine=*/nullptr);
   REQUIRE(context->set_topology(build_two_node_transfer_and_fanout_topology()).ok());
 
   std::vector<EndpointBinding> bindings;
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node0/dev/gpu/0",
-      .node_id = "node0",
-      .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
-      .dev_id = 0,
-  });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node0/dev/gpu/0",
+          .node_id = "node0",
+          .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+          .dev_id = 0,
+      });
   for (int gpu_id = 0; gpu_id < 8; ++gpu_id) {
-    bindings.push_back(EndpointBinding{
-        .endpoint_id = "node1/dev/gpu/" + std::to_string(gpu_id),
-        .node_id = "node1",
-        .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
-        .dev_id = gpu_id,
-    });
+    bindings.push_back(
+        EndpointBinding{
+            .endpoint_id = "node1/dev/gpu/" + std::to_string(gpu_id),
+            .node_id = "node1",
+            .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_GPU,
+            .dev_id = gpu_id,
+        });
   }
-  bindings.push_back(EndpointBinding{
-      .endpoint_id = "node1/dev/cpu/0",
-      .node_id = "node1",
-      .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
-      .dev_id = 0,
-  });
+  bindings.push_back(
+      EndpointBinding{
+          .endpoint_id = "node1/dev/cpu/0",
+          .node_id = "node1",
+          .dev_type = tensorcast::communicator::base::COMMUNICATE_ENGINE_DEV_CPU,
+          .dev_id = 0,
+      });
   for (int rail_id = 0; rail_id < 8; ++rail_id) {
-    bindings.push_back(EndpointBinding{
-        .endpoint_id = "nic_" + std::to_string(rail_id),
-        .node_id = "node1",
-        .ip = "10.2.0." + std::to_string(20 + rail_id),
-        .port = static_cast<uint16_t>(4500 + rail_id),
-    });
+    bindings.push_back(
+        EndpointBinding{
+            .endpoint_id = "nic_" + std::to_string(rail_id),
+            .node_id = "node1",
+            .ip = "10.2.0." + std::to_string(20 + rail_id),
+            .port = static_cast<uint16_t>(4500 + rail_id),
+        });
   }
   REQUIRE(context->set_endpoint_bindings(std::move(bindings)).ok());
 
@@ -926,9 +932,7 @@ TEST_CASE(
   CHECK(cross_node_connection->link()->id == "nic_0_to_netsw_rail_0");
 
   for (int gpu_id = 1; gpu_id < 8; ++gpu_id) {
-    auto fanout_comm_or = context->get_communicator(
-        "node1/dev/gpu/0",
-        "node1/dev/gpu/" + std::to_string(gpu_id));
+    auto fanout_comm_or = context->get_communicator("node1/dev/gpu/0", "node1/dev/gpu/" + std::to_string(gpu_id));
     REQUIRE(fanout_comm_or.ok());
     auto fanout_channel_or = fanout_comm_or.value()->primary_channel();
     REQUIRE(fanout_channel_or.ok());

--- a/core/communicator/routing/types.cc
+++ b/core/communicator/routing/types.cc
@@ -5,10 +5,11 @@
 namespace tensorcast::communicator::routing {
 namespace {
 
-HealthState derive_health_from_counts(uint64_t success_count,
-                                      uint64_t failure_count,
-                                      absl::Time last_success,
-                                      absl::Time last_failure) {
+HealthState derive_health_from_counts(
+    uint64_t success_count,
+    uint64_t failure_count,
+    absl::Time last_success,
+    absl::Time last_failure) {
   if (success_count == 0 && failure_count == 0) {
     return HealthState::kUnknown;
   }
@@ -65,19 +66,11 @@ bool EndpointBinding::has_network_address() const {
 }
 
 HealthState derive_health(const ConnectionStats& stats) {
-  return derive_health_from_counts(
-      stats.success_count,
-      stats.failure_count,
-      stats.last_success,
-      stats.last_failure);
+  return derive_health_from_counts(stats.success_count, stats.failure_count, stats.last_success, stats.last_failure);
 }
 
 HealthState derive_health(const LinkStats& stats) {
-  return derive_health_from_counts(
-      stats.success_count,
-      stats.failure_count,
-      stats.last_success,
-      stats.last_failure);
+  return derive_health_from_counts(stats.success_count, stats.failure_count, stats.last_success, stats.last_failure);
 }
 
 } // namespace tensorcast::communicator::routing

--- a/core/communicator/topology/discovery/discovery_test.cc
+++ b/core/communicator/topology/discovery/discovery_test.cc
@@ -14,13 +14,13 @@
 namespace {
 
 using tensorcast::communicator::topology::Topology;
-using tensorcast::communicator::topology::discovery::LldpParseOptions;
 using tensorcast::communicator::topology::discovery::build_topology_from_discovery;
 using tensorcast::communicator::topology::discovery::build_topology_from_discovery_with_observability;
+using tensorcast::communicator::topology::discovery::LldpParseOptions;
 using tensorcast::communicator::topology::discovery::load_lldp_records_by_nic;
 using tensorcast::communicator::topology::discovery::load_nvlink_snapshot;
-using tensorcast::communicator::topology::discovery::parse_nvlink_runtime_probe_outputs;
 using tensorcast::communicator::topology::discovery::NvlinkSnapshotOptions;
+using tensorcast::communicator::topology::discovery::parse_nvlink_runtime_probe_outputs;
 using tensorcast::communicator::v1::CommunicatorConfig;
 using tensorcast::communicator::v1::NvlinkDiscoveryConfig;
 
@@ -54,9 +54,7 @@ CommunicatorConfig make_simple_numa_config() {
   return config;
 }
 
-std::vector<std::string> endpoint_pool_ids(
-    const Topology& topology,
-    const std::string& endpoint_id) {
+std::vector<std::string> endpoint_pool_ids(const Topology& topology, const std::string& endpoint_id) {
   const auto* endpoint = topology.find_endpoint(endpoint_id);
   if (endpoint == nullptr) {
     return {};
@@ -128,9 +126,7 @@ TEST_CASE("NVLINK runtime parser extracts GPU edges from topology matrix", "[com
       "Legend:\n";
 
   auto snapshot_or = parse_nvlink_runtime_probe_outputs(
-      gpu_query_output,
-      topology_matrix_output,
-      NvlinkSnapshotOptions{.strict = true});
+      gpu_query_output, topology_matrix_output, NvlinkSnapshotOptions{.strict = true});
   REQUIRE(snapshot_or.ok());
   const auto& snapshot = snapshot_or.value();
   REQUIRE(snapshot.gpus.size() == 3);
@@ -144,9 +140,7 @@ TEST_CASE("NVLINK runtime parser extracts GPU edges from topology matrix", "[com
   CHECK(snapshot.edges[1].link_count == 1);
 }
 
-TEST_CASE(
-    "NVLINK runtime parser strips ANSI topology header sequences",
-    "[communicator][topology][discovery]") {
+TEST_CASE("NVLINK runtime parser strips ANSI topology header sequences", "[communicator][topology][discovery]") {
   const std::string gpu_query_output =
       "0, GPU-0\n"
       "1, GPU-1\n"
@@ -164,9 +158,7 @@ TEST_CASE(
       "Legend:\n";
 
   auto snapshot_or = parse_nvlink_runtime_probe_outputs(
-      gpu_query_output,
-      topology_matrix_output,
-      NvlinkSnapshotOptions{.strict = true});
+      gpu_query_output, topology_matrix_output, NvlinkSnapshotOptions{.strict = true});
   REQUIRE(snapshot_or.ok());
   const auto& snapshot = snapshot_or.value();
   REQUIRE(snapshot.gpus.size() == 4);
@@ -322,9 +314,7 @@ TEST_CASE("Host topology builder supports NVLINK runtime probe source", "[commun
   CHECK(topology.find_link("nvlink_GPU-2_to_nvlink_GPU-1") != nullptr);
 }
 
-TEST_CASE(
-    "Host topology builder infers NIC GPU affinity from PCI paths",
-    "[communicator][topology][discovery]") {
+TEST_CASE("Host topology builder infers NIC GPU affinity from PCI paths", "[communicator][topology][discovery]") {
   CommunicatorConfig config = make_simple_numa_config();
   auto* discovery = config.mutable_topology_discovery();
   discovery->set_enable(true);

--- a/core/communicator/topology/discovery/host_topology_builder.cc
+++ b/core/communicator/topology/discovery/host_topology_builder.cc
@@ -17,9 +17,9 @@
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
-#include "core/cuda/cuda_api.h"
 #include "core/communicator/topology/discovery/lldp_source.h"
 #include "core/communicator/topology/discovery/nvlink_source.h"
+#include "core/cuda/cuda_api.h"
 
 namespace tc = tensorcast::communicator::v1;
 
@@ -49,8 +49,8 @@ struct AffinityInferenceStats {
 int longest_common_prefix_len(std::string_view lhs, std::string_view rhs) {
   int prefix_len = 0;
   const size_t max_len = std::min(lhs.size(), rhs.size());
-  while (static_cast<size_t>(prefix_len) < max_len && lhs[static_cast<size_t>(prefix_len)] == rhs[static_cast<size_t>(
-                                                                   prefix_len)]) {
+  while (static_cast<size_t>(prefix_len) < max_len &&
+         lhs[static_cast<size_t>(prefix_len)] == rhs[static_cast<size_t>(prefix_len)]) {
     prefix_len += 1;
   }
   return prefix_len;
@@ -92,9 +92,7 @@ std::string gpu_pci_bdf(const cudaDeviceProp& props) {
       static_cast<unsigned int>(props.pciDeviceID));
 }
 
-absl::StatusOr<std::string> resolve_gpu_pci_path(
-    int gpu_index,
-    const HostTopologyBuilderOptions& options) {
+absl::StatusOr<std::string> resolve_gpu_pci_path(int gpu_index, const HostTopologyBuilderOptions& options) {
   const auto override_it = options.gpu_pci_path_overrides.find(gpu_index);
   if (override_it != options.gpu_pci_path_overrides.end()) {
     if (override_it->second.empty()) {
@@ -154,12 +152,10 @@ absl::StatusOr<std::string> resolve_nic_pci_path(
 std::string build_affinity_degrade_reason(const AffinityInferenceStats& stats) {
   std::vector<std::string> parts;
   if (stats.gpu_candidate_count > stats.gpu_path_resolved_count) {
-    parts.push_back(
-        std::format("gpu_paths_resolved={}/{}", stats.gpu_path_resolved_count, stats.gpu_candidate_count));
+    parts.push_back(std::format("gpu_paths_resolved={}/{}", stats.gpu_path_resolved_count, stats.gpu_candidate_count));
   }
   if (stats.nic_candidate_count > stats.nic_path_resolved_count) {
-    parts.push_back(
-        std::format("nic_paths_resolved={}/{}", stats.nic_path_resolved_count, stats.nic_candidate_count));
+    parts.push_back(std::format("nic_paths_resolved={}/{}", stats.nic_path_resolved_count, stats.nic_candidate_count));
   }
   if (stats.nic_candidate_count > stats.nic_scored_count) {
     parts.push_back(std::format("nic_scored={}/{}", stats.nic_scored_count, stats.nic_candidate_count));
@@ -190,15 +186,16 @@ AffinityInferenceStats infer_nic_gpu_affinity(
     all_gpu_pool_ids.insert(pool_id);
     auto gpu_path_or = resolve_gpu_pci_path(gpu_index, options);
     if (!gpu_path_or.ok()) {
-      VLOG(1) << "Skipping GPU in NIC-GPU affinity inference due to missing PCI path: gpu="
-              << gpu_index << " status=" << gpu_path_or.status();
+      VLOG(1) << "Skipping GPU in NIC-GPU affinity inference due to missing PCI path: gpu=" << gpu_index
+              << " status=" << gpu_path_or.status();
       continue;
     }
     stats.gpu_path_resolved_count += 1;
-    gpu_records.push_back(PciGpuRecord{
-        .pool_id = pool_id,
-        .pci_path = std::move(gpu_path_or).value(),
-    });
+    gpu_records.push_back(
+        PciGpuRecord{
+            .pool_id = pool_id,
+            .pci_path = std::move(gpu_path_or).value(),
+        });
   }
 
   for (auto& endpoint : *endpoints) {
@@ -209,8 +206,8 @@ AffinityInferenceStats infer_nic_gpu_affinity(
 
     auto nic_path_or = resolve_nic_pci_path(endpoint.name, lldp_records, options);
     if (!nic_path_or.ok()) {
-      VLOG(1) << "Skipping NIC in NIC-GPU affinity inference due to missing PCI path: nic="
-              << endpoint.name << " status=" << nic_path_or.status();
+      VLOG(1) << "Skipping NIC in NIC-GPU affinity inference due to missing PCI path: nic=" << endpoint.name
+              << " status=" << nic_path_or.status();
       continue;
     }
     stats.nic_path_resolved_count += 1;
@@ -288,7 +285,7 @@ std::string nic_endpoint_id(const std::string& nic_name) {
 
 bool source_is_enabled(tc::NvlinkDiscoveryConfig::Source source) {
   return source == tc::NvlinkDiscoveryConfig::SOURCE_SNAPSHOT_FILE ||
-         source == tc::NvlinkDiscoveryConfig::SOURCE_RUNTIME_PROBE;
+      source == tc::NvlinkDiscoveryConfig::SOURCE_RUNTIME_PROBE;
 }
 
 std::string nvlink_source_to_string(tc::NvlinkDiscoveryConfig::Source source) {
@@ -306,8 +303,7 @@ std::string nvlink_source_to_string(tc::NvlinkDiscoveryConfig::Source source) {
   }
 }
 
-absl::StatusOr<BaselineBuildResult> build_baseline_from_simple_numa(
-    const tc::CommunicatorConfig& config) {
+absl::StatusOr<BaselineBuildResult> build_baseline_from_simple_numa(const tc::CommunicatorConfig& config) {
   const auto& simple = config.simple_numa();
   if (!simple.enable()) {
     return absl::InvalidArgumentError("simple_numa is disabled");
@@ -343,8 +339,7 @@ absl::StatusOr<BaselineBuildResult> build_baseline_from_simple_numa(
 
     for (int gpu_id : node.gpus()) {
       if (!seen_gpus.insert(gpu_id).second) {
-        return absl::InvalidArgumentError(
-            std::format("duplicate simple_numa gpu id: {}", gpu_id));
+        return absl::InvalidArgumentError(std::format("duplicate simple_numa gpu id: {}", gpu_id));
       }
       const std::string gpu_id_str = gpu_pool_id(gpu_id);
       baseline.pools.push_back(Pool{gpu_id_str, gpu_id_str, PoolType::kGpu});
@@ -356,8 +351,7 @@ absl::StatusOr<BaselineBuildResult> build_baseline_from_simple_numa(
 
     for (const auto& nic_name : node.nics()) {
       if (nic_name.empty()) {
-        return absl::InvalidArgumentError(
-            std::format("simple_numa node {} has empty nic name", node.id()));
+        return absl::InvalidArgumentError(std::format("simple_numa node {} has empty nic name", node.id()));
       }
       const std::string endpoint_id = nic_endpoint_id(nic_name);
       if (!seen_nics.insert(endpoint_id).second) {
@@ -415,8 +409,7 @@ void add_nvlink_topology(
     if (src_gpu_it == gpu_index_by_uuid.end() || dst_gpu_it == gpu_index_by_uuid.end()) {
       continue;
     }
-    if (!gpu_pool_by_index.contains(src_gpu_it->second) ||
-        !gpu_pool_by_index.contains(dst_gpu_it->second)) {
+    if (!gpu_pool_by_index.contains(src_gpu_it->second) || !gpu_pool_by_index.contains(dst_gpu_it->second)) {
       continue;
     }
     edge_gpu_uuids.insert(edge.src_gpu_uuid);
@@ -471,8 +464,8 @@ void add_nvlink_topology(
     auto src_it = endpoint_id_by_gpu_uuid.find(edge.src_gpu_uuid);
     auto dst_it = endpoint_id_by_gpu_uuid.find(edge.dst_gpu_uuid);
     if (src_it == endpoint_id_by_gpu_uuid.end() || dst_it == endpoint_id_by_gpu_uuid.end()) {
-      VLOG(1) << "Skipping NVLINK edge due to missing GPU endpoints: "
-              << edge.src_gpu_uuid << " <-> " << edge.dst_gpu_uuid;
+      VLOG(1) << "Skipping NVLINK edge due to missing GPU endpoints: " << edge.src_gpu_uuid << " <-> "
+              << edge.dst_gpu_uuid;
       continue;
     }
 
@@ -528,9 +521,7 @@ absl::StatusOr<HostTopologyBuildResult> build_topology_from_discovery_with_obser
   observability.nic_endpoint_count = static_cast<int>(endpoints.size());
   observability.lldp_source = discovery_enabled ? lldp_source_description(config) : "disabled";
   const bool emit_rail_switch_endpoints =
-      discovery_enabled
-          ? config.topology_discovery().merge_policy().emit_rail_switch_endpoints()
-          : false;
+      discovery_enabled ? config.topology_discovery().merge_policy().emit_rail_switch_endpoints() : false;
 
   absl::flat_hash_map<std::string, LldpNicRecord> lldp_records;
   if (discovery_enabled) {
@@ -560,15 +551,13 @@ absl::StatusOr<HostTopologyBuildResult> build_topology_from_discovery_with_obser
     observability.affinity_nic_candidate_count = affinity_stats.nic_candidate_count;
     observability.affinity_nic_scored_count = affinity_stats.nic_scored_count;
     observability.affinity_nic_narrowed_count = affinity_stats.nic_narrowed_count;
-    const bool affinity_degraded =
-        affinity_stats.nic_candidate_count > 0 &&
+    const bool affinity_degraded = affinity_stats.nic_candidate_count > 0 &&
         (affinity_stats.nic_candidate_count > affinity_stats.nic_scored_count ||
          affinity_stats.gpu_candidate_count > affinity_stats.gpu_path_resolved_count);
     observability.affinity_degraded = affinity_degraded;
     if (affinity_degraded) {
       observability.affinity_degrade_reason = build_affinity_degrade_reason(affinity_stats);
-      LOG(WARNING) << "NIC-GPU affinity inference degraded: "
-                   << observability.affinity_degrade_reason;
+      LOG(WARNING) << "NIC-GPU affinity inference degraded: " << observability.affinity_degrade_reason;
     }
   }
 
@@ -642,14 +631,11 @@ absl::StatusOr<HostTopologyBuildResult> build_topology_from_discovery_with_obser
           if (nvlink_required) {
             return absl::Status(
                 snapshot_or.status().code(),
-                absl::StrCat(
-                    "failed to run required NVLINK runtime probe: ",
-                    snapshot_or.status().message()));
+                absl::StrCat("failed to run required NVLINK runtime probe: ", snapshot_or.status().message()));
           }
           observability.nvlink_degraded = true;
           observability.nvlink_degrade_reason = snapshot_or.status().ToString();
-          LOG(WARNING) << "NVLINK runtime probe unavailable, skipping NVLINK links: "
-                       << snapshot_or.status();
+          LOG(WARNING) << "NVLINK runtime probe unavailable, skipping NVLINK links: " << snapshot_or.status();
         } else {
           const NvlinkSnapshot& snapshot = snapshot_or.value();
           observability.nvlink_gpu_count = static_cast<int>(snapshot.gpus.size());
@@ -693,16 +679,10 @@ absl::StatusOr<HostTopologyBuildResult> build_topology_from_discovery_with_obser
 
   ValidationOptions validation;
   validation.require_endpoint_links = true;
-  validation.require_connected =
-      discovery_enabled
-          ? config.topology_discovery().merge_policy().require_connected()
-          : options.require_connected_when_discovery_disabled;
+  validation.require_connected = discovery_enabled ? config.topology_discovery().merge_policy().require_connected()
+                                                   : options.require_connected_when_discovery_disabled;
 
-  auto topology_or = Topology::Build(
-      std::move(baseline.pools),
-      std::move(endpoints),
-      std::move(links),
-      validation);
+  auto topology_or = Topology::Build(std::move(baseline.pools), std::move(endpoints), std::move(links), validation);
   if (!topology_or.ok()) {
     return topology_or.status();
   }

--- a/core/communicator/topology/discovery/lldp_source.cc
+++ b/core/communicator/topology/discovery/lldp_source.cc
@@ -34,10 +34,8 @@ absl::StatusOr<LldpNicRecord> parse_lldp_line(const std::string& line, int line_
 
   const size_t first_comma = value.find(',');
   const size_t second_comma = value.find(',', first_comma == std::string::npos ? first_comma : first_comma + 1);
-  if (first_comma == std::string::npos || second_comma == std::string::npos ||
-      second_comma + 1 >= value.size()) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("line ", line_no, ": expected '<pci_bdf>,<nic_name>,<rail_id>'"));
+  if (first_comma == std::string::npos || second_comma == std::string::npos || second_comma + 1 >= value.size()) {
+    return absl::InvalidArgumentError(absl::StrCat("line ", line_no, ": expected '<pci_bdf>,<nic_name>,<rail_id>'"));
   }
 
   record.pci_bdf = std::string(absl::StripAsciiWhitespace(value.substr(0, first_comma)));
@@ -78,9 +76,7 @@ absl::Status handle_parse_error(const absl::Status& status, bool strict) {
 
 } // namespace
 
-absl::StatusOr<std::vector<LldpNicRecord>> load_lldp_records(
-    const std::string& file_path,
-    LldpParseOptions options) {
+absl::StatusOr<std::vector<LldpNicRecord>> load_lldp_records(const std::string& file_path, LldpParseOptions options) {
   std::ifstream input(file_path);
   if (!input.good()) {
     return absl::NotFoundError(absl::StrCat("LLDP file not found: ", file_path));
@@ -117,16 +113,17 @@ absl::StatusOr<std::vector<LldpNicRecord>> load_lldp_records(
       continue;
     }
 
-    const absl::Status conflict = absl::InvalidArgumentError(absl::StrCat(
-        "line ",
-        line_no,
-        ": conflicting LLDP entries for nic '",
-        record.nic_name,
-        "' (existing rail=",
-        it->second.rail_id,
-        ", new rail=",
-        record.rail_id,
-        ")"));
+    const absl::Status conflict = absl::InvalidArgumentError(
+        absl::StrCat(
+            "line ",
+            line_no,
+            ": conflicting LLDP entries for nic '",
+            record.nic_name,
+            "' (existing rail=",
+            it->second.rail_id,
+            ", new rail=",
+            record.rail_id,
+            ")"));
     absl::Status conflict_status = handle_parse_error(conflict, options.strict);
     if (!conflict_status.ok()) {
       return conflict_status;

--- a/core/communicator/topology/discovery/nvlink_source.cc
+++ b/core/communicator/topology/discovery/nvlink_source.cc
@@ -2,6 +2,7 @@
 
 #include "core/communicator/topology/discovery/nvlink_source.h"
 
+#include <sys/wait.h>
 #include <algorithm>
 #include <array>
 #include <cerrno>
@@ -11,7 +12,6 @@
 #include <optional>
 #include <sstream>
 #include <string>
-#include <sys/wait.h>
 #include <utility>
 #include <vector>
 
@@ -130,8 +130,7 @@ absl::StatusOr<std::string> run_command_capture_stdout(const std::string& comman
     return absl::ErrnoToStatus(errno, absl::StrCat("pclose failed for command: ", command));
   }
   if (!WIFEXITED(close_status) || WEXITSTATUS(close_status) != 0) {
-    return absl::UnavailableError(
-        absl::StrCat("command failed: ", command, " (status=", close_status, ")"));
+    return absl::UnavailableError(absl::StrCat("command failed: ", command, " (status=", close_status, ")"));
   }
 
   return output;
@@ -139,8 +138,7 @@ absl::StatusOr<std::string> run_command_capture_stdout(const std::string& comman
 
 absl::StatusOr<NvlinkGpuRecord> parse_gpu_row(const std::vector<std::string>& cols, int line_no) {
   if (cols.size() != 3) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("line ", line_no, ": gpu row expects 3 columns"));
+    return absl::InvalidArgumentError(absl::StrCat("line ", line_no, ": gpu row expects 3 columns"));
   }
   NvlinkGpuRecord record;
   record.gpu_uuid = std::string(absl::StripAsciiWhitespace(cols[1]));
@@ -163,8 +161,7 @@ absl::StatusOr<NvlinkGpuRecord> parse_gpu_row(const std::vector<std::string>& co
 
 absl::StatusOr<NvlinkEdge> parse_edge_row(const std::vector<std::string>& cols, int line_no) {
   if (cols.size() != 5) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("line ", line_no, ": edge row expects 5 columns"));
+    return absl::InvalidArgumentError(absl::StrCat("line ", line_no, ": edge row expects 5 columns"));
   }
 
   NvlinkEdge edge;
@@ -182,8 +179,7 @@ absl::StatusOr<NvlinkEdge> parse_edge_row(const std::vector<std::string>& cols, 
   try {
     edge.link_count = std::stoi(link_count_text);
   } catch (const std::exception&) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("line ", line_no, ": invalid link_count '", link_count_text, "'"));
+    return absl::InvalidArgumentError(absl::StrCat("line ", line_no, ": invalid link_count '", link_count_text, "'"));
   }
   if (edge.link_count <= 0) {
     return absl::InvalidArgumentError(
@@ -197,8 +193,7 @@ absl::StatusOr<NvlinkEdge> parse_edge_row(const std::vector<std::string>& cols, 
         absl::StrCat("line ", line_no, ": invalid bandwidth_hint_gbps '", bandwidth_text, "'"));
   }
   if (edge.bandwidth_hint_gbps < 0.0) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("line ", line_no, ": bandwidth_hint_gbps must be >= 0"));
+    return absl::InvalidArgumentError(absl::StrCat("line ", line_no, ": bandwidth_hint_gbps must be >= 0"));
   }
 
   return edge;
@@ -258,14 +253,15 @@ absl::StatusOr<std::vector<NvlinkGpuRecord>> parse_runtime_gpu_query_output(
 
     if (gpu_index < 0 || gpu_uuid.empty()) {
       absl::Status parse_status = handle_parse_error(
-          absl::InvalidArgumentError(absl::StrCat(
-              "line ",
-              line_no,
-              ": runtime GPU row requires gpu_index>=0 and non-empty gpu_uuid (index=",
-              gpu_index,
-              ", uuid='",
-              gpu_uuid,
-              "')")),
+          absl::InvalidArgumentError(
+              absl::StrCat(
+                  "line ",
+                  line_no,
+                  ": runtime GPU row requires gpu_index>=0 and non-empty gpu_uuid (index=",
+                  gpu_index,
+                  ", uuid='",
+                  gpu_uuid,
+                  "')")),
           strict,
           "NVLINK runtime GPU row");
       if (!parse_status.ok()) {
@@ -277,16 +273,17 @@ absl::StatusOr<std::vector<NvlinkGpuRecord>> parse_runtime_gpu_query_output(
     auto uuid_by_index_it = uuid_by_index.find(gpu_index);
     if (uuid_by_index_it != uuid_by_index.end() && uuid_by_index_it->second != gpu_uuid) {
       absl::Status parse_status = handle_parse_error(
-          absl::InvalidArgumentError(absl::StrCat(
-              "line ",
-              line_no,
-              ": conflicting gpu_uuid for gpu_index ",
-              gpu_index,
-              " (existing='",
-              uuid_by_index_it->second,
-              "', new='",
-              gpu_uuid,
-              "')")),
+          absl::InvalidArgumentError(
+              absl::StrCat(
+                  "line ",
+                  line_no,
+                  ": conflicting gpu_uuid for gpu_index ",
+                  gpu_index,
+                  " (existing='",
+                  uuid_by_index_it->second,
+                  "', new='",
+                  gpu_uuid,
+                  "')")),
           strict,
           "NVLINK runtime GPU row");
       if (!parse_status.ok()) {
@@ -298,16 +295,17 @@ absl::StatusOr<std::vector<NvlinkGpuRecord>> parse_runtime_gpu_query_output(
     auto index_by_uuid_it = index_by_uuid.find(gpu_uuid);
     if (index_by_uuid_it != index_by_uuid.end() && index_by_uuid_it->second != gpu_index) {
       absl::Status parse_status = handle_parse_error(
-          absl::InvalidArgumentError(absl::StrCat(
-              "line ",
-              line_no,
-              ": conflicting gpu_index for gpu_uuid '",
-              gpu_uuid,
-              "' (existing=",
-              index_by_uuid_it->second,
-              ", new=",
-              gpu_index,
-              ")")),
+          absl::InvalidArgumentError(
+              absl::StrCat(
+                  "line ",
+                  line_no,
+                  ": conflicting gpu_index for gpu_uuid '",
+                  gpu_uuid,
+                  "' (existing=",
+                  index_by_uuid_it->second,
+                  ", new=",
+                  gpu_index,
+                  ")")),
           strict,
           "NVLINK runtime GPU row");
       if (!parse_status.ok()) {
@@ -346,8 +344,7 @@ absl::StatusOr<TopologyMatrix> parse_runtime_topology_matrix_output(
   int line_no = 0;
   while (std::getline(input, line)) {
     line_no += 1;
-    const std::string trimmed =
-        std::string(absl::StripAsciiWhitespace(strip_ansi_escape_sequences(line)));
+    const std::string trimmed = std::string(absl::StripAsciiWhitespace(strip_ansi_escape_sequences(line)));
     if (trimmed.empty()) {
       continue;
     }
@@ -381,15 +378,16 @@ absl::StatusOr<TopologyMatrix> parse_runtime_topology_matrix_output(
     const size_t expected_cols = matrix.header_gpu_labels.size() + 1;
     if (tokens.size() < expected_cols) {
       absl::Status parse_status = handle_parse_error(
-          absl::InvalidArgumentError(absl::StrCat(
-              "line ",
-              line_no,
-              ": runtime topology row has ",
-              tokens.size(),
-              " columns, expected >=",
-              expected_cols,
-              " for row ",
-              row_label)),
+          absl::InvalidArgumentError(
+              absl::StrCat(
+                  "line ",
+                  line_no,
+                  ": runtime topology row has ",
+                  tokens.size(),
+                  " columns, expected >=",
+                  expected_cols,
+                  " for row ",
+                  row_label)),
           strict,
           "NVLINK runtime topology row");
       if (!parse_status.ok()) {
@@ -433,37 +431,29 @@ absl::StatusOr<int> parse_nvlink_count_token(
     }
   }
   if (!is_decimal_number(suffix)) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "invalid NVLINK token '",
-        token,
-        "' between ",
-        src_gpu_label,
-        " and ",
-        dst_gpu_label,
-        " (expected NV<number> or NVL)"));
+    return absl::InvalidArgumentError(
+        absl::StrCat(
+            "invalid NVLINK token '",
+            token,
+            "' between ",
+            src_gpu_label,
+            " and ",
+            dst_gpu_label,
+            " (expected NV<number> or NVL)"));
   }
 
   int link_count = 0;
   try {
     link_count = std::stoi(suffix);
   } catch (const std::exception&) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "invalid NVLINK token '",
-        token,
-        "' between ",
-        src_gpu_label,
-        " and ",
-        dst_gpu_label,
-        " (stoi failed)"));
+    return absl::InvalidArgumentError(
+        absl::StrCat(
+            "invalid NVLINK token '", token, "' between ", src_gpu_label, " and ", dst_gpu_label, " (stoi failed)"));
   }
   if (link_count <= 0) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "invalid non-positive NVLINK count '",
-        token,
-        "' between ",
-        src_gpu_label,
-        " and ",
-        dst_gpu_label));
+    return absl::InvalidArgumentError(
+        absl::StrCat(
+            "invalid non-positive NVLINK count '", token, "' between ", src_gpu_label, " and ", dst_gpu_label));
   }
   return link_count;
 }
@@ -484,26 +474,20 @@ std::optional<std::string> lookup_matrix_cell(
 }
 
 void sort_snapshot(NvlinkSnapshot* snapshot) {
-  std::sort(
-      snapshot->gpus.begin(),
-      snapshot->gpus.end(),
-      [](const NvlinkGpuRecord& a, const NvlinkGpuRecord& b) { return a.gpu_uuid < b.gpu_uuid; });
-  std::sort(
-      snapshot->edges.begin(),
-      snapshot->edges.end(),
-      [](const NvlinkEdge& a, const NvlinkEdge& b) {
-        if (a.src_gpu_uuid != b.src_gpu_uuid) {
-          return a.src_gpu_uuid < b.src_gpu_uuid;
-        }
-        return a.dst_gpu_uuid < b.dst_gpu_uuid;
-      });
+  std::sort(snapshot->gpus.begin(), snapshot->gpus.end(), [](const NvlinkGpuRecord& a, const NvlinkGpuRecord& b) {
+    return a.gpu_uuid < b.gpu_uuid;
+  });
+  std::sort(snapshot->edges.begin(), snapshot->edges.end(), [](const NvlinkEdge& a, const NvlinkEdge& b) {
+    if (a.src_gpu_uuid != b.src_gpu_uuid) {
+      return a.src_gpu_uuid < b.src_gpu_uuid;
+    }
+    return a.dst_gpu_uuid < b.dst_gpu_uuid;
+  });
 }
 
 } // namespace
 
-absl::StatusOr<NvlinkSnapshot> load_nvlink_snapshot(
-    const std::string& file_path,
-    NvlinkSnapshotOptions options) {
+absl::StatusOr<NvlinkSnapshot> load_nvlink_snapshot(const std::string& file_path, NvlinkSnapshotOptions options) {
   std::ifstream input(file_path);
   if (!input.good()) {
     return absl::NotFoundError(absl::StrCat("NVLINK snapshot not found: ", file_path));
@@ -543,16 +527,17 @@ absl::StatusOr<NvlinkSnapshot> load_nvlink_snapshot(
         continue;
       }
       if (it->second.gpu_index != gpu.gpu_index) {
-        const absl::Status conflict = absl::InvalidArgumentError(absl::StrCat(
-            "line ",
-            line_no,
-            ": conflicting gpu_index for gpu_uuid '",
-            gpu.gpu_uuid,
-            "' (existing=",
-            it->second.gpu_index,
-            ", new=",
-            gpu.gpu_index,
-            ")"));
+        const absl::Status conflict = absl::InvalidArgumentError(
+            absl::StrCat(
+                "line ",
+                line_no,
+                ": conflicting gpu_index for gpu_uuid '",
+                gpu.gpu_uuid,
+                "' (existing=",
+                it->second.gpu_index,
+                ", new=",
+                gpu.gpu_index,
+                ")"));
         absl::Status conflict_status = handle_parse_error(conflict, options.strict, "NVLINK snapshot GPU row");
         if (!conflict_status.ok()) {
           return conflict_status;
@@ -652,8 +637,8 @@ absl::StatusOr<NvlinkSnapshot> parse_nvlink_runtime_probe_outputs(
 
       if (!forward_token.has_value() && !reverse_token.has_value()) {
         absl::Status parse_status = handle_parse_error(
-            absl::InvalidArgumentError(absl::StrCat(
-                "runtime topology matrix has no cell for GPU pair ", src_label, " <-> ", dst_label)),
+            absl::InvalidArgumentError(
+                absl::StrCat("runtime topology matrix has no cell for GPU pair ", src_label, " <-> ", dst_label)),
             options.strict,
             "NVLINK runtime topology pair");
         if (!parse_status.ok()) {
@@ -666,8 +651,8 @@ absl::StatusOr<NvlinkSnapshot> parse_nvlink_runtime_probe_outputs(
       if (forward_token.has_value()) {
         auto count_or = parse_nvlink_count_token(*forward_token, src_label, dst_label);
         if (!count_or.ok()) {
-          absl::Status parse_status = handle_parse_error(
-              count_or.status(), options.strict, "NVLINK runtime topology token");
+          absl::Status parse_status =
+              handle_parse_error(count_or.status(), options.strict, "NVLINK runtime topology token");
           if (!parse_status.ok()) {
             return parse_status;
           }
@@ -680,8 +665,8 @@ absl::StatusOr<NvlinkSnapshot> parse_nvlink_runtime_probe_outputs(
       if (reverse_token.has_value()) {
         auto count_or = parse_nvlink_count_token(*reverse_token, dst_label, src_label);
         if (!count_or.ok()) {
-          absl::Status parse_status = handle_parse_error(
-              count_or.status(), options.strict, "NVLINK runtime topology token");
+          absl::Status parse_status =
+              handle_parse_error(count_or.status(), options.strict, "NVLINK runtime topology token");
           if (!parse_status.ok()) {
             return parse_status;
           }
@@ -692,16 +677,17 @@ absl::StatusOr<NvlinkSnapshot> parse_nvlink_runtime_probe_outputs(
 
       if (forward_count > 0 && reverse_count > 0 && forward_count != reverse_count) {
         absl::Status parse_status = handle_parse_error(
-            absl::InvalidArgumentError(absl::StrCat(
-                "runtime topology matrix mismatch for ",
-                src_label,
-                " <-> ",
-                dst_label,
-                " (forward=",
-                forward_count,
-                ", reverse=",
-                reverse_count,
-                ")")),
+            absl::InvalidArgumentError(
+                absl::StrCat(
+                    "runtime topology matrix mismatch for ",
+                    src_label,
+                    " <-> ",
+                    dst_label,
+                    " (forward=",
+                    forward_count,
+                    ", reverse=",
+                    reverse_count,
+                    ")")),
             options.strict,
             "NVLINK runtime topology pair");
         if (!parse_status.ok()) {
@@ -743,8 +729,7 @@ absl::StatusOr<NvlinkSnapshot> parse_nvlink_runtime_probe_outputs(
   return snapshot;
 }
 
-absl::StatusOr<NvlinkSnapshot> load_nvlink_runtime_probe(
-    NvlinkRuntimeProbeOptions options) {
+absl::StatusOr<NvlinkSnapshot> load_nvlink_runtime_probe(NvlinkRuntimeProbeOptions options) {
   std::string gpu_query_output;
   if (!options.gpu_query_output_override.empty()) {
     gpu_query_output = options.gpu_query_output_override;
@@ -778,9 +763,7 @@ absl::StatusOr<NvlinkSnapshot> load_nvlink_runtime_probe(
   }
 
   return parse_nvlink_runtime_probe_outputs(
-      gpu_query_output,
-      topology_matrix_output,
-      NvlinkSnapshotOptions{.strict = options.strict});
+      gpu_query_output, topology_matrix_output, NvlinkSnapshotOptions{.strict = options.strict});
 }
 
 } // namespace tensorcast::communicator::topology::discovery

--- a/core/communicator/topology/discovery/nvlink_source.h
+++ b/core/communicator/topology/discovery/nvlink_source.h
@@ -49,9 +49,7 @@ struct NvlinkRuntimeProbeOptions {
 // Snapshot format:
 //   gpu,<gpu_uuid>,<gpu_index>
 //   edge,<src_gpu_uuid>,<dst_gpu_uuid>,<link_count>,<bandwidth_hint_gbps>
-absl::StatusOr<NvlinkSnapshot> load_nvlink_snapshot(
-    const std::string& file_path,
-    NvlinkSnapshotOptions options = {});
+absl::StatusOr<NvlinkSnapshot> load_nvlink_snapshot(const std::string& file_path, NvlinkSnapshotOptions options = {});
 
 // Parse outputs from:
 //   nvidia-smi --query-gpu=index,uuid --format=csv,noheader,nounits
@@ -62,8 +60,7 @@ absl::StatusOr<NvlinkSnapshot> parse_nvlink_runtime_probe_outputs(
     NvlinkSnapshotOptions options = {});
 
 // Discover NVLINK topology from runtime environment.
-absl::StatusOr<NvlinkSnapshot> load_nvlink_runtime_probe(
-    NvlinkRuntimeProbeOptions options = {});
+absl::StatusOr<NvlinkSnapshot> load_nvlink_runtime_probe(NvlinkRuntimeProbeOptions options = {});
 
 } // namespace tensorcast::communicator::topology::discovery
 

--- a/core/communicator/topology/simple_numa_topology.cc
+++ b/core/communicator/topology/simple_numa_topology.cc
@@ -48,8 +48,7 @@ absl::StatusOr<Topology> BuildSwitchTopologyFromSimpleNuma(
     pools.push_back(Pool{cpu_pool_id(node.id()), cpu_pool_id(node.id()), PoolType::kCpu});
     for (int gpu_id : node.gpus()) {
       if (!seen_gpus.insert(gpu_id).second) {
-        return absl::InvalidArgumentError(
-            std::format("duplicate simple_numa gpu id: {}", gpu_id));
+        return absl::InvalidArgumentError(std::format("duplicate simple_numa gpu id: {}", gpu_id));
       }
       pools.push_back(Pool{gpu_pool_id(gpu_id), gpu_pool_id(gpu_id), PoolType::kGpu});
     }
@@ -62,12 +61,10 @@ absl::StatusOr<Topology> BuildSwitchTopologyFromSimpleNuma(
 
   for (const auto& node : simple.nodes()) {
     if (node.nics().empty()) {
-      return absl::InvalidArgumentError(
-          std::format("simple_numa node {} has no nics", node.id()));
+      return absl::InvalidArgumentError(std::format("simple_numa node {} has no nics", node.id()));
     }
     if (node.gpus().empty()) {
-      return absl::InvalidArgumentError(
-          std::format("simple_numa node {} has no gpus", node.id()));
+      return absl::InvalidArgumentError(std::format("simple_numa node {} has no gpus", node.id()));
     }
 
     absl::flat_hash_set<std::string> pool_ids_seen;
@@ -87,8 +84,7 @@ absl::StatusOr<Topology> BuildSwitchTopologyFromSimpleNuma(
 
     for (const auto& nic : node.nics()) {
       if (nic.empty()) {
-        return absl::InvalidArgumentError(
-            std::format("simple_numa node {} has empty nic name", node.id()));
+        return absl::InvalidArgumentError(std::format("simple_numa node {} has empty nic name", node.id()));
       }
       const std::string endpoint_id = std::format("nic_{}", nic);
       if (!seen_nics.insert(endpoint_id).second) {
@@ -119,8 +115,7 @@ absl::StatusOr<Topology> BuildSwitchTopologyFromSimpleNuma(
     return absl::InvalidArgumentError("simple_numa has no nics");
   }
   if (seen_nics.contains(options.switch_id)) {
-    return absl::InvalidArgumentError(
-        std::format("switch_id collides with nic endpoint id: {}", options.switch_id));
+    return absl::InvalidArgumentError(std::format("switch_id collides with nic endpoint id: {}", options.switch_id));
   }
 
   Endpoint switch_endpoint;
@@ -134,11 +129,7 @@ absl::StatusOr<Topology> BuildSwitchTopologyFromSimpleNuma(
   validation.require_endpoint_links = true;
   validation.require_connected = options.require_connected;
 
-  return Topology::Build(
-      std::move(pools),
-      std::move(endpoints),
-      std::move(links),
-      validation);
+  return Topology::Build(std::move(pools), std::move(endpoints), std::move(links), validation);
 }
 
 } // namespace tensorcast::communicator::topology

--- a/core/communicator/topology/simple_numa_topology_tool.cc
+++ b/core/communicator/topology/simple_numa_topology_tool.cc
@@ -25,8 +25,8 @@ int main(int argc, char** argv) {
 
   tensorcast::communicator::topology::Topology topology;
   if (cfg_or->topology_discovery().enable()) {
-    auto build_or = tensorcast::communicator::topology::discovery::build_topology_from_discovery_with_observability(
-        cfg_or.value());
+    auto build_or =
+        tensorcast::communicator::topology::discovery::build_topology_from_discovery_with_observability(cfg_or.value());
     if (!build_or.ok()) {
       std::cerr << "Failed to build topology: " << build_or.status().ToString() << "\n";
       return 1;

--- a/core/communicator/topology/topology.cc
+++ b/core/communicator/topology/topology.cc
@@ -217,8 +217,7 @@ absl::Status Topology::validate(ValidationOptions options) const {
 
     if (endpoint.kind == EndpointKind::kSwitch) {
       if (!endpoint.pool_ids.empty()) {
-        return absl::InvalidArgumentError(
-            std::format("switch endpoint must not bind to pool: {}", endpoint_id));
+        return absl::InvalidArgumentError(std::format("switch endpoint must not bind to pool: {}", endpoint_id));
       }
       continue;
     }
@@ -237,8 +236,7 @@ absl::Status Topology::validate(ValidationOptions options) const {
 
     for (const auto& pool_id : endpoint.pool_ids) {
       if (pool_id.empty()) {
-        return absl::InvalidArgumentError(
-            std::format("endpoint pool id must be non-empty: {}", endpoint_id));
+        return absl::InvalidArgumentError(std::format("endpoint pool id must be non-empty: {}", endpoint_id));
       }
       if (!seen_pool_ids.insert(pool_id).second) {
         return absl::InvalidArgumentError(
@@ -283,21 +281,18 @@ absl::Status Topology::validate(ValidationOptions options) const {
         break;
       case EndpointType::kUnspecified:
       default:
-        return absl::InvalidArgumentError(
-            std::format("client endpoint type unsupported: {}", endpoint_id));
+        return absl::InvalidArgumentError(std::format("client endpoint type unsupported: {}", endpoint_id));
     }
 
     if (require_cpu_pool && cpu_pool_count == 0) {
-      return absl::InvalidArgumentError(
-          std::format("client endpoint requires at least one CPU pool: {}", endpoint_id));
+      return absl::InvalidArgumentError(std::format("client endpoint requires at least one CPU pool: {}", endpoint_id));
     }
     if (forbid_cpu_pool && cpu_pool_count > 0) {
       return absl::InvalidArgumentError(
           std::format("client endpoint must not bind CPU pools: {} -> {}", endpoint_id, first_cpu_pool));
     }
     if (require_gpu_pool && gpu_pool_count == 0) {
-      return absl::InvalidArgumentError(
-          std::format("client endpoint requires at least one GPU pool: {}", endpoint_id));
+      return absl::InvalidArgumentError(std::format("client endpoint requires at least one GPU pool: {}", endpoint_id));
     }
     if (forbid_gpu_pool && gpu_pool_count > 0) {
       return absl::InvalidArgumentError(
@@ -346,13 +341,11 @@ absl::Status Topology::validate(ValidationOptions options) const {
 
     if (link.type == LinkType::kSwitch) {
       if (!(src_switch || dst_switch)) {
-        return absl::InvalidArgumentError(
-            std::format("SW link must include switch endpoint: {}", link_id));
+        return absl::InvalidArgumentError(std::format("SW link must include switch endpoint: {}", link_id));
       }
     } else {
       if (src_switch || dst_switch) {
-        return absl::InvalidArgumentError(
-            std::format("non-SW link cannot include switch endpoint: {}", link_id));
+        return absl::InvalidArgumentError(std::format("non-SW link cannot include switch endpoint: {}", link_id));
       }
     }
 
@@ -376,8 +369,7 @@ absl::Status Topology::validate(ValidationOptions options) const {
   if (options.require_endpoint_links) {
     for (const auto& [endpoint_id, degree] : link_degree) {
       if (degree == 0) {
-        return absl::InvalidArgumentError(
-            std::format("endpoint must have at least one link: {}", endpoint_id));
+        return absl::InvalidArgumentError(std::format("endpoint must have at least one link: {}", endpoint_id));
       }
     }
   }
@@ -425,10 +417,8 @@ std::string Topology::to_dot() const {
 
   for (const auto& [endpoint_id, endpoint] : endpoints_) {
     std::vector<std::string> label_lines;
-    label_lines.push_back(
-        escape_dot(endpoint.name.empty() ? endpoint_id : endpoint.name));
-    label_lines.push_back(
-        escape_dot(std::format("{} {}", to_string(endpoint.kind), to_string(endpoint.type))));
+    label_lines.push_back(escape_dot(endpoint.name.empty() ? endpoint_id : endpoint.name));
+    label_lines.push_back(escape_dot(std::format("{} {}", to_string(endpoint.kind), to_string(endpoint.type))));
     std::vector<std::string> cpu_pools;
     std::vector<std::string> gpu_pools;
     std::vector<std::string> other_pools;
@@ -457,26 +447,19 @@ std::string Topology::to_dot() const {
     }
 
     if (!cpu_pools.empty()) {
-      label_lines.push_back(
-          escape_dot(std::format("cpu_pools={}", join_ids(cpu_pools))));
+      label_lines.push_back(escape_dot(std::format("cpu_pools={}", join_ids(cpu_pools))));
     }
     if (!gpu_pools.empty()) {
-      label_lines.push_back(
-          escape_dot(std::format("gpu_pools={}", join_ids(gpu_pools))));
+      label_lines.push_back(escape_dot(std::format("gpu_pools={}", join_ids(gpu_pools))));
     }
     if (!other_pools.empty()) {
-      label_lines.push_back(
-          escape_dot(std::format("pools={}", join_ids(other_pools))));
+      label_lines.push_back(escape_dot(std::format("pools={}", join_ids(other_pools))));
     }
     if (endpoint.bandwidth_gbps > 0.0) {
-      label_lines.push_back(
-          escape_dot(std::format("bw={}Gbps", endpoint.bandwidth_gbps)));
+      label_lines.push_back(escape_dot(std::format("bw={}Gbps", endpoint.bandwidth_gbps)));
     }
     const std::string label = join_label_lines(label_lines);
-    output += std::format(
-        "  \"{}\" [label=\"{}\"];\n",
-        escape_dot(endpoint_id),
-        label);
+    output += std::format("  \"{}\" [label=\"{}\"];\n", escape_dot(endpoint_id), label);
   }
 
   for (const auto& [link_id, link] : links_) {
@@ -484,12 +467,10 @@ std::string Topology::to_dot() const {
     label_lines.push_back(escape_dot(link.name.empty() ? link_id : link.name));
     label_lines.push_back(escape_dot(std::format("{}", to_string(link.type))));
     if (link.bandwidth_gbps > 0.0) {
-      label_lines.push_back(
-          escape_dot(std::format("bw={}Gbps", link.bandwidth_gbps)));
+      label_lines.push_back(escape_dot(std::format("bw={}Gbps", link.bandwidth_gbps)));
     }
     if (link.latency_us > 0.0) {
-      label_lines.push_back(
-          escape_dot(std::format("lat={}us", link.latency_us)));
+      label_lines.push_back(escape_dot(std::format("lat={}us", link.latency_us)));
     }
     const std::string label = join_label_lines(label_lines);
     output += std::format(

--- a/core/communicator/topology/topology_test.cc
+++ b/core/communicator/topology/topology_test.cc
@@ -16,6 +16,7 @@
 
 namespace {
 
+using tensorcast::communicator::topology::BuildSwitchTopologyFromSimpleNuma;
 using tensorcast::communicator::topology::Endpoint;
 using tensorcast::communicator::topology::EndpointKind;
 using tensorcast::communicator::topology::EndpointType;
@@ -23,7 +24,6 @@ using tensorcast::communicator::topology::Link;
 using tensorcast::communicator::topology::LinkType;
 using tensorcast::communicator::topology::Pool;
 using tensorcast::communicator::topology::PoolType;
-using tensorcast::communicator::topology::BuildSwitchTopologyFromSimpleNuma;
 using tensorcast::communicator::topology::SimpleNumaTopologyOptions;
 using tensorcast::communicator::topology::Topology;
 using tensorcast::communicator::topology::ValidationOptions;
@@ -156,11 +156,7 @@ TEST_CASE("Topology rail-optimized 8-GPU/8-NIC/2-CPU NVLINK layout", "[communica
   options.require_endpoint_links = true;
   options.require_connected = false; // NVLINK and network fabrics are modeled as separate components.
 
-  auto topology_or = Topology::Build(
-      std::move(pools),
-      std::move(endpoints),
-      std::move(links),
-      options);
+  auto topology_or = Topology::Build(std::move(pools), std::move(endpoints), std::move(links), options);
   INFO(topology_or.status());
   REQUIRE(topology_or.ok());
   const Topology& topology = topology_or.value();
@@ -213,11 +209,7 @@ TEST_CASE("Topology no-rail 4-GPU/1-NIC/1-CPU layout", "[communicator][topology]
   options.require_endpoint_links = true;
   options.require_connected = true;
 
-  auto topology_or = Topology::Build(
-      std::move(pools),
-      std::move(endpoints),
-      std::move(links),
-      options);
+  auto topology_or = Topology::Build(std::move(pools), std::move(endpoints), std::move(links), options);
   INFO(topology_or.status());
   REQUIRE(topology_or.ok());
   const Topology& topology = topology_or.value();
@@ -265,19 +257,13 @@ TEST_CASE("Topology rejects switch links with mismatched endpoint types", "[comm
   options.require_endpoint_links = true;
   options.require_connected = true;
 
-  auto topology_or = Topology::Build(
-      std::move(pools),
-      std::move(endpoints),
-      std::move(links),
-      options);
+  auto topology_or = Topology::Build(std::move(pools), std::move(endpoints), std::move(links), options);
   INFO(topology_or.status());
   CHECK_FALSE(topology_or.ok());
-  CHECK(std::string(topology_or.status().message()).find("endpoint types must match") !=
-        std::string::npos);
+  CHECK(std::string(topology_or.status().message()).find("endpoint types must match") != std::string::npos);
 }
 
-TEST_CASE("Topology rejects forward and P2P links with mismatched endpoint types",
-          "[communicator][topology]") {
+TEST_CASE("Topology rejects forward and P2P links with mismatched endpoint types", "[communicator][topology]") {
   const auto build_mismatched_link = [](LinkType link_type) {
     std::vector<Pool> pools;
     pools.push_back(Pool{"cpu0", "cpu0", PoolType::kCpu});
@@ -314,19 +300,14 @@ TEST_CASE("Topology rejects forward and P2P links with mismatched endpoint types
     options.require_endpoint_links = true;
     options.require_connected = true;
 
-    return Topology::Build(
-        std::move(pools),
-        std::move(endpoints),
-        std::move(links),
-        options);
+    return Topology::Build(std::move(pools), std::move(endpoints), std::move(links), options);
   };
 
   for (LinkType link_type : {LinkType::kForward, LinkType::kP2P}) {
     auto topology_or = build_mismatched_link(link_type);
     INFO(topology_or.status());
     CHECK_FALSE(topology_or.ok());
-    CHECK(std::string(topology_or.status().message()).find("endpoint types must match") !=
-          std::string::npos);
+    CHECK(std::string(topology_or.status().message()).find("endpoint types must match") != std::string::npos);
   }
 }
 
@@ -359,11 +340,7 @@ TEST_CASE("Topology rejects disconnected graphs when required", "[communicator][
   options.require_endpoint_links = false;
   options.require_connected = true;
 
-  auto topology_or = Topology::Build(
-      std::move(pools),
-      std::move(endpoints),
-      std::move(links),
-      options);
+  auto topology_or = Topology::Build(std::move(pools), std::move(endpoints), std::move(links), options);
   INFO(topology_or.status());
   CHECK_FALSE(topology_or.ok());
   CHECK(std::string(topology_or.status().message()).find("disconnected") != std::string::npos);
@@ -387,8 +364,7 @@ TEST_CASE("SimpleNuma topology rejects duplicate node ids", "[communicator][topo
   auto topology_or = BuildSwitchTopologyFromSimpleNuma(config);
   INFO(topology_or.status());
   CHECK_FALSE(topology_or.ok());
-  CHECK(std::string(topology_or.status().message()).find("duplicate simple_numa node id") !=
-        std::string::npos);
+  CHECK(std::string(topology_or.status().message()).find("duplicate simple_numa node id") != std::string::npos);
 }
 
 TEST_CASE("SimpleNuma topology rejects duplicate gpu ids", "[communicator][topology]") {
@@ -410,8 +386,7 @@ TEST_CASE("SimpleNuma topology rejects duplicate gpu ids", "[communicator][topol
   auto topology_or = BuildSwitchTopologyFromSimpleNuma(config);
   INFO(topology_or.status());
   CHECK_FALSE(topology_or.ok());
-  CHECK(std::string(topology_or.status().message()).find("duplicate simple_numa gpu id") !=
-        std::string::npos);
+  CHECK(std::string(topology_or.status().message()).find("duplicate simple_numa gpu id") != std::string::npos);
 }
 
 TEST_CASE("SimpleNuma topology rejects nodes with empty NIC lists", "[communicator][topology]") {
@@ -445,6 +420,5 @@ TEST_CASE("SimpleNuma topology rejects switch_id collisions", "[communicator][to
   auto topology_or = BuildSwitchTopologyFromSimpleNuma(config, options);
   INFO(topology_or.status());
   CHECK_FALSE(topology_or.ok());
-  CHECK(std::string(topology_or.status().message()).find("switch_id collides") !=
-        std::string::npos);
+  CHECK(std::string(topology_or.status().message()).find("switch_id collides") != std::string::npos);
 }

--- a/core/communicator/transport/rdma_context.cc
+++ b/core/communicator/transport/rdma_context.cc
@@ -164,14 +164,15 @@ misc::result_t RdmaContext::ibv_init() {
         continue;
       }
 
-      scan_candidates.push_back(PortScanCandidate{
-          .dev_id = d,
-          .device = devices[d],
-          .device_name = device_name,
-          .port = port,
-          .port_attr = port_attr,
-          .best_gid_index = best_gid_index,
-      });
+      scan_candidates.push_back(
+          PortScanCandidate{
+              .dev_id = d,
+              .device = devices[d],
+              .device_name = device_name,
+              .port = port,
+              .port_attr = port_attr,
+              .best_gid_index = best_gid_index,
+          });
     }
 
     if (misc::SUCCESS != misc::wrap_ibv_close_device(context)) {
@@ -180,9 +181,7 @@ misc::result_t RdmaContext::ibv_init() {
   }
 
   std::sort(
-      scan_candidates.begin(),
-      scan_candidates.end(),
-      [](const PortScanCandidate& lhs, const PortScanCandidate& rhs) {
+      scan_candidates.begin(), scan_candidates.end(), [](const PortScanCandidate& lhs, const PortScanCandidate& rhs) {
         if (lhs.device_name != rhs.device_name) {
           return lhs.device_name < rhs.device_name;
         }
@@ -206,17 +205,15 @@ misc::result_t RdmaContext::ibv_init() {
     struct ibv_port_attr port_attr{};
     std::memset(&port_attr, 0, sizeof(port_attr));
     if (misc::SUCCESS != misc::wrap_ibv_query_port(context, candidate.port, &port_attr)) {
-      LOG(WARNING) << "unable to re-query port attr " << candidate.device_name
-                   << " port=" << candidate.port;
+      LOG(WARNING) << "unable to re-query port attr " << candidate.device_name << " port=" << candidate.port;
       if (misc::SUCCESS != misc::wrap_ibv_close_device(context)) {
         return misc::INTERNAL_ERROR;
       }
       continue;
     }
     if (!is_port_usable(port_attr)) {
-      LOG(INFO) << "skip unstable RDMA port after recheck: dev=" << candidate.device_name
-                << " port=" << candidate.port << " state=" << port_attr.state
-                << " link_layer=" << static_cast<int>(port_attr.link_layer);
+      LOG(INFO) << "skip unstable RDMA port after recheck: dev=" << candidate.device_name << " port=" << candidate.port
+                << " state=" << port_attr.state << " link_layer=" << static_cast<int>(port_attr.link_layer);
       if (misc::SUCCESS != misc::wrap_ibv_close_device(context)) {
         return misc::INTERNAL_ERROR;
       }
@@ -225,8 +222,8 @@ misc::result_t RdmaContext::ibv_init() {
 
     auto dev = std::make_shared<NetDev>(context, candidate.dev_id, candidate.device, candidate.port, port_attr);
     if (dev->get_best_gid_index() <= 0) {
-      LOG(INFO) << "skip RDMA candidate due to missing usable GID after recheck: dev="
-                << candidate.device_name << " port=" << candidate.port;
+      LOG(INFO) << "skip RDMA candidate due to missing usable GID after recheck: dev=" << candidate.device_name
+                << " port=" << candidate.port;
       if (misc::SUCCESS != misc::wrap_ibv_close_device(context)) {
         return misc::INTERNAL_ERROR;
       }
@@ -241,21 +238,18 @@ misc::result_t RdmaContext::ibv_init() {
     return misc::INTERNAL_ERROR;
   }
 
-  std::sort(
-      devs_.begin(),
-      devs_.end(),
-      [](const net_dev_t& lhs, const net_dev_t& rhs) {
-        if (lhs->get_rail_id() != rhs->get_rail_id()) {
-          return lhs->get_rail_id() < rhs->get_rail_id();
-        }
-        if (lhs->get_name() != rhs->get_name()) {
-          return lhs->get_name() < rhs->get_name();
-        }
-        if (lhs->get_port() != rhs->get_port()) {
-          return lhs->get_port() < rhs->get_port();
-        }
-        return lhs->get_dev_id() < rhs->get_dev_id();
-      });
+  std::sort(devs_.begin(), devs_.end(), [](const net_dev_t& lhs, const net_dev_t& rhs) {
+    if (lhs->get_rail_id() != rhs->get_rail_id()) {
+      return lhs->get_rail_id() < rhs->get_rail_id();
+    }
+    if (lhs->get_name() != rhs->get_name()) {
+      return lhs->get_name() < rhs->get_name();
+    }
+    if (lhs->get_port() != rhs->get_port()) {
+      return lhs->get_port() < rhs->get_port();
+    }
+    return lhs->get_dev_id() < rhs->get_dev_id();
+  });
 
   for (const auto& dev : devs_) {
     auto it = rail_devs_.find(dev->get_rail_id());
@@ -270,9 +264,8 @@ misc::result_t RdmaContext::ibv_init() {
       continue;
     }
     const bool is_primary = rail_it->second == dev;
-    LOG(INFO) << "RDMA rail device registered: dev=" << dev->get_name()
-              << " port=" << dev->get_port() << " rail_id=" << dev->get_rail_id()
-              << " role=" << (is_primary ? "primary" : "backup");
+    LOG(INFO) << "RDMA rail device registered: dev=" << dev->get_name() << " port=" << dev->get_port()
+              << " rail_id=" << dev->get_rail_id() << " role=" << (is_primary ? "primary" : "backup");
   }
 
   for (auto dev : devs_) {
@@ -432,8 +425,7 @@ net_dev_t RdmaContext::get_best_dev(int gpu_id) {
                    << " after affinity scan; max_prefix_candidates is empty";
       return nullptr;
     }
-    const int fallback_idx =
-        max_prefix_candidates[static_cast<size_t>(gpu_id) % max_prefix_candidates.size()];
+    const int fallback_idx = max_prefix_candidates[static_cast<size_t>(gpu_id) % max_prefix_candidates.size()];
     LOG(WARNING) << "No RDMA candidate satisfies max GID + max PCI-prefix jointly for gpu_id=" << gpu_id
                  << "; fallback to max-prefix candidate dev=" << devs_[fallback_idx]->get_name();
     dev_vector_[gpu_id] = devs_[fallback_idx];

--- a/core/communicator/transport/request.cc
+++ b/core/communicator/transport/request.cc
@@ -20,8 +20,8 @@ bool is_truthy_env_value(const char* value) {
   if (value == nullptr) {
     return false;
   }
-  return std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 || std::strcmp(value, "TRUE") == 0
-      || std::strcmp(value, "True") == 0 || std::strcmp(value, "on") == 0 || std::strcmp(value, "ON") == 0;
+  return std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 || std::strcmp(value, "TRUE") == 0 ||
+      std::strcmp(value, "True") == 0 || std::strcmp(value, "on") == 0 || std::strcmp(value, "ON") == 0;
 }
 
 std::atomic<bool>& rdma_profile_enabled_flag() {
@@ -242,8 +242,7 @@ void ReadRequest::notify_completion(const absl::Status& status) {
 
 uint64_t ReadRequest::elapsed_since_create_us() const {
   const auto now = std::chrono::steady_clock::now();
-  return static_cast<uint64_t>(
-      std::chrono::duration_cast<std::chrono::microseconds>(now - created_at_).count());
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(now - created_at_).count());
 }
 
 void ReadRequest::finalize_rdma_profile_status() {

--- a/core/store/components/endpoint_id.cc
+++ b/core/store/components/endpoint_id.cc
@@ -8,17 +8,12 @@
 
 namespace tensorcast::store::components {
 
-std::string derive_endpoint_id(
-    std::string_view node_id,
-    common::memory::MemoryLocation memory_type,
-    int device_id) {
+std::string derive_endpoint_id(std::string_view node_id, common::memory::MemoryLocation memory_type, int device_id) {
   if (node_id.empty()) {
     return {};
   }
-  const std::string_view dev_type =
-      memory_type == common::memory::MemoryLocation::GPU ? "gpu" : "cpu";
-  const int endpoint_dev_id =
-      memory_type == common::memory::MemoryLocation::GPU ? std::max(0, device_id) : 0;
+  const std::string_view dev_type = memory_type == common::memory::MemoryLocation::GPU ? "gpu" : "cpu";
+  const int endpoint_dev_id = memory_type == common::memory::MemoryLocation::GPU ? std::max(0, device_id) : 0;
   return absl::StrCat(node_id, "/dev/", dev_type, "/", endpoint_dev_id);
 }
 

--- a/core/store/components/endpoint_id.h
+++ b/core/store/components/endpoint_id.h
@@ -12,10 +12,7 @@
 namespace tensorcast::store::components {
 
 // Canonical endpoint id format: "<node_id>/dev/<gpu|cpu>/<dev_id>".
-std::string derive_endpoint_id(
-    std::string_view node_id,
-    common::memory::MemoryLocation memory_type,
-    int device_id);
+std::string derive_endpoint_id(std::string_view node_id, common::memory::MemoryLocation memory_type, int device_id);
 
 std::string derive_endpoint_id(const WorkerIdentity& local_identity, const DeviceKey& device);
 

--- a/core/store/materialization/dataplane/runtime/streaming_buffer_adapter.cc
+++ b/core/store/materialization/dataplane/runtime/streaming_buffer_adapter.cc
@@ -41,8 +41,8 @@ void StreamingBufferAdapter::return_chunk(int slot_id) {
     VLOG(1) << "Recovered producer-owned slot via abort_producer_slot slot=" << slot_id;
     return;
   }
-  LOG(ERROR) << "Failed to release slot after return_chunk fallback slot=" << slot_id
-             << " return_status=" << status << " abort_status=" << abort_status;
+  LOG(ERROR) << "Failed to release slot after return_chunk fallback slot=" << slot_id << " return_status=" << status
+             << " abort_status=" << abort_status;
 }
 
 absl::Status StreamingBufferAdapter::mark_chunk_ready(int slot_id, uint64_t global_chunk_idx, size_t valid_bytes) {

--- a/core/store/materialization/dataplane/sources/tests/remote_key_source_routing_fallback_test.cc
+++ b/core/store/materialization/dataplane/sources/tests/remote_key_source_routing_fallback_test.cc
@@ -89,7 +89,10 @@ std::shared_ptr<Communicator> make_engine_on_port(int port) {
   return engine;
 }
 
-void register_cpu_tensor(const std::shared_ptr<Communicator>& engine, const std::string& key, std::vector<uint8_t>& src) {
+void register_cpu_tensor(
+    const std::shared_ptr<Communicator>& engine,
+    const std::string& key,
+    std::vector<uint8_t>& src) {
   Communicator::RegisterTensorOptions reg_opts;
   reg_opts.register_mr = false;
   reg_opts.needs_staging = false;
@@ -209,9 +212,7 @@ TEST_CASE("RemoteKeySource falls back to direct reads when routed lookup fails",
   REQUIRE(received == payload);
 }
 
-TEST_CASE(
-    "RemoteKeySource keeps strict direct fallback after routed failure",
-    "[store][p2p][routing]") {
+TEST_CASE("RemoteKeySource keeps strict direct fallback after routed failure", "[store][p2p][routing]") {
   constexpr std::size_t kArtifactBytes = 512 * 1024;
   const std::string tensor_key = "remote_key_source_strict_fallback_tensor";
   const std::string local_endpoint = "node_local/dev/cpu/0";

--- a/docs/benchmarks/20260316-communicator-vs-transfer-engine-comparison.md
+++ b/docs/benchmarks/20260316-communicator-vs-transfer-engine-comparison.md
@@ -9,8 +9,12 @@ This document defines a chart set that makes TensorCast communicator and
 Mooncake Transfer Engine performance easy to compare without hiding the
 remaining caveats.
 
-`2026-03-22` 起，`0105` 的主目标从“仅看带宽差距”调整为“量化任务过程中的非数据传输代价”。
-因此本页中的 `GB/s` 图表用于定位趋势，不再单独作为根因结论；根因分析需结合 communicator bench 新增的 amortizable/recurring profiling 字段。
+Starting on `2026-03-22`, the primary objective of `0105` changed from
+"bandwidth-gap-only comparison" to "quantifying non-transfer cost during
+task execution." Therefore, the `GB/s` charts on this page are used to locate
+trends and are no longer treated as standalone root-cause conclusions.
+Root-cause analysis must combine the new amortizable/recurring profiling fields
+from communicator bench.
 
 The output is intentionally split into:
 

--- a/docs/designs/0058-communicator-topology-model.md
+++ b/docs/designs/0058-communicator-topology-model.md
@@ -19,33 +19,44 @@ related_code:
 
 # Summary
 
-建立一套可组合、可搜索的通信拓扑模型，把“可达性”与“执行路径”解耦：
+Define a composable and searchable communication topology model that decouples
+"reachability" from "execution path":
 
-- 以 **Pool / Endpoint / Link** 结构化表达拓扑图。
-- 以 **Connection** 封装真实通信实现（RDMA/TCP/SHM 等）。
-- 以 **Channel / Communicator** 管理多跳路径、多路径并行与策略选择。
-- 引入 **Switch Endpoint / SW Link**，把交换结构压缩为可搜索的图结构，避免端到端组合爆炸。
+- use **Pool / Endpoint / Link** to express topology as a graph
+- use **Connection** to wrap executable transports (RDMA/TCP/SHM, etc.)
+- use **Channel / Communicator** to manage multi-hop paths, multipath parallelism,
+  and policy selection
+- introduce **Switch Endpoint / SW Link** to compress switching structures into a
+  searchable graph and avoid end-to-end combination explosion
 
-该模型为后续的 **multipath、拓扑选路、故障切换** 提供统一的数据结构与统计入口，并可在不重写现有传输层的前提下演进。
+This model provides a unified data structure and statistics entry point for
+future **multipath routing, topology-aware routing, and failover**, while
+allowing incremental adoption without rewriting the existing transport stack.
 
 # Goals / Non-Goals
 
 ## Goals
 
-- 明确表达“资源域 + 设备端点 + 链路”的拓扑关系，并可被路径搜索直接消费。
-- 用 Switch Endpoint / SW Link 把交换结构压缩进图模型，避免枚举式组合爆炸。
-- 在 Communicator 内引入“多路径 + 多跳”的抽象，支持基于统计的路径选择与故障切换。
-- 兼容现有 Communicator 传输实现与配置模型，允许渐进式迁移。
+- Represent topology relations as "resource domain + device endpoint + link" and
+  make them directly consumable by path search.
+- Compress switching structures into the graph via Switch Endpoint / SW Link
+  instead of pre-enumerating combinations.
+- Introduce "multipath + multi-hop" abstractions inside Communicator, with
+  stats-aware path selection and failover.
+- Stay compatible with existing Communicator transports and config model, and
+  support incremental migration.
 
 ## Non-Goals
 
-- 重写 RDMA/TCP/MTCP 传输实现或复制引擎。
-- 改变 P2P 选源策略（Global Store 的 replica 选择策略不在本设计范围）。
-- 在首版就实现跨节点的全局最优路由（首版以局部图、局部策略为主）。
+- Rewriting RDMA/TCP/MTCP transport implementations or copy engines.
+- Changing P2P source-selection policy (Global Store replica selection is out
+  of scope for this design).
+- Delivering global optimal cross-node routing in v1 (v1 focuses on local
+  graphs and local policies).
 
 # Architecture & Interfaces
 
-## 分层结构
+## Layered Model
 
 ```mermaid
 flowchart TB
@@ -54,130 +65,173 @@ flowchart TB
   Link --> Connection[Connection]
   Connection --> Channel[Channel]
   Channel --> Communicator[Communicator]
-  Switch["Switch Endpoint"] --- Link
+  Switch[Switch Endpoint] --- Link
 ```
 
-- **Topology 表达层**：`Pool / Endpoint / Link` 表达可达性与结构。
-- **执行层**：`Connection` 封装真实传输（RDMA/TCP/SHM 等）。
-- **调度复用层**：`Channel / Communicator` 管理多跳路径与策略选择。
+- **Topology expression layer**: `Pool / Endpoint / Link` represent structure
+  and reachability.
+- **Execution layer**: `Connection` wraps executable transport objects
+  (RDMA/TCP/SHM, etc.).
+- **Scheduling and reuse layer**: `Channel / Communicator` manage multi-hop
+  paths and policy selection.
 
-## Phase 2 包装层细化
+## Phase 2 Wrapper Refinement
 
-Phase 2 在不改动现有数据面行为的前提下，引入 routing 包装层把 Topology 映射到现有通信实现：
+Phase 2 introduces a routing wrapper layer that maps Topology to existing
+communication execution without changing current data-plane behavior:
 
-- **RoutingContext**：持有 `Topology` 与 `EndpointBinding`（node id / IP / port / device ids），生成 src→dst 的路由 Communicator。
-- **RouteChannel**：表达一条路径（Phase 2 仅支持 direct 1-hop；多 hop 返回 `UNIMPLEMENTED`）。
-- **ConnectionAdapter**：封装执行层适配；`EngineAdapter` 复用 `engine::Communicator`，`NvlinkAdapter` 作为占位实现。
-- **Stats/Health**：`ConnectionStats` / `LinkStats` 记录成功/失败/时延/最后错误，并派生 `HealthState` 供后续路由。
+- **RoutingContext**: holds `Topology` and `EndpointBinding`
+  (`node_id / ip / port / device_ids`) and builds routed communicators for
+  `src -> dst`.
+- **RouteChannel**: represents one route path (Phase 2 supports direct 1-hop
+  only; multi-hop returns `UNIMPLEMENTED`).
+- **ConnectionAdapter**: execution adapter wrapper; `EngineAdapter` reuses
+  `engine::Communicator`, and `NvlinkAdapter` is a placeholder implementation.
+- **Stats/Health**: `ConnectionStats` / `LinkStats` track success/failure/
+  latency/last_error and derive `HealthState` for later routing decisions.
 
-NVLINK 选择规则：同节点 + NVLINK endpoints + adapter available → NVLINK，否则回退到 `AUTO`（engine 路径）。该包装层尚未接入 P2P 读路径，Phase 4 统一接入。
+NVLINK selection rule: same-node + NVLINK endpoints + available adapter implies
+NVLINK path; otherwise fall back to `AUTO` (engine path). This wrapper is not
+yet wired into the P2P read path and will be integrated in Phase 4.
 
-## 对象模型（字段语义）
+## Object Model (Field Semantics)
 
-### Pool（资源域）
-- 作用：描述资源归属与上下文（CPU/GPU/NUMA 等），为端点提供亲和与策略边界。
-- 关键字段：
-  - `type`：CPU / GPU
+### Pool (Resource Domain)
+
+- Role: describes resource ownership and context (CPU/GPU/NUMA), and provides
+  affinity and policy boundaries for endpoints.
+- Key fields:
+  - `type`: CPU / GPU
   - `uuid`
   - `endpoint_list`
 
-### Endpoint（传输端点）
-- 作用：通信单边实体；承载设备能力与拓扑属性。
-- 类型：
-  - **Client Endpoint**：真实设备端点（NIC/PCIe/NVLink）。
-  - **Switch Endpoint**：仅用于路径搜索的抽象交换节点。
-- 关键字段：
-  - `type`：NIC / PCIE / NVLINK + Client 或 Switch
-  - `pool_ids`
-    - NIC/PCIE：至少包含一个 CPU pool + 一个 GPU pool
-    - NVLINK：仅包含 GPU pools（CPU pool 为空）
-    - Switch：不绑定任何 pool
-  - `name` / `uuid`
-  - `bw`（用于路径打分与 striping 权重）
-  - `communicators_map`：`{ dst: [communicator_list] }`
-  - `link_list`：从该端点出发的 Link
-  - （可选）`buffer_manager` / `channel_list`
+### Endpoint (Transfer Endpoint)
 
-### Link（拓扑边）
-- 作用：拓扑图上的“可达性边”；服务于路径搜索，而非直接等同真实连接。
-- 关键字段：
+- Role: one-side communication entity carrying device capability and topology
+  attributes.
+- Types:
+  - **Client Endpoint**: concrete device endpoint (NIC/PCIe/NVLink).
+  - **Switch Endpoint**: abstract switch node used only by path search.
+- Key fields:
+  - `type`: NIC / PCIE / NVLINK + Client or Switch
+  - `pool_ids`
+    - NIC/PCIE: at least one CPU pool + one GPU pool
+    - NVLINK: GPU pools only (empty CPU pool)
+    - Switch: no pool binding
+  - `name` / `uuid`
+  - `bw` (path scoring and striping weight)
+  - `communicators_map`: `{ dst: [communicator_list] }`
+  - `link_list`: outgoing links from this endpoint
+  - (optional) `buffer_manager` / `channel_list`
+
+### Link (Topology Edge)
+
+- Role: reachability edge in the topology graph; used by path search and not
+  equivalent to a concrete connection object.
+- Key fields:
   - `name` / `uuid`
   - `bw` / `latency`
   - `src_endpoint` / `dst_endpoint`
-  - `type`：`FORWARD / P2P / SW`
-  - `connections`：`{ dst: { proto: connection } }`
+  - `type`: `FORWARD / P2P / SW`
+  - `connections`: `{ dst: { proto: connection } }`
 
-### Connection（真实连接封装）
-- 作用：可执行的通信通道封装（协议 + 端点 + 实现对象）。
-- 关键字段：
-  - `type`：`POOL_FWD / P2P / SW`
-  - `proto`：SHM / RDMA / TCP / ...
+### Connection (Executable Connection Wrapper)
+
+- Role: executable communication wrapper (protocol + endpoints + implementation
+  object).
+- Key fields:
+  - `type`: `POOL_FWD / P2P / SW`
+  - `proto`: SHM / RDMA / TCP / ...
   - `src_endpoint` / `dst_endpoint`
-  - `link_list`：多跳时的实际 Link 列表
-  - `comm_method`：具体通信实现对象（QP / socket / ring）
-  - `mct_map`：`{ msg_size: mct }`
+  - `link_list`: concrete link list for multi-hop
+  - `comm_method`: concrete implementation object (QP / socket / ring)
+  - `mct_map`: `{ msg_size: mct }`
 
-### Channel（路径）
-- 作用：从 src 到 dst 的一条具体路径（多跳 Connection 序列）。
-- 关键字段：
+### Channel (Path)
+
+- Role: one concrete path from source to destination (a sequence of Connection
+  hops).
+- Key fields:
   - `uuid`
   - `src_endpoint` / `dst_endpoint`
-  - `hop_list`：`[connection0, connection1, ...]`
+  - `hop_list`: `[connection0, connection1, ...]`
 
-### Communicator（点到点聚合）
-- 作用：一个 src ↔ dst 对之间的通信能力聚合，管理多条 Channel。
-- 关键字段：
+### Communicator (Point-to-Point Aggregation)
+
+- Role: communication-capability aggregation for one `src <-> dst` pair,
+  managing multiple channels.
+- Key fields:
   - `uuid`
   - `src_endpoint` / `dst_endpoint`
   - `channel_list`
-  - `mct_map`：`{ channel: { msg_size: mct } }`
+  - `mct_map`: `{ channel: { msg_size: mct } }`
 
-## Switch Endpoint / SW Link 的作用
+## Why Switch Endpoint / SW Link
 
-交换结构（PCIe switch、NVSwitch、网络交换机、bond/team 等）会导致端到端路径组合爆炸。引入 Switch Endpoint / SW Link 后：
+Switching structures (PCIe switch, NVSwitch, network switch, bond/team, etc.)
+otherwise trigger end-to-end path explosion. With Switch Endpoint / SW Link:
 
-- 拓扑以图形式表达，路径搜索在图上进行。
-- Link 代表可达性与属性，不再提前枚举所有端到端组合。
-- SW Link 下可挂多个 Connection，用于表达“同一拓扑边的多种实现”。
+- topology is represented as a graph and searched directly
+- links represent reachability and attributes without pre-enumerating all
+  endpoint pairs
+- one SW link can host multiple connections to represent multiple
+  implementations on the same topology edge
 
-# Multipath / Topology Routing / Failover 支撑
+# Multipath / Topology Routing / Failover Support
 
-该模型原生支持后续 TODO：
+This model natively supports future work:
 
-1. **Multipath**：Communicator 管理多条 Channel，可基于 `mct_map` 做 striping 和权重选择。
-2. **拓扑选路**：路径搜索可用 BW/latency/拥塞/失败率等作为代价函数，支持 k-shortest 或多约束搜索。
-3. **故障切换**：Link/Connection 健康状态变化时，路径搜索可回避故障边，并在 Communicator 中切换 Channel。
-4. **统计闭环**：`mct_map` 作为 per-connection / per-channel 成本缓存，配合 runtime 统计形成自适应路由。
+1. **Multipath**: Communicator manages multiple channels and can perform
+   striping and weighted selection via `mct_map`.
+2. **Topology-aware routing**: path search can use BW/latency/congestion/failure
+   rate as cost functions (k-shortest or constrained search).
+3. **Failover**: path search can avoid degraded edges and switch channels when
+   link/connection health changes.
+4. **Stats feedback loop**: `mct_map` acts as per-connection/per-channel cost
+   cache and can be combined with runtime stats for adaptive routing.
 
 # Error Model & Invariants
 
-- 图必须是可连通的（src/dst 至少存在一条可达路径）。
-- Switch Endpoint 只参与路径搜索，不直接承载传输对象。
-- Connection 的生命周期与底层传输对象一致，连接不可用应及时从路径候选集中剔除。
-- 路由选择失败必须降级：回退到单路径或现有默认直连策略。
+- The graph must remain connected (at least one reachable path for each
+  `src/dst` pair).
+- Switch Endpoint participates in path search only and does not carry transfer
+  objects directly.
+- Connection lifecycle must stay aligned with underlying transport object
+  lifecycle; unavailable connections must be removed from candidate paths in
+  time.
+- Routing selection failure must degrade safely to single path or existing
+  default direct-connection policy.
 
 # Schema Changes (if any)
 
-无。
+None.
 
 # Naming Compliance
 
-- 类/结构体（PascalCase）：`Pool`、`Endpoint`、`Link`、`Connection`、`Channel`、`Communicator`。
-- 函数/方法（snake_case）：`build_topology`、`find_channels`、`select_channel`、`update_mct`。
-- 常量/枚举（ALL_CAPS）：`SW_LINK`、`P2P_LINK`、`FORWARD_LINK`。
+- Classes/structs (PascalCase): `Pool`, `Endpoint`, `Link`, `Connection`,
+  `Channel`, `Communicator`.
+- Functions/methods (snake_case): `build_topology`, `find_channels`,
+  `select_channel`, `update_mct`.
+- Constants/enums (ALL_CAPS): `SW_LINK`, `P2P_LINK`, `FORWARD_LINK`.
 
 # Trade-offs & Risks
 
-- **复杂度增加**：引入拓扑图与路径搜索，需要严格的可视化与可观测性支撑。
-- **配置负担**：需要新的拓扑配置结构，必须提供兼容映射与默认生成策略。
-- **运行时开销**：路径搜索与统计更新需要边界控制（缓存、周期更新）。
+- **Higher complexity**: adding graph modeling and path search requires strong
+  observability and visualization support.
+- **Configuration overhead**: a new topology config structure is required and
+  must provide compatibility mapping and default generation.
+- **Runtime overhead**: path search and stats updates require bounded control
+  (cache and periodic refresh).
 
 # Compatibility & Acceptance Criteria
 
-- 现有 `Communicator::read_tensor` 等调用保持可用，默认行为不退化。
-- 新拓扑模型可在单机和多机环境下建立可达路径并找到至少一条 Channel。
-- 在模拟故障（断链、握手失败）下，路径可自动切换且不导致全局崩溃。
-- 统计数据可持续更新，并在路径选择中可见生效。
+- Existing calls such as `Communicator::read_tensor` remain available, with no
+  default behavior regression.
+- The new topology model can build reachable paths on both single-host and
+  multi-host environments and find at least one channel.
+- Under simulated failures (link down, handshake failure), route switching
+  works without global crash.
+- Stats continue to update and are visibly consumed by path selection.
 
 # References
 

--- a/docs/designs/0059-host-topology-discovery-lldp-nvlink.md
+++ b/docs/designs/0059-host-topology-discovery-lldp-nvlink.md
@@ -24,29 +24,42 @@ related_code:
 
 # Summary
 
-当前拓扑建模仍主要依赖显式输入（`simple_numa` 或手工构造），LLDP 信息仅在 `NetDev::read_rail_id()` 中作为 RDMA rail 选择的局部输入使用，未进入统一拓扑模型。NVLINK 也尚未形成可配置、可测试、可合并的数据来源。
+Current topology modeling still relies mostly on explicit inputs (`simple_numa`
+or manual construction). LLDP is only used as a local input in
+`NetDev::read_rail_id()` for RDMA rail selection and is not part of the
+unified topology model. NVLINK also does not yet provide a configurable,
+testable, and mergeable source.
 
-本设计定义一条主机内拓扑发现与建模流水线：
+This design defines a host-local topology discovery and modeling pipeline:
 
-- 从 LLDP 文件读取 NIC rail 与 PCI 信息。
-- 从 NVLINK 数据源读取 GPU 间链路信息。
-- 按统一规则合并，生成当前机器的 `Topology`（`Pool / Endpoint / Link`）与配套绑定信息。
-- 保持兼容：发现失败时可回退到现有行为，不阻断当前读路径。
+- read NIC rail and PCI information from LLDP input
+- read GPU interconnect information from NVLINK input
+- merge both sources under deterministic rules to generate the host `Topology`
+  (`Pool / Endpoint / Link`) and binding metadata
+- preserve compatibility: discovery failures degrade to existing behavior and do
+  not block the current read path
 
 # Goals / Non-Goals
 
 ## Goals
 
-- 把 LLDP 与 NVLINK 纳入统一的 host-topology 数据面，而非零散逻辑。
-- 引入可配置的数据源与严格/宽松校验策略，遵循统一运行时配置原则（禁止新增 ad-hoc env 作为主路径）。
-- 产出确定性的拓扑对象，支持 DOT 导出、单测校验、后续路由策略消费。
-- 明确降级路径：LLDP 缺失、NVLINK 不可用、部分字段冲突时都有可预期行为。
+- Bring LLDP and NVLINK into one unified host-topology data plane instead of
+  scattered logic.
+- Introduce configurable data sources and strict/relaxed validation policies,
+  following unified runtime config principles (no new ad-hoc env vars on the
+  main path).
+- Produce deterministic topology objects that support DOT export, unit testing,
+  and downstream routing consumption.
+- Define clear degradation behavior for LLDP missing, NVLINK unavailable, and
+  partial field conflicts.
 
 ## Non-Goals
 
-- 首版不做跨机器全局拓扑发现与全局最优路由。
-- 首版不要求完成多跳路由（`RoutingContext` 当前 direct 1-hop 限制保持不变）。
-- 首版不移除历史 `TENSORCAST_LLDP_FILE_NAME` 行为，只做兼容并规划弃用。
+- v1 does not implement cluster-wide topology discovery or global optimal
+  routing across nodes.
+- v1 does not require multi-hop routing (`RoutingContext` remains direct 1-hop).
+- v1 does not remove the legacy `TENSORCAST_LLDP_FILE_NAME` behavior; it keeps
+  compatibility and plans deprecation separately.
 
 # Architecture & Interfaces
 
@@ -69,99 +82,121 @@ flowchart LR
 
 ## Source 1: LLDP Rail Snapshot
 
-输入文件沿用当前容器提供格式（示例）：
+The input file follows the current container-provided format (example):
 
 ```text
 brainpf0=0000:0e:00.0,mlx5_0,1
 brainvf0=0000:0e:00.1,mlx5_9,1
 ```
 
-解析规则：
+Parsing rules:
 
-- 忽略空行与 `#` 注释行。
-- 每行格式为 `<if_name>=<pci_bdf>,<nic_name>,<rail_id>`。
-- `rail_id` 解析为正整数；非法值按策略处理（fail 或 warn+skip）。
-- 主键以 `nic_name`（如 `mlx5_0`）为准，`if_name` 作为附属标签。
+- ignore empty lines and `#` comment lines
+- each line format is `<if_name>=<pci_bdf>,<nic_name>,<rail_id>`
+- parse `rail_id` as a positive integer; invalid values follow policy
+  (fail or warn+skip)
+- use `nic_name` (for example `mlx5_0`) as the primary key, and keep `if_name`
+  as a secondary label
 
-输出结构（概念）：
+Output shape (conceptual):
 
 - `LldpNicRecord { if_name, pci_bdf, nic_name, rail_id }`
 
 ## Source 2: NVLINK Topology
 
-定义统一抽象接口，首版支持两类来源：
+Define a unified abstraction with two v1 source modes:
 
-- `snapshot_file`：离线快照文件（开发机和 CI 友好，便于可重复测试）。
-- `runtime_probe`：运行时探测（当前实现基于 `nvidia-smi --query-gpu=index,uuid` 与 `nvidia-smi topo -m`，后续可演进为 NVML 或同等接口）。
+- `snapshot_file`: offline snapshot input (developer and CI friendly,
+  reproducible)
+- `runtime_probe`: runtime probing (current implementation based on
+  `nvidia-smi --query-gpu=index,uuid` and `nvidia-smi topo -m`, with a future
+  path to NVML or equivalent APIs)
 
-输出结构（概念）：
+Output shape (conceptual):
 
 - `NvlinkGpuRecord { gpu_uuid, gpu_index }`
 - `NvlinkEdge { src_gpu_uuid, dst_gpu_uuid, link_count, bandwidth_hint_gbps }`
 
 ## Baseline Host Inventory
 
-首版采用“配置优先，发现补充”：
+v1 uses a "config-first, discovery-augmented" model:
 
-- CPU/GPU/NIC 基线由 `simple_numa`（已存在）或后续 host inventory provider 提供。
-- LLDP 负责 NIC rail 与 PCI 标签补强。
-- NVLINK 负责 GPU-GPU 互联关系补强。
+- CPU/GPU/NIC baseline comes from existing `simple_numa` or a future host
+  inventory provider
+- LLDP enriches NIC rail and PCI labels
+- NVLINK enriches GPU-to-GPU interconnect relations
 
-这样可以避免仅靠 LLDP（没有 GPU 信息）无法完成完整拓扑的问题。
+This avoids the LLDP-only limitation (LLDP alone does not contain GPU
+information and cannot produce a complete topology).
 
 ## Canonical Merge Model
 
-新增中间模型（概念）：
+Introduce conceptual intermediate models:
 
 - `HostDiscoverySnapshot`
 - `HostTopologyMergeInput`
 - `HostTopologyMergeResult`
 
-合并原则（确定性）：
+Merge rules (deterministic):
 
-1. 先建立 CPU/GPU pool 与 NIC endpoint 基线。
-2. 用 LLDP 结果为 NIC endpoint 绑定 `rail_id`、`pci_bdf`、`if_name` 标签。
-3. 执行 NIC↔GPU 亲和性推断：按 PCI 拓扑最短“距离”（最长公共 PCI 路径前缀）缩小 NIC 的 GPU pool 集合。
-4. 基于 rail 生成网络 switch 端点（`netsw_rail_<id>`）并建立 `SW` 链路。
-5. 为每个 GPU 生成 NVLINK endpoint（`nvlink_<gpu_uuid>`），按 `NvlinkEdge` 生成 `P2P` 链路。
-6. 最终生成可验证的 `Topology`；如果网络图与 NVLINK 图不连通，允许 `require_connected=false`。
+1. Build baseline CPU/GPU pools and NIC endpoints first.
+2. Attach LLDP labels (`rail_id`, `pci_bdf`, `if_name`) to NIC endpoints.
+3. Run NIC<->GPU affinity inference: narrow NIC GPU pool candidates using PCI
+   topology distance (longest common PCI-path prefix).
+4. Create network switch endpoints by rail (`netsw_rail_<id>`) and generate `SW`
+   links.
+5. Create NVLINK endpoints per GPU (`nvlink_<gpu_uuid>`) and generate `P2P`
+   links from `NvlinkEdge`.
+6. Emit a validated `Topology`; allow `require_connected=false` when network and
+   NVLINK graphs are not fully connected.
 
 ## NIC-GPU Affinity Inference
 
-推断目标：在不改变 `simple_numa` 基线 CPU 归属的前提下，让每个 NIC 只保留“最近”的 GPU pool 子集，减少跨 root-complex 或跨 NUMA 的非必要路径。
+Inference objective: without changing baseline CPU ownership from `simple_numa`,
+keep only the nearest GPU pool subset for each NIC to reduce unnecessary paths
+across root complexes or NUMA boundaries.
 
-输入来源与优先级：
+Input sources and priority:
 
-- GPU PCI path：
-  - 优先使用测试覆盖钩子 `HostTopologyBuilderOptions.gpu_pci_path_overrides`（用于确定性单测）。
-  - 默认路径：`cudaGetDeviceProperties` 获取 `domain:bus:device`，再 resolve `/sys/bus/pci/devices/<bdf>` realpath。
-- NIC PCI path：
-  - 优先使用 `HostTopologyBuilderOptions.nic_pci_path_overrides`。
-  - 默认路径 1：LLDP 中 `pci_bdf` 对应的 sysfs realpath。
-  - 默认路径 2（降级）：`/sys/class/infiniband/<nic>/device` realpath。
+- GPU PCI path:
+  - prefer test hook `HostTopologyBuilderOptions.gpu_pci_path_overrides`
+    (deterministic unit tests)
+  - default path: use `cudaGetDeviceProperties` for `domain:bus:device`, then
+    resolve `/sys/bus/pci/devices/<bdf>` realpath
+- NIC PCI path:
+  - prefer `HostTopologyBuilderOptions.nic_pci_path_overrides`
+  - default path 1: sysfs realpath for LLDP `pci_bdf`
+  - default path 2 (degrade): `/sys/class/infiniband/<nic>/device` realpath
 
-推断规则（确定性）：
+Inference rules (deterministic):
 
-1. 只对 `EndpointKind::kClient && EndpointType::kNic` 端点执行。
-2. 在该 NIC 现有 `pool_ids` 的 GPU 子集范围内打分，避免引入基线之外的 GPU。
-3. 以 NIC/GPU PCI realpath 的最长公共前缀长度作为亲和分值，保留所有并列最高分 GPU（处理并列/多卡同距）。
-4. 输出 `pool_ids` 保序：先保留原 CPU pool，再保留筛选后的 GPU pool。
+1. Apply only to `EndpointKind::kClient && EndpointType::kNic` endpoints.
+2. Score only GPU subsets already present in NIC `pool_ids`, without introducing
+   non-baseline GPUs.
+3. Use longest common prefix length of NIC/GPU PCI realpaths as affinity score,
+   and keep all GPUs tied at the top score (supports equal-distance cases).
+4. Keep output `pool_ids` stable: original CPU pools first, then filtered GPU
+   pools.
 
-降级与兼容：
+Degrade and compatibility behavior:
 
-- 任一 NIC 或 GPU 无法解析 PCI path 时，跳过该对象，不中断拓扑构建。
-- 若亲和性推断部分失败，则标记 observability 降级并保留基线 pool，不改变 fail-fast 行为边界（除非上层 required 语义要求）。
-- 推断逻辑默认仅在 `topology_discovery.enable=true` 时启用。
+- if PCI path resolution fails for any NIC or GPU, skip that object and keep
+  topology building alive
+- if affinity inference partially fails, mark observability degradation and keep
+  baseline pools; do not expand fail-fast boundaries unless upper required
+  semantics request it
+- inference is enabled by default only when `topology_discovery.enable=true`
 
-可观测性：
+Observability:
 
-- 增加字段：
+- add fields:
   - `affinity_nic_candidate_count`
   - `affinity_nic_scored_count`
   - `affinity_nic_narrowed_count`
   - `affinity_degraded`
   - `affinity_degrade_reason`
-- `simple_numa_topology_tool` stderr 汇总中同步输出亲和性统计，便于灰度验证。
+- include affinity summary in `simple_numa_topology_tool` stderr output for
+  staged verification
 
 ## Topology Projection Rules
 
@@ -174,11 +209,12 @@ brainvf0=0000:0e:00.1,mlx5_9,1
   - `nvlink_<gpu_uuid_or_index>` (`kClient`, `kNvlink`)
 - Link:
   - `nic_<x> -> netsw_rail_<r>` (`kSwitch`)
-  - `nvlink_<a> <-> nvlink_<b>` (`kP2P`, 双向显式边)
+  - `nvlink_<a> <-> nvlink_<b>` (`kP2P`, explicit bidirectional edges)
 
 ## Config Additions (Proto-Level)
 
-在 `tensorcast.communicator.v1.CommunicatorConfig` 下新增发现配置段（命名示意）：
+Add a discovery config section under
+`tensorcast.communicator.v1.CommunicatorConfig` (illustrative naming):
 
 ```proto
 message TopologyDiscoveryConfig {
@@ -189,64 +225,85 @@ message TopologyDiscoveryConfig {
 }
 ```
 
-建议字段语义：
+Suggested field semantics:
 
-- `lldp.file_path`：默认 `/host-config/lldp-info.txt`，支持在开发机指向仓库快照。
-- `lldp.required`：true 时文件缺失/解析失败即启动失败。
-- `nvlink.source`：`DISABLED | SNAPSHOT_FILE | RUNTIME_PROBE`。
-- `nvlink.required`：true 时 NVLINK 源不可用即启动失败。
-- `merge_policy.emit_rail_switch_endpoints`：是否显式建模 rail switch。
+- `lldp.file_path`: defaults to `/host-config/lldp-info.txt`, supports repository
+  snapshots on development hosts
+- `lldp.required`: fail startup on missing file or parse failure when true
+- `nvlink.source`: `DISABLED | SNAPSHOT_FILE | RUNTIME_PROBE`
+- `nvlink.required`: fail startup when NVLINK source is unavailable and true
+- `merge_policy.emit_rail_switch_endpoints`: whether to model rail switch
+  endpoints explicitly
 
-说明：
+Notes:
 
-- `DaemonConfig` 已嵌入 `communicator`，无需新增并行配置入口。
-- 不新增新的环境变量控制发现逻辑；历史 env 仅作兼容兜底路径。
+- `DaemonConfig` already embeds communicator config; no parallel config entry is
+  required
+- no new environment variable is introduced for discovery control; legacy env is
+  compatibility fallback only
 
 ## Integration Points
 
-- 新增模块：`core/communicator/topology/discovery/`（parser/source/merge/builder）。
-- `RoutingContext` 保持接口稳定；通过 `set_topology(...)` 注入发现结果。
-- `EndpointBinding` 建议增补可选字段（如 `pci_bdf`、`rail_id`、`gpu_uuid`）以支持后续路由策略。
-- `core/communicator/transport/net_dev.cc` 的 `read_rail_id()` 迁移为调用统一 LLDP 解析组件，避免重复解析逻辑。
+- add module `core/communicator/topology/discovery/`
+  (parser/source/merge/builder)
+- keep `RoutingContext` interface stable and inject discovery output through
+  `set_topology(...)`
+- extend `EndpointBinding` with optional fields (`pci_bdf`, `rail_id`,
+  `gpu_uuid`) for future routing policies
+- migrate `read_rail_id()` in `core/communicator/transport/net_dev.cc` to reuse
+  the unified LLDP parser and avoid duplicated parsing logic
 
-## Cross-node NIC rail matching（路由阶段增量）
+## Cross-Node NIC Rail Matching (Routing Increment)
 
-为匹配“每个 GPU 亲和本地 NIC/NVLINK endpoint，跨节点走 NIC rail 对齐”的实践部署，本设计在路由阶段补充了跨节点 rail 匹配策略（保持 `RoutingContext` 1-hop 语义不变）：
+To align with practical deployment policy (each GPU prefers local NIC/NVLINK
+endpoints, and cross-node paths prefer aligned NIC rails), this design adds a
+cross-node rail matching policy at routing stage while keeping `RoutingContext`
+1-hop semantics unchanged:
 
-1. 若 `src -> dst` 存在 direct link，沿用 direct 1-hop。
-2. 若 direct link 不存在且 `src_binding.node_id != dst_binding.node_id`：
-   - 从本机拓扑中为 source 选择本地 NIC（优先 rail 命中，再结合 GPU pool 亲和）。
-   - 以该 NIC rail 作为 preferred rail，在目标节点 bindings 中选择可用网络地址端点（评分优先级：preferred rail > dst rail > endpoint/NIC 特征）。
-   - 用本地 NIC 邻接链路（通常是 `nic -> netsw_rail_<id>`）作为链路锚点建立 1-hop channel。
-3. 该策略允许运行时 endpoint id（例如 `node/dev/gpu/<id>`）与拓扑 endpoint id 解耦，不要求两者完全同名。
-4. 若 rail 匹配失败，保持现有错误语义并由上层 `RemoteKeySource` 继续 strict direct fallback。
+1. If a direct link exists for `src -> dst`, keep direct 1-hop behavior.
+2. If no direct link exists and `src_binding.node_id != dst_binding.node_id`:
+   - select a local NIC for source from local topology (rail match first, then
+     GPU-pool affinity)
+   - use that NIC rail as preferred rail and choose an available network
+     endpoint in destination bindings (score priority:
+     preferred rail > destination rail > endpoint/NIC features)
+   - use local NIC adjacent link (typically `nic -> netsw_rail_<id>`) as route
+     anchor to build a 1-hop channel
+3. This policy decouples runtime endpoint ids (for example `node/dev/gpu/<id>`)
+   from topology endpoint ids and does not require strict naming equality.
+4. If rail matching fails, preserve existing error semantics and let upper
+   `RemoteKeySource` continue strict direct fallback.
 
 # Error Model & Invariants
 
-- LLDP 解析不变量：
-  - `nic_name` 不可为空。
-  - 同 `nic_name` 不允许冲突的 `rail_id`。
-  - `pci_bdf` 需符合 `dddd:bb:ss.f` 基本格式。
-- NVLINK 不变量：
-  - 端点 GPU 必须可映射到已知 GPU pool。
-  - 自环边无效；重复边合并计数。
-- 合并不变量：
-  - `Topology::validate()` 必须通过。
-  - 不因部分源缺失导致崩溃；按 required 策略 fail-fast 或 degrade。
+- LLDP parsing invariants:
+  - `nic_name` must not be empty
+  - the same `nic_name` must not map to conflicting `rail_id` values
+  - `pci_bdf` must satisfy base `dddd:bb:ss.f` format
+- NVLINK invariants:
+  - endpoint GPUs must map to known GPU pools
+  - self-loop edges are invalid; duplicate edges are merged by count
+- Merge invariants:
+  - `Topology::validate()` must pass
+  - missing partial source data must not crash; follow required policy for
+    fail-fast or degrade
 
-降级策略：
+Degrade policy:
 
-- `topology_discovery.enable=false`：完全回退现有路径。
-- LLDP 不可用且 `lldp.required=false`：rail 设为 unknown，网络拓扑退化为单 switch 或无 rail 分层。
-- NVLINK 不可用且 `nvlink.required=false`：只生成网络侧拓扑，不生成 NVLINK 链路。
+- `topology_discovery.enable=false`: fully fall back to existing path
+- LLDP unavailable with `lldp.required=false`: rail is unknown and network
+  topology degrades to a single switch layer (or no rail layering)
+- NVLINK unavailable with `nvlink.required=false`: emit network-side topology
+  only, without NVLINK links
 
 # Schema Changes (if any)
 
-有。需要扩展：
+Yes. Extend:
 
-- `proto/tensorcast/communicator/v1/communicator_config.proto`（新增 `TopologyDiscoveryConfig` 与子消息）。
+- `proto/tensorcast/communicator/v1/communicator_config.proto`
+  (add `TopologyDiscoveryConfig` and submessages)
 
-若 `.proto` 变更，必须执行：
+If `.proto` is modified, run:
 
 ```bash
 bash tools/build_proto_python.sh
@@ -254,36 +311,40 @@ bash tools/build_proto_python.sh
 
 # Naming Compliance
 
-- 类/结构体（PascalCase）：
+- Classes/structs (PascalCase):
   - `LldpDiscoveryConfig`
   - `NvlinkDiscoveryConfig`
   - `HostDiscoverySnapshot`
   - `HostTopologyMergeResult`
-- 函数/方法（snake_case）：
+- Functions/methods (snake_case):
   - `load_lldp_records`
   - `collect_nvlink_edges`
   - `merge_discovery_sources`
   - `build_topology_from_discovery`
-- 常量/枚举（ALL_CAPS）：
+- Constants/enums (ALL_CAPS):
   - `NVLINK_SOURCE_DISABLED`
   - `NVLINK_SOURCE_SNAPSHOT_FILE`
   - `NVLINK_SOURCE_RUNTIME_PROBE`
 
 # Trade-offs & Risks
 
-- 引入新配置字段会提升系统复杂度。
-  - 缓解：默认关闭，按阶段启用，提供清晰 fallback。
-- 运行时 NVLINK 探测在不同驱动环境下可能不稳定。
-  - 缓解：首版优先快照输入，运行时探测独立开关。
-- LLDP 文件格式来自环境约定，存在漂移风险。
-  - 缓解：定义严格 parser + 版本化样例 + 单元测试。
+- New config fields increase system complexity.
+  - Mitigation: keep disabled by default, roll out in phases, and provide clear
+    fallback behavior.
+- Runtime NVLINK probing can be unstable across driver environments.
+  - Mitigation: prioritize snapshot input in v1 and gate runtime probing behind
+    an independent switch.
+- LLDP format depends on environment conventions and may drift.
+  - Mitigation: strict parser, versioned sample files, and unit tests.
 
 # Compatibility & Acceptance Criteria
 
-- 不开启 `topology_discovery` 时，行为与当前版本保持一致。
-- 开启后可基于 LLDP + NVLINK 构建当前机器拓扑，并可导出 DOT。
-- 任一来源缺失时按 `required` 配置执行 fail-fast 或 degrade，且日志可定位。
-- `RoutingContext` 与 `RemoteKeySource` 现有调用链不破坏；失败可回退 direct 读路径。
+- When `topology_discovery` is disabled, behavior matches current version.
+- When enabled, LLDP + NVLINK can build host topology and export DOT.
+- If any source is missing, behavior follows `required` policy (fail-fast or
+  degrade) with diagnosable logs.
+- Existing `RoutingContext` and `RemoteKeySource` call chains remain intact; on
+  failure, direct read fallback still works.
 
 # References
 

--- a/docs/designs/0105-communicator-small-packet-latency-and-throughput-optimization.md
+++ b/docs/designs/0105-communicator-small-packet-latency-and-throughput-optimization.md
@@ -25,26 +25,37 @@ links:
 
 # Summary
 
-`2026-03-16` 对比数据显示，communicator 在单次逻辑请求规模较小（`32 MiB`、`64 MiB`）时，仍明显落后于相关工作（Mooncake Transfer Engine），而在 `256 MiB+` 时已进入同一性能等级。
+The `2026-03-16` comparison shows that communicator still lags related work
+(Mooncake Transfer Engine) when one logical request is relatively small
+(`32 MiB`, `64 MiB`), while it already reaches the same performance class at
+`256 MiB+`.
 
-在 `0105` 的复盘中，发现此前“带宽下降”有一部分来自测量区间内非数据传输成本（如初始化、buffer clear/verify、校验拷贝等）抬高了分母；这与最初想回答的“任务过程中非数据面成本占比”不完全一致。
+During the `0105` retrospective, we found that part of the previous
+"bandwidth drop" came from non-transfer costs inside the measurement window
+(for example initialization, buffer clear/verify, and verification copy), which
+inflated the denominator. This is not fully aligned with the original question:
+"what share of total task time is non-data-plane cost?"
 
-因此本设计将目标调整为：
+Therefore, this design adjusts the objective to:
 
-1. 优先量化任务过程中的非数据传输代价。
-2. 区分“一次性可均摊成本”与“每次传输重复成本”。
-3. 在上述可归因前提下，再推进控制面/数据面优化决策。
+1. Prioritize quantifying non-transfer cost during task execution.
+2. Separate one-time amortizable cost from recurring per-transfer cost.
+3. Make control-plane and data-plane optimization decisions only after costs are
+   attributable.
 
-本设计给出一个分阶段方案：
+This design provides a phased plan:
 
-1. 先补齐可归因观测，量化每个开销项，并明确 amortizable vs recurring 分类。
-2. 优化控制路径与窗口/ACK 粒度，降低每个逻辑请求的控制往返成本。
-3. 优化 RDMA/MTCP 热路径中的每 WR bookkeeping、future/wait 和日志噪声。
-4. 在严格回归和可回滚前提下渐进上线。
+1. Fill the observability gap first, quantify each cost term, and classify
+   amortizable vs recurring costs.
+2. Optimize control-path behavior and window/ACK granularity to reduce
+   round-trip overhead per logical request.
+3. Optimize per-WR bookkeeping, future/wait chains, and log noise on
+   RDMA/MTCP hot paths.
+4. Roll out incrementally with strict regression checks and clear rollback.
 
 ## Baseline
 
-来自 [20260316-communicator-vs-transfer-engine-comparison.md](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md)：
+From [20260316-communicator-vs-transfer-engine-comparison.md](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md):
 
 | Logical request size | Communicator | Transfer Engine | Gap |
 | --- | --- | --- | --- |
@@ -55,74 +66,98 @@ links:
 
 # Problem Statement
 
-## 1. 控制线程串行导致小包固定开销放大
+## 1. Single-threaded control loop amplifies fixed overhead for small packets
 
-当前 `Communicator` 仅启动一个请求线程处理 `request_queue_`：
+Today `Communicator` starts only one request thread to consume
+`request_queue_`:
 
-- 请求线程启动点：`core/communicator/engine/engine.cc` (`request_thread_`)
-- 主循环：`do_read_request_loop()`
-- 队列定义：`core/communicator/engine/engine.h` (`request_queue_`)
+- request-thread entry: `core/communicator/engine/engine.cc`
+  (`request_thread_`)
+- main loop: `do_read_request_loop()`
+- queue definition: `core/communicator/engine/engine.h` (`request_queue_`)
 
-单线程串行在大量短请求、混合 peer 场景下会放大排队等待；即使单 peer 场景，也会在 control send/pending 维护路径上叠加额外抖动。
+This single-threaded serialization increases queueing delay under many short
+requests and mixed-peer traffic. Even in single-peer traffic, it adds jitter on
+control-send and pending-maintenance paths.
 
-## 2. RDMA 窗口推进由 ACK 驱动，回填节奏偏保守
+## 2. RDMA window refill is ACK-driven and currently conservative
 
-RDMA 路径中，source 侧在 `resume_rdma_reads()` 一次 pass 内只要“有进展”就 break，等待 ACK 再继续：
+On the RDMA path, source-side `resume_rdma_reads()` breaks a pass as soon as it
+sees "some progress," then waits for ACK before continuing:
 
-- `resume_rdma_reads()` break-on-progress：`core/communicator/engine/engine.cc`
-- ACK 回调触发继续推进：`ENGINE_OP_RDMA_READ_DONE_EX` 处理分支内调用 `resume_rdma_reads()`
+- `resume_rdma_reads()` break-on-progress:
+  `core/communicator/engine/engine.cc`
+- ACK callback triggers follow-up refill: `resume_rdma_reads()` is called inside
+  `ENGINE_OP_RDMA_READ_DONE_EX`
 
-该机制在中小逻辑请求下会增加“窗口-ACK-窗口”往返轮次，放大控制路径占比。
+For small and medium logical requests, this creates extra
+"window -> ACK -> window" rounds and increases control-path share.
 
-## 3. RDMA 每 WR 级别队列操作与 completion bookkeeping 成本偏高
+## 3. RDMA per-WR queue operations and completion bookkeeping are expensive
 
-当前 `read_multi()` 为每个 posted WR 执行一次 request enqueue，并在 CQ completion 为每个 WR pop：
+Today `read_multi()` enqueues once per posted WR, and CQ completion pops once
+per WR:
 
-- `read_multi()`：`core/communicator/transport/rdma_transport.cc`
-- `do_process_wc()`：`core/communicator/transport/rdma_transport.cc`
-- request completion/ACK 队列：`core/communicator/transport/request.h`
+- `read_multi()`: `core/communicator/transport/rdma_transport.cc`
+- `do_process_wc()`: `core/communicator/transport/rdma_transport.cc`
+- request completion/ACK queue: `core/communicator/transport/request.h`
 
-小包/中包下 WR 数较多时，这类原子与队列操作会成为不可忽略的固定成本。
+When small/medium packets require many WRs, these atomics and queue operations
+become non-trivial fixed cost.
 
-## 4. MTCP staged 路径存在单线程信用等待 + future 串行等待
+## 4. MTCP staged path has single-thread credit waits plus serial future waits
 
-MTCP staging 使用单线程循环消费，并在资源不足时退避 sleep：
+MTCP staging currently consumes work in a single-thread loop and backs off with
+sleep when resources are insufficient:
 
-- 线程入口：`core/communicator/engine/engine.cc` (`mtcp_staging_loop()`)
-- 退避等待：`process_mtcp_read_task()` 中 `absl::SleepFor(backoff)`
+- thread entry: `core/communicator/engine/engine.cc` (`mtcp_staging_loop()`)
+- backoff wait: `absl::SleepFor(backoff)` in `process_mtcp_read_task()`
 
-MTCP transport 侧存在大量 `std::async` 与 `future.get()/wait()` 等待链：
+MTCP transport also has many `std::async` chains and `future.get()/wait()`
+waits:
 
-- send path async/release：`core/communicator/transport/mtcp_transport.cc`
-- recv path 按 future 顺序等待：`core/communicator/transport/mtcp_transport.cc`
+- send-path async/release: `core/communicator/transport/mtcp_transport.cc`
+- recv-path ordered waits on futures:
+  `core/communicator/transport/mtcp_transport.cc`
 
-在 fallback 或混合流量下，这些等待与调度开销会放大尾延迟。
+Under fallback or mixed traffic, this waiting/scheduling overhead inflates tail
+latency.
 
-## 5. 热路径 `LOG(INFO)` 频率过高
+## 5. `LOG(INFO)` frequency is too high on hot paths
 
-`rdma_resume`、`READ_RESPONSE_EX`、`read_multi` completion 等热路径存在高频 `LOG(INFO)`，在高请求率下会产生额外 CPU 与锁竞争负担。
+Hot paths such as `rdma_resume`, `READ_RESPONSE_EX`, and `read_multi`
+completion currently emit high-frequency `LOG(INFO)`, adding avoidable CPU and
+lock contention at high request rates.
 
 # Goals / Non-Goals
 
 ## Goals
 
-1. 量化 communicator benchmark 中非数据传输代价，并提供可复现的字段化输出。
-2. 将开销拆分为“一次性可均摊成本”（初始化、预热）与“每次传输重复成本”（clear、enqueue、wait、verify）。
-3. 显式覆盖用户关注项：数据拷贝成本、内存分配成本、校验成本。
-4. 在保持 `256 MiB+` direct RDMA 路径无明显回退的前提下，为后续优化提供归因基线。
-5. 方案默认可控、可回滚，不引入隐式环境变量开关。
-6. 所有新调优项进入统一 runtime 配置（`communicator_config.proto`），遵循 [0004-unified-runtime-config.md](./0004-unified-runtime-config.md)。
+1. Quantify non-transfer cost in communicator benchmark and output reproducible
+   structured fields.
+2. Split cost into one-time amortizable cost (init/warmup) and recurring
+   per-transfer cost (clear/enqueue/wait/verify).
+3. Explicitly cover user-prioritized cost types: data-copy cost,
+   memory-allocation cost, and verification cost.
+4. Preserve `256 MiB+` direct RDMA throughput (no obvious regression) while
+   building an attribution baseline for further optimization.
+5. Keep the plan controllable and rollback-safe with no implicit environment
+   toggles.
+6. Add all new tuning knobs to unified runtime config
+   (`communicator_config.proto`) and follow
+   [0004-unified-runtime-config.md](./0004-unified-runtime-config.md).
 
 ## Non-Goals
 
-1. 不重写 communicator 为另一套传输引擎。
-2. 不改变 Global Store / Store Daemon 架构语义。
-3. 不在本阶段追求 full-8 ceiling 与 TE 完全一致（本设计聚焦小包/中包）。
-4. 不引入破坏兼容的协议语义变更。
+1. Do not rewrite communicator into a different transport engine.
+2. Do not change Global Store / Store Daemon architectural semantics.
+3. Do not target TE full-8 ceiling in this phase (this design focuses on
+   small/medium packets).
+4. Do not introduce protocol-level incompatible semantic changes.
 
 # Architecture & Interfaces
 
-## 优化分层
+## Optimization Layers
 
 ```mermaid
 flowchart LR
@@ -131,9 +166,10 @@ flowchart LR
   C --> D[Phase 4<br>Rollout and guardrails]
 ```
 
-## Phase 1: 观测与归因基线
+## Phase 1: Observability and attribution baseline
 
-新增 request/batch 级性能快照（以统计为主，不在默认热路径打印）：
+Add request/batch-level performance snapshots (primarily aggregated metrics;
+no default hot-path printing):
 
 - `control_queue_wait_us`
 - `control_send_us`
@@ -144,80 +180,92 @@ flowchart LR
 - `rdma_cq_completion_total`
 - `mtcp_staging_wait_us`
 - `mtcp_future_wait_us`
-- `amortizable_init_*`（init / buffer allocation / warmup）
-- `recurring_*`（clear / issue / wait / verify）
+- `amortizable_init_*` (init / buffer allocation / warmup)
+- `recurring_*` (clear / issue / wait / verify)
 - `verify_buffer_alloc_us`
 - `verify_copy_us`
 - `verify_checksum_us`
 - `amortized_per_iteration_us`
 - `amortized_per_request_us`
 
-落点：
+Instrumentation landing points:
 
-- request 生命周期：`core/communicator/transport/request.h`
-- engine 控制路径：`core/communicator/engine/engine.cc`
-- transport 数据路径：`core/communicator/transport/rdma_transport.cc`、`core/communicator/transport/mtcp_transport.cc`
-- benchmark 输出层：`core/communicator/bench/communicator_bench.cc`
+- request lifecycle: `core/communicator/transport/request.h`
+- engine control path: `core/communicator/engine/engine.cc`
+- transport data path:
+  `core/communicator/transport/rdma_transport.cc` and
+  `core/communicator/transport/mtcp_transport.cc`
+- benchmark output layer: `core/communicator/bench/communicator_bench.cc`
 
-原则：
+Principles:
 
-1. 默认仅聚合指标，不逐请求 `INFO` 输出。
-2. `ITER` 输出用于定位单轮瓶颈，`SUMMARY` 输出用于 amortizable/recurring 归因。
-3. 允许按采样率输出 debug 详情，避免常态噪声。
+1. Aggregate by default; no per-request `INFO` output.
+2. Use `ITER` output for single-run bottleneck localization and `SUMMARY` output
+   for amortizable/recurring attribution.
+3. Allow sampled debug details to avoid steady-state noise.
 
-## Phase 2: 控制路径与窗口/ACK 粒度
+## Phase 2: Control path and window/ACK granularity
 
-### 2.1 请求分发并行化（保持每 peer 顺序）
+### 2.1 Parallel request dispatch while preserving per-peer order
 
-将单请求线程升级为“分片队列 + 固定 worker 池”：
+Upgrade the single request thread into "sharded queues + fixed worker pool":
 
-- 按 `dst_url` 哈希分片，保证同 peer 请求顺序。
-- 不改变 `pending_requests_` 语义。
-- 默认 worker 数为 `1`，与旧行为一致。
+- shard by `dst_url` hash to preserve in-order behavior per peer
+- keep `pending_requests_` semantics unchanged
+- default worker count remains `1` for backward-compatible behavior
 
 ### 2.2 RDMA refill budget
 
-在 `resume_rdma_reads()` 引入每次 pass 的推进预算，不再“有进展即 break”：
+Add per-pass progress budget in `resume_rdma_reads()`, replacing
+"break on any progress":
 
-- 预算维度：`window` 数或 `bytes`。
-- 保持 credit 安全边界（不突破 `FlowCreditLedger`）。
-- 当达到预算后再等待 ACK，减少频繁控制往返。
+- budget dimension: number of `window`s or `bytes`
+- keep credit safety boundary (must not exceed `FlowCreditLedger`)
+- wait for ACK after budget is consumed to reduce frequent control round trips
 
-### 2.3 ACK 批处理窗口
+### 2.3 ACK batching window
 
-在保持 lease 生命周期正确性的前提下，允许同一 request 的多个已完成 window 合并 ACK（受上限和超时约束）：
+While preserving lease lifecycle correctness, allow one request to batch ACKs
+for multiple completed windows (bounded by max count and timeout):
 
-- 限制最大延迟，避免 source 侧 credit 长时间不归还。
-- 保持最终窗口完成语义与失败语义不变。
+- bound max ACK delay to avoid long credit retention at source side
+- keep final-window completion semantics and failure semantics unchanged
 
-## Phase 3: RDMA / MTCP 微优化
+## Phase 3: RDMA / MTCP micro-optimizations
 
-### 3.1 RDMA inflight bookkeeping 批化
+### 3.1 Batch RDMA inflight bookkeeping
 
-将“每 WR 入队一个 request 指针”优化为“每 post 批次一个 inflight 记录 + remaining 计数”，减少队列 push/pop 次数。
+Optimize from "one request pointer enqueued per WR" to
+"one inflight record per post batch + remaining counter" to reduce queue
+push/pop operations.
 
-### 3.2 RDMA completion signal 间隔化（可控）
+### 3.2 RDMA completion signaling interval (configurable)
 
-引入可配置的 signaled WR 间隔（默认 `1` 保持旧行为），在稳定场景下降低 CQ 事件密度。
+Add configurable signaled-WR interval (default `1` for compatibility) to reduce
+CQ event density in stable scenarios.
 
-### 3.3 MTCP staged 路径去阻塞化
+### 3.3 De-block MTCP staged path
 
-减少 `std::async + wait/get` 串行等待链，优先复用已有 async task 跟踪机制；把 credit 不足等待从“主动 sleep 退避”向“事件驱动唤醒”收敛。
+Reduce `std::async + wait/get` serial wait chains, reuse existing async task
+tracking when possible, and move insufficient-credit waits from
+"active sleep backoff" toward "event-driven wakeup."
 
-### 3.4 热路径日志降噪
+### 3.4 Reduce hot-path log noise
 
-将高频 `LOG(INFO)` 下沉到 `VLOG(1/2)` 或采样日志，保留 `WARNING/ERROR` 与关键一次性 `INFO`。
+Downgrade high-frequency `LOG(INFO)` to `VLOG(1/2)` or sampled logging while
+keeping `WARNING/ERROR` and key one-time `INFO` logs.
 
-## Phase 4: 渐进上线
+## Phase 4: Incremental rollout
 
-1. 先启用观测，不改行为。
-2. 启用控制粒度优化（默认保守值）。
-3. 在小规模灰度中启用 RDMA/MTCP 微优化。
-4. 达到阈值后将新参数作为推荐默认值写入文档。
+1. Enable observability first without behavior changes.
+2. Enable control-granularity optimizations with conservative defaults.
+3. Enable RDMA/MTCP micro-optimizations in small-scale canary.
+4. Promote recommended defaults into docs after thresholds are met.
 
 # Proposed Config Additions
 
-以下字段属于统一 runtime 配置扩展，目标文件为 `proto/tensorcast/communicator/v1/communicator_config.proto`：
+The following fields are unified runtime config extensions in
+`proto/tensorcast/communicator/v1/communicator_config.proto`:
 
 - `TransportConfig.request_worker_count`
 - `RdmaConfig.resume_max_windows_per_pass`
@@ -226,70 +274,86 @@ flowchart LR
 - `RdmaConfig.unsignaled_wr_interval`
 - `TransportConfig.hotpath_log_sample_rate`
 
-默认值全部保持兼容旧行为（`1` 或 `0` 表示关闭新策略）。
+All default values remain backward-compatible (`1` or `0` means new behavior is
+off).
 
 # Invariants & Error Model
 
-1. `pending_requests_` 生命周期不变，结果回调仍负责清理。
-2. 不允许因为 ACK 批处理导致 credit 永久不归还。
-3. refill budget 不能突破 `FlowCreditLedger` 上限。
-4. 发生 transport 错误时，`ReadRequest::set_result()` 仍保持幂等完成。
-5. 任何优化都不允许引入“静默 fallback + 吞错”。
+1. `pending_requests_` lifecycle stays unchanged and result callbacks still own
+   cleanup.
+2. ACK batching must never cause permanent credit leak.
+3. Refill budget must not exceed `FlowCreditLedger` limits.
+4. On transport errors, `ReadRequest::set_result()` must remain idempotent.
+5. No optimization may introduce silent fallback or swallowed errors.
 
 # Schema Changes
 
-无数据库 schema 变更，不涉及 `schema.sql`。
+No database schema changes; `schema.sql` is not involved.
 
 # Naming Compliance
 
-本设计新增接口/字段遵循仓库命名规则：
+New interfaces/fields in this design follow repository naming rules:
 
-- C++ class / struct（PascalCase）
+- C++ classes/structs (PascalCase)
   - `SmallPacketPerfSnapshot`
   - `RdmaInflightBatch`
-- C++ functions / methods（snake_case）
+- C++ functions/methods (snake_case)
   - `resume_rdma_reads_with_budget`
   - `flush_pending_rdma_ack_batch`
   - `enqueue_request_shard`
-- Proto fields（snake_case）
+- Proto fields (snake_case)
   - `request_worker_count`
   - `resume_max_windows_per_pass`
   - `ack_batch_max_windows`
   - `ack_batch_max_delay_us`
   - `unsignaled_wr_interval`
   - `hotpath_log_sample_rate`
-- 常量（ALL_CAPS）
+- constants (ALL_CAPS)
   - `kDefaultResumeMaxWindowsPerPass`
   - `kDefaultAckBatchMaxDelayUs`
 
 # Trade-offs & Risks
 
-1. 并行 request worker 增加并发复杂度，若分片策略不当可能引入顺序回归。
-2. ACK 批处理可能提升吞吐但加大短时内存占用；需要严格 TTL 与上限。
-3. unsignaled WR 间隔化会降低 CQ 压力，但错误可见性变慢；需保留保守默认值。
-4. MTCP 去阻塞化涉及线程模型调整，必须先由观测数据证明收益再扩大范围。
+1. Parallel request workers increase concurrency complexity; bad sharding may
+   regress ordering behavior.
+2. ACK batching can improve throughput but may increase short-term memory usage;
+   strict TTL and limits are required.
+3. Unsignaled-WR interval reduces CQ pressure but delays error visibility;
+   conservative defaults are required.
+4. MTCP de-blocking changes concurrency behavior and must be scaled only after
+   observed benefit is proven.
 
 # Compatibility & Acceptance Criteria
 
-## 功能正确性
+## Functional correctness
 
-1. 现有 API 与 wire 语义保持兼容。
-2. `bazel test //core/communicator:rdma_engine_test`、`//core/communicator:staging_flow_controller_test`、`//core/communicator:request_test`、`//core/communicator:mtcp_transport_lane_test` 全通过。
+1. Existing API and wire semantics remain compatible.
+2. `bazel test //core/communicator:rdma_engine_test`,
+   `//core/communicator:staging_flow_controller_test`,
+   `//core/communicator:request_test`, and
+   `//core/communicator:mtcp_transport_lane_test` all pass.
 
-## 性能验收
+## Performance acceptance
 
-在与 [20260316 baseline](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md) 同口径的单 NIC 严格 direct RDMA 读测下：
+Under the same single-NIC strict direct-RDMA read setup as the
+[20260316 baseline](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md):
 
-1. `ITER` 与 `SUMMARY` 必须同时给出 amortizable 与 recurring 字段，且覆盖 clear/issue/wait/verify 子项。
-2. `verify` 需明确拆分 `buffer_alloc`、`copy`、`checksum`，可判断是否每轮重复发生。
-3. 必须给出 `amortized_per_iteration_us` 与 `amortized_per_request_us`，支持“一次性成本均摊后”的读法。
-4. `256 MiB+` 相对 baseline 吞吐不回退超过 `3%`（带宽保留为护栏指标，而非唯一目标）。
-5. 新增指标可用于判定小包瓶颈是否主要落在控制面与重复开销，而非纯数据面极限。
+1. `ITER` and `SUMMARY` must both output amortizable and recurring fields,
+   including clear/issue/wait/verify subitems.
+2. `verify` must be split into `buffer_alloc`, `copy`, and `checksum` so we can
+   determine whether they recur each iteration.
+3. `amortized_per_iteration_us` and `amortized_per_request_us` must be provided
+   to support amortized interpretation.
+4. `256 MiB+` throughput must not regress by more than `3%` relative to
+   baseline (bandwidth remains a guardrail, not the only objective).
+5. New metrics must be sufficient to judge whether small-packet bottlenecks are
+   mainly on control path and recurring overhead, not pure data-plane limits.
 
-## 可运维性
+## Operability
 
-1. 热路径 `INFO` 日志量显著下降（以请求数归一化统计）。
-2. 所有调优项可通过配置单独关闭并回退旧行为。
+1. Hot-path `INFO` log volume drops significantly (normalized by request
+   count).
+2. All new tuning behaviors can be disabled independently and rolled back.
 
 # References
 

--- a/docs/plans/0058-communicator-topology-model.md
+++ b/docs/plans/0058-communicator-topology-model.md
@@ -20,77 +20,133 @@ related_code:
 
 # Objective
 
-在现有 Communicator 之上引入可搜索拓扑模型（Pool / Endpoint / Link）与路径级抽象（Connection / Channel / Communicator），为多路径、拓扑选路与故障切换提供统一的数据结构与策略入口，并保持现有读写路径可兼容回退。
+Introduce a searchable topology model (Pool / Endpoint / Link) and
+path-level abstractions (Connection / Channel / Communicator) on top of the
+current Communicator implementation, so multipath, topology-aware routing, and
+failover share one unified data model and policy entry point while keeping the
+current read/write path backward-compatible and rollback-safe.
 
 # Current State & Grounding
 
-- 通信层以 `communicator::engine::Communicator` 为中心，面向 peer 的连接抽象是 `engine::Channel`，其内部管理 TCP/MTCP/RDMA 连接与握手状态（`core/communicator/engine/engine.h`，`core/communicator/engine/channel.h`）。
-- 数据面传输直接由 Communicator 选择 RDMA 或 MTCP，路径选择缺乏明确的“拓扑图”，也不存在多跳或多路径抽象（`core/communicator/README.md`，`core/communicator/docs/comm-read-tensor.md`）。
-- P2P 选源由 Global Store 协调，数据面仍由 Communicator 完成读写，当前没有拓扑级路由或自动 failover（`docs/architecture/p2p-transfer-strategies.md`）。
-- 现有 `CommunicatorConfig` 只有 `simple_numa` 等轻量映射，缺少可表达交换结构的拓扑模型（`proto/tensorcast/communicator/v1/communicator_config.proto`）。
+- The communication layer centers on `communicator::engine::Communicator`.
+  Peer-level connection abstraction is `engine::Channel`, which manages
+  TCP/MTCP/RDMA connections and handshake state
+  (`core/communicator/engine/engine.h`,
+  `core/communicator/engine/channel.h`).
+- Data-plane transfer is currently chosen directly by Communicator (RDMA or
+  MTCP). Path selection has no explicit topology graph, and there is no
+  multi-hop or multipath abstraction
+  (`core/communicator/README.md`,
+  `core/communicator/docs/comm-read-tensor.md`).
+- P2P source selection is coordinated by Global Store, while data transfer is
+  still executed by Communicator. There is currently no topology-level routing
+  or automatic failover
+  (`docs/architecture/p2p-transfer-strategies.md`).
+- Existing `CommunicatorConfig` only has lightweight mappings such as
+  `simple_numa`; it lacks a topology model that can represent switching
+  structures (`proto/tensorcast/communicator/v1/communicator_config.proto`).
 
 # Phases & Milestones
 
-- [ ] Phase 1: 拓扑模型与配置骨架
-  - [ ] Milestone 1.1: 新增拓扑数据结构（`Pool` / `Endpoint` / `Link`）与图构建器（建议落在 `core/communicator/topology/`），并提供最小可视化/调试导出。
-  - [ ] Milestone 1.2: 扩展 `CommunicatorConfig` 引入拓扑描述（或等价独立拓扑配置段），并提供从 `simple_numa` 的兼容映射；遵循 `docs/designs/0004-unified-runtime-config.md`。
-  - [ ] Milestone 1.3: 拓扑校验与单元测试（连通性、带宽/延迟字段、Switch Endpoint 合法性）。
+- [ ] Phase 1: Topology model and config skeleton
+  - [ ] Milestone 1.1: Add topology data structures (`Pool` / `Endpoint` /
+    `Link`) and graph builder (recommended under
+    `core/communicator/topology/`), with minimal visualization/debug export.
+  - [ ] Milestone 1.2: Extend `CommunicatorConfig` with topology description
+    (or equivalent standalone topology config section), and provide
+    compatibility mapping from `simple_numa`; follow
+    `docs/designs/0004-unified-runtime-config.md`.
+  - [ ] Milestone 1.3: Add topology validation and unit tests
+    (connectivity, bandwidth/latency fields, Switch Endpoint legality).
 
-- [ ] Phase 2: 执行层映射与兼容桥接
-  - [ ] Milestone 2.1: 新增 `Connection` 与路径级 `Channel`（为避免与 `engine::Channel` 冲突，可在新命名空间引入 `RouteChannel`）并完成到现有传输对象的映射。
-  - [ ] Milestone 2.2: 构建 `Communicator` 聚合器（src-dst 维度）与 Connection 复用缓存，支持多 hop。
-  - [ ] Milestone 2.3: 增加基础统计与健康状态收集（Link/Connection 级别）用于后续路由。
+- [ ] Phase 2: Execution-layer mapping and compatibility bridge
+  - [ ] Milestone 2.1: Add `Connection` and path-level `Channel`
+    (to avoid conflict with `engine::Channel`, use `RouteChannel` in a new
+    namespace) and complete mapping to existing transport objects.
+  - [ ] Milestone 2.2: Build a `Communicator` aggregator (src-dst dimension)
+    plus connection-reuse cache, with multi-hop support.
+  - [ ] Milestone 2.3: Add baseline stats and health collection
+    (Link/Connection level) for later routing decisions.
 
-- [ ] Phase 3: 路径搜索、multipath 与故障切换
-  - [ ] Milestone 3.1: 实现 k-shortest 或最短路搜索（BW/latency/统计混合打分），产出多条候选 Channel。
-  - [ ] Milestone 3.2: `mct_map` 统计闭环，支持按消息大小选择路径并实现 striping。
-  - [ ] Milestone 3.3: 连接失败/握手失败时的自动 failover（回退到其它 Channel 或默认直连）。
+- [ ] Phase 3: Path search, multipath, and failover
+  - [ ] Milestone 3.1: Implement k-shortest or shortest-path search
+    (mixed scoring across BW/latency/stats) and output multiple candidate
+    channels.
+  - [ ] Milestone 3.2: Build `mct_map` feedback loop to support
+    message-size-aware path selection and striping.
+  - [ ] Milestone 3.3: Add automatic failover on connection/handshake failures
+    (switch to alternate channel or default direct path).
 
-- [ ] Phase 4: 业务集成与回归验证
-  - [ ] Milestone 4.1: 在 P2P 读路径引入“路由选择”入口（保持默认回退到旧逻辑），逐步接入 `P2PLoader` / `RemoteKeySource`。
-  - [ ] Milestone 4.2: 增加集成测试与压力回归（多 GPU / 多 NIC / 交换拓扑模拟），并完善文档更新。
+- [ ] Phase 4: Product integration and regression validation
+  - [ ] Milestone 4.1: Introduce routing selection entry in P2P read path
+    (default fallback to existing logic), then gradually integrate with
+    `P2PLoader` / `RemoteKeySource`.
+  - [ ] Milestone 4.2: Add integration tests and stress regression
+    (multi-GPU / multi-NIC / switched-topology simulation), and finish doc
+    updates.
 
-## Phase 2 Mapping Decisions (补充方案)
+## Phase 2 Mapping Decisions (Supplement)
 
-**目标**：在不改动现有数据面行为的前提下，将拓扑可达性映射到现有通信实现，并显式纳入 NVLINK 作为本地 GPU↔GPU 传输。
+**Objective**: map topology reachability to existing communication execution
+without changing current data-plane behavior, while explicitly including NVLINK
+as the local GPU-to-GPU transfer path.
 
-**运行时映射来源**
-- Endpoint 的运行时绑定信息（IP/Port/NIC/GPU UUID 等）以 **Global Store** 为权威来源。
-- 路由层只消费 GS 侧的节点与设备元数据，不引入额外的硬件发现或本地探测。
+**Runtime mapping source**
+- Runtime endpoint binding metadata (IP/Port/NIC/GPU UUID, etc.) uses
+  **Global Store** as the source of truth.
+- The routing layer only consumes node/device metadata from GS and does not
+  introduce extra hardware discovery or local probing.
 
-**传输适配与落地位置**
-- 新增 **NvlinkAdapter** 作为 NVLINK 传输的唯一落地入口（routing/中间层负责选择，执行层由 NvlinkAdapter 完成）。
-- 现有 RDMA/MTCP/TCP 继续由 `engine::Communicator` 执行，作为 **EngineAdapter** 复用。
+**Transport adapters and integration point**
+- Add **NvlinkAdapter** as the only execution entry for NVLINK transport
+  (routing/middleware selects it, and execution is completed by
+  NvlinkAdapter).
+- Existing RDMA/MTCP/TCP execution remains in `engine::Communicator`, reused
+  through **EngineAdapter**.
 
-**映射规则（最小可用）**
-- 同节点 GPU↔GPU：优先走 NVLINK（NvlinkAdapter），失败回退到已有路径。
-- 跨节点通信：仍走 RDMA/MTCP/TCP（EngineAdapter）。
-- Switch Endpoint 仅参与路径搜索，不直接生成 Connection。
+**Mapping rules (minimum viable)**
+- Same-node GPU-to-GPU: prefer NVLINK (`NvlinkAdapter`), fallback to existing
+  path on failure.
+- Cross-node communication: continue using RDMA/MTCP/TCP (`EngineAdapter`).
+- Switch Endpoint participates only in path search and does not directly create
+  `Connection` objects.
 
 # Tasks
 
-- 更新 `core/communicator/README.md`，补充拓扑与多路径语义。
-- 更新 `docs/architecture/p2p-transfer-strategies.md`，说明路由与 failover 在数据面的位置。
-- 若修改 `.proto`，运行 `bash tools/build_proto_python.sh` 并通过 `bazel test //proto/...`。
-- 增加基准或调试工具，便于输出拓扑图与路径选择日志。
+- Update `core/communicator/README.md` with topology and multipath semantics.
+- Update `docs/architecture/p2p-transfer-strategies.md` to describe routing and
+  failover placement in the data plane.
+- If `.proto` is modified, run `bash tools/build_proto_python.sh` and
+  `bazel test //proto/...`.
+- Add benchmark or debug tooling to export topology graphs and
+  path-selection logs.
 
 # Test / Rollout / Backout
 
-- **单元测试**：拓扑构建、路径搜索、Switch Endpoint 约束、连接健康状态更新。
-- **集成测试**：复用现有 `tcp_engine_test` / `rdma` 相关测试，并新增多路径与 failover 场景。
-- **回归验证**：对 `read_tensor` 关键路径做性能对比，确认无退化。
-- **上线策略**：新增配置开关，默认关闭；先在影子模式输出路径选择日志。
-- **回退策略**：禁用拓扑路由配置，回退到旧的直连通道选择。
+- **Unit tests**: topology construction, path search, Switch Endpoint
+  constraints, and connection-health updates.
+- **Integration tests**: reuse current `tcp_engine_test` / RDMA-related tests,
+  plus new multipath and failover scenarios.
+- **Regression validation**: run performance comparison on
+  `read_tensor` critical path and confirm no regression.
+- **Rollout strategy**: add a config switch, default off; first run in
+  shadow mode with path-selection logs.
+- **Backout strategy**: disable topology-routing config and return to the
+  previous direct-channel selection.
 
 # Risks & Tracking
 
-- **复杂度上升**：需确保拓扑模型与现有 `engine::Channel` 的语义边界清晰。
-- **配置兼容**：拓扑配置必须兼容 `simple_numa`，避免破坏现有部署。
-- **性能不确定性**：路径搜索与统计更新需要限频与缓存。
+- **Complexity increase**: keep semantic boundaries clear between topology model
+  and existing `engine::Channel`.
+- **Config compatibility**: topology config must stay compatible with
+  `simple_numa` to avoid deployment breakage.
+- **Performance uncertainty**: path search and stats updates require bounded
+  frequency and caching.
 
 # Owner Checklist
 
-- [ ] 设计与计划双向链接已建立。
-- [ ] 配置变更遵循统一配置设计（`docs/designs/0004-unified-runtime-config.md`）。
-- [ ] 文档更新覆盖核心模块 README 与架构说明。
-- [ ] 关键路径有基准/回归指标。
+- [ ] Bidirectional links between design and plan are in place.
+- [ ] Config changes follow unified config design
+  (`docs/designs/0004-unified-runtime-config.md`).
+- [ ] Doc updates cover core module README and architecture guides.
+- [ ] Benchmark/regression metrics cover the critical path.

--- a/docs/plans/0105-communicator-small-packet-latency-and-throughput-optimization.md
+++ b/docs/plans/0105-communicator-small-packet-latency-and-throughput-optimization.md
@@ -22,113 +22,165 @@ related_code:
 
 # Objective
 
-围绕 `0105` 设计落地一套“非数据传输代价量化 + 定向优化”执行路径。第一目标不是直接追求单一带宽数字，而是把任务过程中的非数据面成本拆分清楚：哪些属于一次性可均摊成本，哪些是每次传输都要重复支付的成本；在此基础上再推进小包/中包优化，同时保持 `256 MiB+` 吞吐不回退。
+Deliver the `0105` design as an execution path centered on
+"non-transfer-cost quantification + targeted optimization." The first objective
+is not a single bandwidth number. It is to clearly split non-data-plane cost
+inside task execution into one-time amortizable cost and recurring
+per-transfer cost. After attribution is clear, we then optimize
+small/medium-packet behavior while keeping `256 MiB+` throughput regression-free.
 
 # Current State & Grounding
 
-## Baseline（2026-03-16）
+## Baseline (2026-03-16)
 
-来自 [20260316-communicator-vs-transfer-engine-comparison.md](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md)：
+From [20260316-communicator-vs-transfer-engine-comparison.md](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md):
 
 | Logical request size | Communicator | Transfer Engine | Gap |
 | --- | --- | --- | --- |
 | `32 MiB` | `18.56 GB/s` | `22.49 GB/s` | `-3.93 GB/s` (`-17.5%`) |
 | `64 MiB` | `20.56 GB/s` | `22.75 GB/s` | `-2.19 GB/s` (`-9.6%`) |
-| `256 MiB` | `23.17 GB/s` | `23.02 GB/s` | 同一性能等级 |
-| `1 GiB` | `23.96 GB/s` | `23.69 GB/s` | 同一性能等级 |
+| `256 MiB` | `23.17 GB/s` | `23.02 GB/s` | same class |
+| `1 GiB` | `23.96 GB/s` | `23.69 GB/s` | same class |
 
-## 已确认的代码侧瓶颈锚点
+## Confirmed code-side bottleneck anchors
 
-1. 请求控制面当前是单线程串行消费
-   - 请求线程创建: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
-   - 循环处理入口 `do_read_request_loop()`: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
-   - 队列/在途表定义 `request_queue_`、`pending_requests_`: [core/communicator/engine/engine.h](../../core/communicator/engine/engine.h)
-2. RDMA refill/ACK 推进节奏偏保守
-   - `resume_rdma_reads()` 在 `made_progress` 后立即 break: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
-   - `ENGINE_OP_RDMA_READ_DONE_EX` 中 ACK 后再触发 refill: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
-3. RDMA 路径每 WR bookkeeping 粒度较细
-   - `read_multi()` 每个 posted WR 都会 `enqueue_completion_bytes` 和 `per_qp_inflight_queues_.push(...)`: [core/communicator/transport/rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc)
-   - `do_process_wc()` 每个 completion 都 `pop` 并更新请求完成态: [core/communicator/transport/rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc)
-   - ACK/完成跟踪结构在 `ReadRequest`: [core/communicator/transport/request.h](../../core/communicator/transport/request.h)
-4. MTCP staged 路径存在较重等待链
-   - staging 线程串行消费 `mtcp_staging_queue_`: [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
-   - MTCP 发送/接收路径包含大量 `std::async` 与 future `wait/get`: [core/communicator/transport/mtcp_transport.cc](../../core/communicator/transport/mtcp_transport.cc)
-5. 热路径 `LOG(INFO)` 频率偏高
-   - 典型热点包括 `read_tensor` 入队、`resume_rdma_reads`、`read_multi` posted/completion 等路径（同上文件）。
+1. Request control path is currently single-thread serialized.
+   - request thread creation:
+     [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+   - loop entry `do_read_request_loop()`:
+     [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+   - queue/inflight structures `request_queue_`, `pending_requests_`:
+     [core/communicator/engine/engine.h](../../core/communicator/engine/engine.h)
+2. RDMA refill/ACK cadence is conservative.
+   - `resume_rdma_reads()` breaks immediately after `made_progress`:
+     [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+   - refill is re-triggered after ACK inside `ENGINE_OP_RDMA_READ_DONE_EX`:
+     [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+3. RDMA path bookkeeping is too fine-grained at per-WR level.
+   - in `read_multi()`, each posted WR executes `enqueue_completion_bytes` and
+     `per_qp_inflight_queues_.push(...)`:
+     [core/communicator/transport/rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc)
+   - in `do_process_wc()`, each completion performs `pop` and request-state
+     updates:
+     [core/communicator/transport/rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc)
+   - ACK/completion tracking structures in `ReadRequest`:
+     [core/communicator/transport/request.h](../../core/communicator/transport/request.h)
+4. MTCP staged path has heavy wait chains.
+   - staging thread serially consumes `mtcp_staging_queue_`:
+     [core/communicator/engine/engine.cc](../../core/communicator/engine/engine.cc)
+   - MTCP send/recv path includes many `std::async` and future `wait/get` calls:
+     [core/communicator/transport/mtcp_transport.cc](../../core/communicator/transport/mtcp_transport.cc)
+5. Hot-path `LOG(INFO)` frequency is high.
+   - typical hot spots include `read_tensor` enqueue,
+     `resume_rdma_reads`, and `read_multi` posted/completion paths
+     (same files above).
 
-## 约束与边界
+## Constraints and boundaries
 
-1. 配置必须走统一 runtime config，不引入临时环境变量开关（见 [0004-unified-runtime-config.md](../designs/0004-unified-runtime-config.md) 与 [communicator_config.proto](../../proto/tensorcast/communicator/v1/communicator_config.proto)）。
-2. `pending_requests_` 生命周期语义、错误传播语义、`ReadRequest::set_result()` 幂等行为不得破坏。
-3. `FlowCreditLedger` 的 credit 上限与释放路径必须保持安全约束（[core/communicator/engine/staging_flow_controller.cc](../../core/communicator/engine/staging_flow_controller.cc)）。
+1. Configuration must use unified runtime config. No temporary env-var
+   feature switches are allowed on the main path (see
+   [0004-unified-runtime-config.md](../designs/0004-unified-runtime-config.md)
+   and
+   [communicator_config.proto](../../proto/tensorcast/communicator/v1/communicator_config.proto)).
+2. `pending_requests_` lifecycle semantics, error-propagation semantics, and
+   idempotent `ReadRequest::set_result()` behavior must remain intact.
+3. `FlowCreditLedger` credit limits and release path must keep their safety
+   constraints
+   ([core/communicator/engine/staging_flow_controller.cc](../../core/communicator/engine/staging_flow_controller.cc)).
 
 # Phases & Milestones
 
-- [ ] Phase 0: 基线冻结与观测口径统一
-  - [ ] Milestone 0.1: 固化本轮优化对比口径（`32/64/256 MiB`, `threads=1`, `batch_size=1`，单 NIC strict direct RDMA）。
-  - [ ] Milestone 0.2: 固化 benchmark 产出字段和解析规则（优先 `amortizable_*` 与 `recurring_*`，并保留 `bw_GBps`/`bw_gbps` 兼容）。
-  - [ ] Milestone 0.3: 记录基线 case 元数据（host pair、GPU/NIC 对应、qp/outstanding 配置）。
+- [ ] Phase 0: Baseline freeze and metric-definition alignment
+  - [ ] Milestone 0.1: Freeze the comparison setup for this round
+    (`32/64/256 MiB`, `threads=1`, `batch_size=1`, single-NIC strict direct
+    RDMA).
+  - [ ] Milestone 0.2: Freeze benchmark output fields and parser rules
+    (prioritize `amortizable_*` and `recurring_*` while keeping
+    `bw_GBps`/`bw_gbps` compatibility).
+  - [ ] Milestone 0.3: Record baseline case metadata (host pair,
+    GPU/NIC mapping, qp/outstanding settings).
 
-- [ ] Phase 1: Instrumentation First（先观测后优化）
-  - [ ] Milestone 1.1: 在 `ReadRequest` 增加 request 级统计快照容器（不改变现有完成语义）。
-  - [ ] Milestone 1.2: 在 benchmark/engine/transport 关键路径补齐统计埋点（queue wait、control send、window/ack 轮次、WR posted/completion、MTCP 等待时间）。
-  - [ ] Milestone 1.3: benchmark 输出提供 amortizable（init/warmup）与 recurring（clear/issue/wait/verify）字段，并支持 per-iteration/per-request 均摊视角。
-  - [ ] Milestone 1.4: `verify` 开销拆分为内存分配、数据拷贝、校验计算三个子项，形成“可均摊/不可均摊”归因报表。
+- [ ] Phase 1: Instrumentation first (observe before optimize)
+  - [ ] Milestone 1.1: Add a request-level stats snapshot container in
+    `ReadRequest` (without changing completion semantics).
+  - [ ] Milestone 1.2: Add instrumentation on benchmark/engine/transport hot
+    paths (queue wait, control send, window/ACK rounds, WR posted/completion,
+    MTCP wait times).
+  - [ ] Milestone 1.3: Extend benchmark output with amortizable
+    (init/warmup) and recurring (clear/issue/wait/verify) fields, with both
+    per-iteration and per-request amortized views.
+  - [ ] Milestone 1.4: Split `verify` cost into allocation/copy/checksum to
+    produce an amortizable vs non-amortizable attribution report.
 
-- [ ] Phase 2: 控制路径与窗口粒度优化
-  - [ ] Milestone 2.1: 把单请求线程演进为“按 peer 分片 + 固定 worker 池”，默认 `worker_count=1` 保持旧行为。
-  - [ ] Milestone 2.2: `resume_rdma_reads()` 引入 per-pass budget（window 或 bytes 预算），替代“有进展即等待 ACK”策略。
-  - [ ] Milestone 2.3: ACK 批处理策略落地（最大窗口数 + 最大延迟约束），保证 credit 能及时回收。
-  - [ ] Milestone 2.4: 完成功能回归与小流量灰度验证。
+- [ ] Phase 2: Control path and window-granularity optimization
+  - [ ] Milestone 2.1: Evolve from single request thread to
+    "per-peer sharding + fixed worker pool" with `worker_count=1` as
+    compatible default.
+  - [ ] Milestone 2.2: Introduce per-pass budget (window or bytes) in
+    `resume_rdma_reads()`, replacing "wait for ACK after any progress."
+  - [ ] Milestone 2.3: Land ACK batching strategy
+    (max windows + max delay constraints) while guaranteeing timely credit
+    recovery.
+  - [ ] Milestone 2.4: Complete functional regression and low-traffic canary
+    verification.
 
-- [ ] Phase 3: RDMA/MTCP 数据面微优化
-  - [ ] Milestone 3.1: RDMA inflight bookkeeping 从“每 WR 记录”收敛到“批记录 + remaining 计数”。
-  - [ ] Milestone 3.2: 增加可控 signaled WR 间隔能力（默认兼容旧行为）。
-  - [ ] Milestone 3.3: MTCP staged 路径减少 future 串行等待与主动 sleep 退避，向事件驱动推进。
-  - [ ] Milestone 3.4: 热路径日志降噪完成（`INFO -> VLOG` 或采样）。
+- [ ] Phase 3: RDMA/MTCP data-plane micro-optimizations
+  - [ ] Milestone 3.1: Converge RDMA inflight bookkeeping from "per-WR records"
+    to "batch record + remaining counter."
+  - [ ] Milestone 3.2: Add configurable signaled-WR interval
+    (default remains backward-compatible).
+  - [ ] Milestone 3.3: Reduce serial future waits and active sleep backoff in
+    MTCP staged path, moving toward event-driven behavior.
+  - [ ] Milestone 3.4: Complete hot-path log noise reduction
+    (`INFO -> VLOG` or sampled logging).
 
-- [ ] Phase 4: 验收、灰度与默认值收敛
-  - [ ] Milestone 4.1: 跑通完整验证矩阵（功能、性能、非退化、稳定性）。
-  - [ ] Milestone 4.2: 达成验收阈值后形成推荐配置默认值。
-  - [ ] Milestone 4.3: 完成文档同步（设计、计划、benchmark 结果页）。
+- [ ] Phase 4: Acceptance, canary rollout, and default convergence
+  - [ ] Milestone 4.1: Run the full validation matrix
+    (functionality, performance, non-regression, stability).
+  - [ ] Milestone 4.2: Produce recommended config defaults after acceptance
+    thresholds are met.
+  - [ ] Milestone 4.3: Complete doc sync (design, plan, benchmark result pages).
 
 # Tasks
 
-## 模块任务拆分
+## Module task breakdown
 
-| 模块 | 任务 | 关键文件 |
+| Module | Task | Key files |
 | --- | --- | --- |
-| Engine 调度层 | 请求分片队列与 worker 池、RDMA refill budget、ACK 批处理触发策略 | [engine.cc](../../core/communicator/engine/engine.cc), [engine.h](../../core/communicator/engine/engine.h) |
-| Flow 控制层 | credit 边界校验、预算推进与释放安全性回归 | [staging_flow_controller.cc](../../core/communicator/engine/staging_flow_controller.cc) |
-| RDMA 传输层 | inflight 批化、signaled 间隔化、completion 处理路径适配 | [rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc) |
-| Request 状态层 | request 级统计聚合、ACK 队列批处理元数据 | [request.h](../../core/communicator/transport/request.h) |
-| MTCP 传输层 | 去除高成本等待链、减少主动退避等待 | [mtcp_transport.cc](../../core/communicator/transport/mtcp_transport.cc) |
-| 配置与协议 | 新增优化配置项并保持默认兼容 | [communicator_config.proto](../../proto/tensorcast/communicator/v1/communicator_config.proto) |
-| 基准与文档 | benchmark 复测、结果归档、设计/计划同步更新 | [20260316 comparison](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md), [20260315 progress](../benchmarks/20260315-communicator-rdma-nic-gdr-progress.md) |
+| Engine scheduler layer | Request sharded queues and worker pool, RDMA refill budget, ACK-batch trigger policy | [engine.cc](../../core/communicator/engine/engine.cc), [engine.h](../../core/communicator/engine/engine.h) |
+| Flow-control layer | Credit-boundary checks, budget progression and release safety regression | [staging_flow_controller.cc](../../core/communicator/engine/staging_flow_controller.cc) |
+| RDMA transport layer | Inflight batching, signaled interval, completion-path adaptation | [rdma_transport.cc](../../core/communicator/transport/rdma_transport.cc) |
+| Request state layer | Request-level stats aggregation, ACK-batch metadata | [request.h](../../core/communicator/transport/request.h) |
+| MTCP transport layer | Remove high-cost wait chains, reduce active backoff waits | [mtcp_transport.cc](../../core/communicator/transport/mtcp_transport.cc) |
+| Config and protocol | Add new tuning config fields with backward-compatible defaults | [communicator_config.proto](../../proto/tensorcast/communicator/v1/communicator_config.proto) |
+| Benchmark and docs | Re-run benchmarks, archive results, sync design/plan docs | [20260316 comparison](../benchmarks/20260316-communicator-vs-transfer-engine-comparison.md), [20260315 progress](../benchmarks/20260315-communicator-rdma-nic-gdr-progress.md) |
 
-## 执行顺序约束
+## Execution-order constraints
 
-1. 必须先完成 Phase 1 观测再进入 Phase 2/3，避免“盲调”。
-2. Phase 2 与 Phase 3 可分支并行，但每项优化都必须以 Phase 1 指标下降为前提。
-3. 配置项先加字段再开策略，默认值必须保持旧行为。
+1. Phase 1 observability must finish before entering Phase 2/3 to avoid blind
+   tuning.
+2. Phase 2 and Phase 3 may run in parallel branches, but each optimization must
+   be justified by Phase 1 metric improvements.
+3. Add config fields before enabling new strategies, and keep default values
+   backward-compatible.
 
 # Test / Rollout / Backout
 
 ## Validation Matrix
 
-| 维度 | 内容 | 通过标准 |
+| Dimension | Content | Pass criteria |
 | --- | --- | --- |
-| 单元/组件回归 | `//core/communicator:request_test`, `:rdma_engine_test`, `:staging_flow_controller_test`, `:mtcp_transport_lane_test`, `:mtcp_transfer_completion_tracker_test`, `:tcp_engine_test` | 全通过，无新增 flaky |
-| 配置回归 | `//core/communicator:config_io_test` + 新增配置字段读写/默认值测试 | 新字段默认值等价旧行为 |
-| 归因完整性 | `ITER`/`SUMMARY` 同时产出 amortizable + recurring 字段；`verify` 拆分 alloc/copy/checksum | 字段齐全，可稳定解析 |
-| 小包结构性指标 | `32 MiB`、`64 MiB` strict direct RDMA 单请求对比 baseline | 能量化 recurring 主项并识别 top bottleneck |
-| 大包非退化 | `256 MiB`、`1 GiB` 同口径复测 | 相对 baseline 回退不超过 `3%` |
-| 成本分类 | `amortized_per_iteration_us`、`amortized_per_request_us` 与 recurring per-request 指标 | 可判断一次性成本是否可被后续传输均摊 |
-| 稳定性 | 长时压测 + error path（ACK 延迟、部分 post 失败、MTCP fallback） | 无死锁/泄漏/静默失败 |
+| Unit/component regression | `//core/communicator:request_test`, `:rdma_engine_test`, `:staging_flow_controller_test`, `:mtcp_transport_lane_test`, `:mtcp_transfer_completion_tracker_test`, `:tcp_engine_test` | All pass, no new flaky tests |
+| Config regression | `//core/communicator:config_io_test` + new config field read/write/default tests | New field defaults are equivalent to old behavior |
+| Attribution completeness | `ITER`/`SUMMARY` output amortizable + recurring fields together; `verify` split into alloc/copy/checksum | Fields are complete and stably parseable |
+| Small-packet structural metrics | `32 MiB`, `64 MiB` strict direct-RDMA single-request baseline comparison | Can quantify dominant recurring costs and identify top bottlenecks |
+| Large-packet non-regression | `256 MiB`, `1 GiB` retest under same setup | Regression no more than `3%` vs baseline |
+| Cost classification | `amortized_per_iteration_us`, `amortized_per_request_us`, and recurring per-request metrics | Can determine whether one-time cost is amortizable over subsequent transfers |
+| Stability | long-run stress + error paths (ACK delay, partial post failure, MTCP fallback) | No deadlock, leak, or silent failure |
 
-## 执行命令（示例）
+## Execution commands (examples)
 
-1. C++ 回归：
+1. C++ regression:
    - `bazel test //core/communicator:request_test`
    - `bazel test //core/communicator:rdma_engine_test`
    - `bazel test //core/communicator:staging_flow_controller_test`
@@ -136,41 +188,51 @@ related_code:
    - `bazel test //core/communicator:mtcp_transfer_completion_tracker_test`
    - `bazel test //core/communicator:tcp_engine_test`
    - `bazel test //core/communicator:config_io_test`
-2. benchmark 工具链：
+2. Benchmark toolchain:
    - `tools/communicator/run_bench_case.py`
    - `tools/communicator/launch_remote_bench_case.py`
    - `tools/communicator/render_te_comparison_charts.py`
 
 ## Rollout
 
-1. 第一步只上线观测埋点（策略默认关闭）。
-2. 第二步灰度启用控制粒度优化（请求 worker、refill budget、ACK batch）。
-3. 第三步灰度启用 RDMA/MTCP 微优化（bookkeeping/signaled/等待链优化）。
-4. 第四步根据验收结果收敛推荐默认值并更新文档。
+1. Step 1: ship instrumentation only (all new strategies disabled by default).
+2. Step 2: canary control-granularity optimizations
+   (request workers, refill budget, ACK batch).
+3. Step 3: canary RDMA/MTCP micro-optimizations
+   (bookkeeping, signaled interval, wait-chain optimizations).
+4. Step 4: converge recommended defaults based on acceptance and update docs.
 
 ## Backout
 
-1. 所有新策略均可通过配置项单独关闭并回退到旧行为。
-2. 若出现 `256 MiB+` 回退或稳定性问题，优先回退 Phase 3，再回退 Phase 2。
-3. 保留 Phase 1 观测能力，用于回退后的二次定位。
+1. Each new strategy can be independently disabled via config and rolled back to
+   old behavior.
+2. If `256 MiB+` regresses or stability issues appear, back out Phase 3 first,
+   then Phase 2.
+3. Keep Phase 1 observability available for post-backout diagnosis.
 
 # Risks & Tracking
 
-- [ ] 风险 1: 请求 worker 并行化引入顺序语义回归
-  - 跟踪: 按 peer 分片保证顺序，补充顺序一致性测试。
-- [ ] 风险 2: ACK 批处理导致 credit 回收变慢或堆积
-  - 跟踪: 设置 `ack_batch_max_windows` 与 `ack_batch_max_delay_us` 双阈值，增加超时告警。
-- [ ] 风险 3: unsignaled WR 间隔化影响错误可见性
-  - 跟踪: 默认 `1`，灰度阶段逐步放大并监控 completion 异常率。
-- [ ] 风险 4: MTCP 去阻塞化修改并发模型引入隐性死锁
-  - 跟踪: 增加压力和超时失败路径测试，确保线程池不被阻塞等待。
-- [ ] 风险 5: 热路径日志降噪影响问题定位
-  - 跟踪: 保留采样日志与 debug 开关，确保关键错误仍保留 `WARNING/ERROR`。
+- [ ] Risk 1: request-worker parallelization regresses ordering semantics
+  - Tracking: preserve order via per-peer sharding and add ordering consistency
+    tests.
+- [ ] Risk 2: ACK batching slows credit recovery or creates backlog
+  - Tracking: enforce dual thresholds (`ack_batch_max_windows`,
+    `ack_batch_max_delay_us`) and add timeout alerts.
+- [ ] Risk 3: unsignaled-WR interval affects error visibility
+  - Tracking: keep default `1`, scale up gradually in canary, and monitor
+    completion anomaly rate.
+- [ ] Risk 4: MTCP de-blocking changes concurrency behavior and introduces
+  latent deadlocks
+  - Tracking: add stress tests and timeout-path tests to ensure worker threads
+    are not blocked waiting.
+- [ ] Risk 5: hot-path log reduction hurts troubleshooting
+  - Tracking: keep sampled logs and debug switches while preserving
+    `WARNING/ERROR` for critical failures.
 
 # Owner Checklist
 
-- [ ] 设计/计划双向链接已建立且可解析。
-- [ ] 里程碑均为可验证结果，不是实现动作描述。
-- [ ] 所有配置增量遵循统一 runtime config。
-- [ ] 验收矩阵覆盖“性能提升 + 非退化 + 稳定性 + 可回滚”。
-- [ ] benchmark 结果文档在每轮关键里程碑后同步更新。
+- [ ] Design and plan links are bidirectional and resolvable.
+- [ ] Milestones are verifiable outcomes, not implementation action labels.
+- [ ] All config increments follow unified runtime config.
+- [ ] Acceptance matrix covers uplift, non-regression, stability, and rollback.
+- [ ] Benchmark-result docs are synced after each key milestone.


### PR DESCRIPTION
## What's Changed

- **style**: Run clang-format on all files to fix code style inconsistencies
- **docs**: Translate project documentation from Chinese to English

## Why

- Enforce consistent code formatting across the codebase via clang-format
- Improve accessibility for English-speaking contributors

## Changes

- Ran `pre-commit run clang-format --all-files` to auto-fix formatting
- Translated the following documents:
  - [x] `docs/benchmarks/20260316-communicator-vs-transfer-engine-comparison.md`
  - [x] `docs/designs/0105-communicator-small-packet-latency-and-throughput-optimization.md`
  - [x] `docs/plans/0105-communicator-small-packet-latency-and-throughput-optimization.md`
  - [x] `docs/designs/0058-communicator-topology-model.md`
  - [x] `docs/designs/0059-host-topology-discovery-lldp-nvlink.md`
  - [x] `docs/plans/0058-communicator-topology-model.md`

## How to Test

```bash
# Verify formatting is clean
pre-commit run clang-format --all-files
# Expected: Passed ✅