### PR TITLE
fix: satisfy Python type checks

### DIFF
--- a/tensorcast/pytorch/module_binding.py
+++ b/tensorcast/pytorch/module_binding.py
@@ -58,11 +58,8 @@ def attach_tensors_to_module(
             unexpected.append(full_name)
             continue
         module, local_name = _lookup_module_and_name(model, full_name)
-        if (
-            local_name in module._parameters
-            and module._parameters[local_name] is not None
-        ):
-            param = module._parameters[local_name]
+        param = module._parameters.get(local_name)
+        if param is not None:
             aliases = (
                 parameter_aliases.get(id(param), (full_name,))
                 if preserve_aliases
@@ -79,8 +76,8 @@ def attach_tensors_to_module(
                 param.data = tensor
             attached.update(aliases)
             continue
-        if local_name in module._buffers and module._buffers[local_name] is not None:
-            buf = module._buffers[local_name]
+        buf = module._buffers.get(local_name)
+        if buf is not None:
             replacement = _materialize_tensor_like(buf, tensor)
             aliases = (
                 buffer_aliases.get(id(buf), (full_name,))
@@ -171,11 +168,8 @@ def allocate_unbound_module_tensors(
     parameter_aliases, buffer_aliases = _collect_alias_registrations(model)
     for full_name in sorted({str(name) for name in tensor_names}):
         module, local_name = _lookup_module_and_name(model, full_name)
-        if (
-            local_name in module._parameters
-            and module._parameters[local_name] is not None
-        ):
-            param = module._parameters[local_name]
+        param = module._parameters.get(local_name)
+        if param is not None:
             if not param.is_meta:
                 allocated[full_name] = param.data
                 continue
@@ -188,8 +182,8 @@ def allocate_unbound_module_tensors(
                 alias_module._parameters[alias_local_name] = replacement
             allocated[full_name] = replacement.data
             continue
-        if local_name in module._buffers and module._buffers[local_name] is not None:
-            buf = module._buffers[local_name]
+        buf = module._buffers.get(local_name)
+        if buf is not None:
             if not buf.is_meta:
                 allocated[full_name] = buf
                 continue

--- a/tensorcast/pytorch/trace_capture.py
+++ b/tensorcast/pytorch/trace_capture.py
@@ -241,9 +241,7 @@ class TraceMode(TorchDispatchMode):
             else self._compose_ranges(base_range, range_spec, base_dim_map)
         )
         propagated_dim_map = (
-            base_dim_map
-            if dim_map is None
-            else tuple(base_dim_map[dim] for dim in dim_map)
+            base_dim_map if dim_map is None else self._remap_dims(base_dim_map, dim_map)
         )
         self._view_meta[id(result)] = (
             weakref.ref(result),
@@ -252,6 +250,15 @@ class TraceMode(TorchDispatchMode):
             propagated_dim_map,
         )
         return result
+
+    def _remap_dims(
+        self,
+        base_dim_map: Optional[tuple[int, ...]],
+        dim_map: tuple[int, ...],
+    ) -> tuple[int, ...]:
+        if base_dim_map is None:
+            raise RuntimeError("Missing dim map for remapped trace view")
+        return tuple(base_dim_map[dim] for dim in dim_map)
 
     def _compose_ranges(
         self,
@@ -539,7 +546,10 @@ def trace_model_load(
     try:
         with trace_mode:
             if native_load_weights is None:
-                model.load_weights(weights_iterator)
+                load_weights = getattr(model, "load_weights", None)
+                if not callable(load_weights):
+                    raise RuntimeError("model must provide callable load_weights")
+                load_weights(weights_iterator)
             else:
                 native_load_weights(model, weights_iterator)
     finally:

--- a/tensorcast/serving/builder/publication.py
+++ b/tensorcast/serving/builder/publication.py
@@ -22,6 +22,8 @@ from tensorcast.api.store.serving_builder import (
 )
 from tensorcast.api.store.types import CanonicalIndex
 from tensorcast.types import (
+    AssemblyReadinessPolicy,
+    AssemblyRequirementSetRef,
     BindingValueRef,
     BuilderMode,
     PureTransformPublicationSpec,
@@ -250,8 +252,8 @@ def build_binding_finalize_publication_bundle_from_context(
     serving_version_key: str | None = None,
     serving_manifest_ref: str | None = None,
     layout_id: str | None = None,
-    requirements: object = None,
-    readiness_policy: object = None,
+    requirements: AssemblyRequirementSetRef | None = None,
+    readiness_policy: AssemblyReadinessPolicy | None = None,
     structural_view_ids: tuple[str, ...] = (),
     admission_facts: ServingAdmissionFacts | None = None,
 ) -> RepresentationPublishSpec:

--- a/tensorcast/serving/preload.py
+++ b/tensorcast/serving/preload.py
@@ -484,6 +484,8 @@ def acquire_local_ready_preload_lease(
         runtime = get_runtime_context()
     if client is None:
         client = runtime.ensure_client()
+    if client is None:
+        raise RuntimeError("TensorCast runtime did not provide a store daemon client")
     response = client.acquire_binding_value_by_local_ref(
         local_serving_ref=local_serving_ref,
         expected_device_uuid=expected_device_uuid,

--- a/tensorcast/serving/runtime.py
+++ b/tensorcast/serving/runtime.py
@@ -73,11 +73,12 @@ def _profile_resource_path(profile: str, filename: str) -> str:
     if profile_name is None:
         raise ValueError("runtime.profile must be non-empty")
     try:
-        resource = importlib.resources.files("tensorcast").joinpath(
-            "config",
-            "profiles",
-            profile_name,
-            filename,
+        resource = (
+            importlib.resources.files("tensorcast")
+            .joinpath("config")
+            .joinpath("profiles")
+            .joinpath(profile_name)
+            .joinpath(filename)
         )
     except (FileNotFoundError, ModuleNotFoundError) as exc:
         raise ValueError(

--- a/tensorcast/serving/runtime_contract.py
+++ b/tensorcast/serving/runtime_contract.py
@@ -47,7 +47,7 @@ class SourceBoundContractState:
         flags = int(getattr(server_config, "source_bound_capability_flags", 0) or 0)
         version = int(getattr(server_config, "source_bound_contract_version", 0) or 0)
         capability_names = tuple(
-            capability.name
+            str(capability.name)
             for capability in SourceBoundCapability
             if flags & int(capability)
         )


### PR DESCRIPTION
## Summary
- narrow PyTorch module binding Optional types
- type serving publication/preload/runtime helper paths precisely
- keep trace capture dynamic load_weights call checked before invocation

## Validation
- source .venv/bin/activate && ruff check .
- source .venv/bin/activate && ruff format --check .
- source .venv/bin/activate && pyright ./tensorcast
- source .venv/bin/activate && mypy ./tensorcast
- source .venv/bin/activate && pytest tests/python/test_pytorch_module_binding.py tests/python/test_pytorch_trace_capture.py tests/python/test_serving_builder_publication.py tests/python/test_serving_preload_acquire.py tests/python/test_serving_runtime_contract.py