### PR TITLE
fix(build): declare sweep task header dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,10 @@ find ./external -name "header.h"            # Search for header
 cat third_party/<lib>/BUILD                 # Check target definitions
 ```
 
-**Note**: Run `bazel build //...` first if `./external/` is empty.
+**Note**: Run `bazel build //core/... //daemon/...` first if `./external/` is
+empty. The `third_party/*/BUILD` files are wrappers injected into fetched
+archives; a workspace-wide `//...` also analyzes those wrapper directories as
+local packages, where the archive payload is intentionally absent.
 
 ## Coding Standards
 

--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -843,6 +843,8 @@ sc_header_only_library(
     hdrs = ["state/sweep_tasks.h"],
     deps = [
         ":background_scheduler_hdr",
+        ":binding_registry_lib",
+        ":derived_view_export_manager_lib",
         ":ipc_region_registry_lib",
         ":lip_manager_lib",
         ":ref_tracker_hdr",


### PR DESCRIPTION
## Summary
- declare the two direct libraries included by sweep_tasks.h
- document the supported full production Bazel graph without analyzing archive BUILD wrappers as local packages

## Validation
- pre-commit hooks (all passed; buildifier-lint rerun after its initial downloader failure)
- WLC full production graph validation follows on this exact commit